### PR TITLE
Reduce the number of constraints in `AugmentedFCircuit` for Nova

### DIFF
--- a/folding-schemes/src/folding/circuits/nonnative.rs
+++ b/folding-schemes/src/folding/circuits/nonnative.rs
@@ -194,6 +194,7 @@ where
     // Used for extracting a list of field elements of type `C::ScalarField` from the public input
     // `p`, in exactly the same way as how `NonNativeAffineVar` is represented as limbs of type
     // `FpVar` in-circuit.
+    #[allow(clippy::type_complexity)]
     pub fn inputize(p: C) -> Result<(Vec<C::ScalarField>, Vec<C::ScalarField>), SynthesisError> {
         point_to_nonnative_limbs_custom_opt(p, OptimizationType::Constraints)
     }
@@ -243,9 +244,9 @@ where
 mod tests {
     use super::*;
     use ark_pallas::{Fr, Projective};
-    use ark_r1cs_std::{alloc::AllocVar, R1CSVar, ToConstraintFieldGadget};
+    use ark_r1cs_std::R1CSVar;
     use ark_relations::r1cs::ConstraintSystem;
-    use ark_std::{UniformRand, Zero};
+    use ark_std::UniformRand;
 
     #[test]
     fn test_alloc_zero() {

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -522,8 +522,6 @@ where
         })?;
         cf_x.enforce_equal(&is_basecase.select(&cf_u_i1_x_base, &cf_u_i1_x)?)?;
 
-        println!("Constraints: {}", cs.num_constraints());
-
         Ok(())
     }
 }

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -222,7 +222,7 @@ where
     ) -> Result<Vec<Boolean<C::ScalarField>>, SynthesisError> {
         let mut sponge = PoseidonSpongeVar::<C::ScalarField>::new(cs, poseidon_config);
 
-        let input: Vec<FpVar<C::ScalarField>> = vec![
+        let input: Vec<FpVar<C::ScalarField>> = [
             U_i_vec,
             vec![u_i.u.clone()],
             u_i.x.clone(),

--- a/folding-schemes/src/folding/nova/cyclefold.rs
+++ b/folding-schemes/src/folding/nova/cyclefold.rs
@@ -195,8 +195,8 @@ where
         r_bits: Vec<Boolean<CF2<C>>>,
         r_nonnat: NonNativeFieldVar<C::ScalarField, CF2<C>>,
         cmT: GC,
-        // ci1 is assumed to be always with cmE=0, u=1 (checks done previous to this method)
         ci1: CycleFoldCommittedInstanceVar<C, GC>,
+        // ci2 is assumed to be always with cmE=0, u=1 (checks done previous to this method)
         ci2: CycleFoldCommittedInstanceVar<C, GC>,
     ) -> Result<CycleFoldCommittedInstanceVar<C, GC>, SynthesisError> {
         Ok(CycleFoldCommittedInstanceVar {
@@ -217,8 +217,8 @@ where
         r_bits: Vec<Boolean<CF2<C>>>,
         r_nonnat: NonNativeFieldVar<C::ScalarField, CF2<C>>,
         cmT: GC,
-        // ci1 is assumed to be always with cmE=0, u=1 (checks done previous to this method)
         ci1: CycleFoldCommittedInstanceVar<C, GC>,
+        // ci2 is assumed to be always with cmE=0, u=1 (checks done previous to this method)
         ci2: CycleFoldCommittedInstanceVar<C, GC>,
         ci3: CycleFoldCommittedInstanceVar<C, GC>,
     ) -> Result<(), SynthesisError> {

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -2,7 +2,6 @@
 use ark_crypto_primitives::sponge::Absorb;
 use ark_ec::{CurveGroup, Group};
 use ark_ff::PrimeField;
-use ark_r1cs_std::fields::nonnative::params::OptimizationType;
 use ark_r1cs_std::{groups::GroupOpsBounds, prelude::CurveVar, ToConstraintFieldGadget};
 use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
@@ -14,7 +13,7 @@ use super::{circuits::CF2, nifs::NIFS, CommittedInstance, Nova};
 use crate::commitment::{
     kzg::Proof as KZGProof, pedersen::Params as PedersenParams, CommitmentScheme,
 };
-use crate::folding::circuits::nonnative::point_to_nonnative_limbs_custom_opt;
+use crate::folding::circuits::nonnative::NonNativeAffineVar;
 use crate::frontend::FCircuit;
 use crate::Error;
 use crate::{Decider as DeciderTrait, FoldingScheme};
@@ -151,12 +150,9 @@ where
         // compute U = U_{d+1}= NIFS.V(U_d, u_d, cmT)
         let U = NIFS::<C1, CS1>::verify(proof.r, running_instance, incoming_instance, &proof.cmT);
 
-        let (cmE_x, cmE_y) =
-            point_to_nonnative_limbs_custom_opt::<C1>(U.cmE, OptimizationType::Constraints)?;
-        let (cmW_x, cmW_y) =
-            point_to_nonnative_limbs_custom_opt::<C1>(U.cmW, OptimizationType::Constraints)?;
-        let (cmT_x, cmT_y) =
-            point_to_nonnative_limbs_custom_opt::<C1>(proof.cmT, OptimizationType::Constraints)?;
+        let (cmE_x, cmE_y) = NonNativeAffineVar::inputize(U.cmE)?;
+        let (cmW_x, cmW_y) = NonNativeAffineVar::inputize(U.cmW)?;
+        let (cmT_x, cmT_y) = NonNativeAffineVar::inputize(proof.cmT)?;
 
         let public_input: Vec<C1::ScalarField> = vec![
             vec![i],

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -16,7 +16,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 use crate::ccs::r1cs::{extract_r1cs, extract_w_x, R1CS};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::nonnative::{
-    nonnative_field_to_field_elements, point_to_nonnative_limbs,
+    nonnative_field_to_field_elements, nonnative_affine_to_field_elements,
 };
 use crate::frontend::FCircuit;
 use crate::utils::vec::is_zero_vec;
@@ -73,8 +73,8 @@ where
         z_0: Vec<C::ScalarField>,
         z_i: Vec<C::ScalarField>,
     ) -> Result<C::ScalarField, Error> {
-        let (cmE_x, cmE_y) = point_to_nonnative_limbs::<C>(self.cmE)?;
-        let (cmW_x, cmW_y) = point_to_nonnative_limbs::<C>(self.cmW)?;
+        let (cmE_x, cmE_y) = nonnative_affine_to_field_elements::<C>(self.cmE)?;
+        let (cmW_x, cmW_y) = nonnative_affine_to_field_elements::<C>(self.cmW)?;
 
         CRH::<C::ScalarField>::evaluate(
             poseidon_config,
@@ -392,22 +392,18 @@ where
                 i_usize: Some(0),
                 z_0: Some(self.z_0.clone()), // = z_i
                 z_i: Some(self.z_i.clone()),
-                u_i: Some(self.u_i.clone()), // = dummy
-                U_i: Some(self.U_i.clone()), // = dummy
-                U_i1: Some(U_i1.clone()),
-                r_nonnat: Some(r_Fq),
+                u_i_cmW: Some(self.u_i.cmW.clone()), // = dummy
+                U_i: Some(self.U_i.clone()),         // = dummy
+                U_i1_cmE: Some(U_i1.cmE.clone()),
+                U_i1_cmW: Some(U_i1.cmW.clone()),
                 cmT: Some(cmT),
                 F: self.F.clone(),
                 x: Some(u_i1_x),
-                cf1_u_i: None,
-                cf2_u_i: None,
+                cf1_u_i_cmW: None,
+                cf2_u_i_cmW: None,
                 cf_U_i: None,
-                cf1_U_i1: None,
-                cf_U_i1: None,
                 cf1_cmT: None,
                 cf2_cmT: None,
-                cf1_r_nonnat: None,
-                cf2_r_nonnat: None,
                 cf_x: Some(cf_u_i1_x),
             };
 
@@ -451,7 +447,7 @@ where
             };
 
             // fold self.cf_U_i + cfW_U -> folded running with cfW
-            let (_cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, cfW_r1_Fq) = self
+            let (_cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, _) = self
                 .fold_cyclefold_circuit(
                     self.cf_W_i.clone(), // CycleFold running instance witness
                     self.cf_U_i.clone(), // CycleFold running instance
@@ -459,7 +455,7 @@ where
                     cfW_circuit,
                 )?;
             // fold [the output from folding self.cf_U_i + cfW_U] + cfE_U = folded_running_with_cfW + cfE
-            let (_cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r2_Fq) =
+            let (_cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
                 self.fold_cyclefold_circuit(cfW_W_i1, cfW_U_i1.clone(), cfE_u_i_x, cfE_circuit)?;
 
             cf_u_i1_x = cf_U_i1.hash_cyclefold(&self.poseidon_config)?;
@@ -471,23 +467,19 @@ where
                 i_usize: Some(i_usize),
                 z_0: Some(self.z_0.clone()),
                 z_i: Some(self.z_i.clone()),
-                u_i: Some(self.u_i.clone()),
+                u_i_cmW: Some(self.u_i.cmW.clone()),
                 U_i: Some(self.U_i.clone()),
-                U_i1: Some(U_i1.clone()),
-                r_nonnat: Some(r_Fq),
+                U_i1_cmE: Some(U_i1.cmE.clone()),
+                U_i1_cmW: Some(U_i1.cmW.clone()),
                 cmT: Some(cmT),
                 F: self.F.clone(),
                 x: Some(u_i1_x),
                 // cyclefold values
-                cf1_u_i: Some(cfW_u_i.clone()),
-                cf2_u_i: Some(cfE_u_i.clone()),
+                cf1_u_i_cmW: Some(cfW_u_i.cmW.clone()),
+                cf2_u_i_cmW: Some(cfE_u_i.cmW.clone()),
                 cf_U_i: Some(self.cf_U_i.clone()),
-                cf1_U_i1: Some(cfW_U_i1.clone()),
-                cf_U_i1: Some(cf_U_i1.clone()),
                 cf1_cmT: Some(cfW_cmT),
                 cf2_cmT: Some(cf_cmT),
-                cf1_r_nonnat: Some(cfW_r1_Fq),
-                cf2_r_nonnat: Some(cf_r2_Fq),
                 cf_x: Some(cf_u_i1_x),
             };
 

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -16,7 +16,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 use crate::ccs::r1cs::{extract_r1cs, extract_w_x, R1CS};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::nonnative::{
-    nonnative_field_to_field_elements, nonnative_affine_to_field_elements,
+    nonnative_affine_to_field_elements, nonnative_field_to_field_elements,
 };
 use crate::frontend::FCircuit;
 use crate::utils::vec::is_zero_vec;
@@ -447,13 +447,12 @@ where
             };
 
             // fold self.cf_U_i + cfW_U -> folded running with cfW
-            let (_cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, _) = self
-                .fold_cyclefold_circuit(
-                    self.cf_W_i.clone(), // CycleFold running instance witness
-                    self.cf_U_i.clone(), // CycleFold running instance
-                    cfW_u_i_x,
-                    cfW_circuit,
-                )?;
+            let (_cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, _) = self.fold_cyclefold_circuit(
+                self.cf_W_i.clone(), // CycleFold running instance witness
+                self.cf_U_i.clone(), // CycleFold running instance
+                cfW_u_i_x,
+                cfW_circuit,
+            )?;
             // fold [the output from folding self.cf_U_i + cfW_U] + cfE_U = folded_running_with_cfW + cfE
             let (_cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
                 self.fold_cyclefold_circuit(cfW_W_i1, cfW_U_i1.clone(), cfE_u_i_x, cfE_circuit)?;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -342,7 +342,7 @@ where
     fn prove_step(&mut self) -> Result<(), Error> {
         let augmented_F_circuit: AugmentedFCircuit<C1, C2, GC2, FC>;
 
-        if self.i > C1::ScalarField::from_le_bytes_mod_order(&std::usize::MAX.to_le_bytes()) {
+        if self.i > C1::ScalarField::from_le_bytes_mod_order(&usize::MAX.to_le_bytes()) {
             return Err(Error::MaxStep);
         }
         let mut i_bytes: [u8; 8] = [0; 8];
@@ -392,10 +392,10 @@ where
                 i_usize: Some(0),
                 z_0: Some(self.z_0.clone()), // = z_i
                 z_i: Some(self.z_i.clone()),
-                u_i_cmW: Some(self.u_i.cmW.clone()), // = dummy
-                U_i: Some(self.U_i.clone()),         // = dummy
-                U_i1_cmE: Some(U_i1.cmE.clone()),
-                U_i1_cmW: Some(U_i1.cmW.clone()),
+                u_i_cmW: Some(self.u_i.cmW), // = dummy
+                U_i: Some(self.U_i.clone()), // = dummy
+                U_i1_cmE: Some(U_i1.cmE),
+                U_i1_cmW: Some(U_i1.cmW),
                 cmT: Some(cmT),
                 F: self.F.clone(),
                 x: Some(u_i1_x),
@@ -466,16 +466,16 @@ where
                 i_usize: Some(i_usize),
                 z_0: Some(self.z_0.clone()),
                 z_i: Some(self.z_i.clone()),
-                u_i_cmW: Some(self.u_i.cmW.clone()),
+                u_i_cmW: Some(self.u_i.cmW),
                 U_i: Some(self.U_i.clone()),
-                U_i1_cmE: Some(U_i1.cmE.clone()),
-                U_i1_cmW: Some(U_i1.cmW.clone()),
+                U_i1_cmE: Some(U_i1.cmE),
+                U_i1_cmW: Some(U_i1.cmW),
                 cmT: Some(cmT),
                 F: self.F.clone(),
                 x: Some(u_i1_x),
                 // cyclefold values
-                cf1_u_i_cmW: Some(cfW_u_i.cmW.clone()),
-                cf2_u_i_cmW: Some(cfE_u_i.cmW.clone()),
+                cf1_u_i_cmW: Some(cfW_u_i.cmW),
+                cf2_u_i_cmW: Some(cfE_u_i.cmW),
                 cf_U_i: Some(self.cf_U_i.clone()),
                 cf1_cmT: Some(cfW_cmT),
                 cf2_cmT: Some(cf_cmT),
@@ -514,11 +514,11 @@ where
 
         // set values for next iteration
         self.i += C1::ScalarField::one();
-        self.z_i = z_i1.clone();
+        self.z_i = z_i1;
         self.w_i = Witness::<C1>::new(w_i1, self.r1cs.A.n_rows);
         self.u_i = self.w_i.commit::<CS1>(&self.cs_params, x_i1)?;
-        self.W_i = W_i1.clone();
-        self.U_i = U_i1.clone();
+        self.W_i = W_i1;
+        self.U_i = U_i1;
 
         #[cfg(test)]
         {

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -203,14 +203,13 @@ pub mod tests {
     use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
     use ark_ff::{BigInteger, PrimeField};
     use ark_pallas::{Fr, Projective};
-    use ark_std::{ops::Mul, UniformRand, Zero};
+    use ark_std::{ops::Mul, UniformRand};
 
     use crate::ccs::r1cs::tests::{get_test_r1cs, get_test_z};
     use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
     use crate::folding::nova::circuits::ChallengeGadget;
     use crate::folding::nova::traits::NovaR1CS;
     use crate::transcript::poseidon::{poseidon_test_config, PoseidonTranscript};
-    use crate::utils::vec::vec_scalar_mul;
 
     #[allow(clippy::type_complexity)]
     pub(crate) fn prepare_simple_fold_inputs<C>() -> (


### PR DESCRIPTION
This PR depends on #84.

For the test `folding::nova::tests::test_ivc`:
Before 520db300f3f8929b211b91897ec1ed4387d06d7a: 138240
After 520db300f3f8929b211b91897ec1ed4387d06d7a: 86756 (1.6x improvement)

Two notable optimization techniques are employed:
1. Instead of allocating two witness variables `a, b` and enforce their equality by calling `a.conditional_enforce_equal(&b, &cond)`, we can avoid the allocation of `b` and directly set `b = a`. The former might be costly due to the checks in allocation and `conditional_enforce_equal`. See `nova/circuits.rs` for details.
2. Before 520db300f3f8929b211b91897ec1ed4387d06d7a, `NonNativeFieldVar::to_constraint_field` was majorly called for generating the inputs (preimage) to hash functions. However, it turns out that the underlying conversion strategy (optimized for weight), although aimed to reducing the number of limbs, is suboptimal for reducing the length of hash preimage. We can go further by maximizing the number of bits per limb, thereby minimizing the preimage length. See `circuits/nonnative.rs` for details.