### PR TITLE
Fix the incorrect `NonNativeAffineVar::inputize` implementation

### DIFF
--- a/folding-schemes/src/folding/circuits/nonnative/affine.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/affine.rs
@@ -1,5 +1,4 @@
 use ark_ec::{AffineRepr, CurveGroup};
-use ark_ff::PrimeField;
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     fields::fp::FpVar,
@@ -95,12 +94,8 @@ where
     pub fn inputize(p: C) -> Result<(Vec<C::ScalarField>, Vec<C::ScalarField>), SynthesisError> {
         let affine = p.into_affine();
         if affine.is_zero() {
-            let x = NonNativeUintVar::inputize(
-                C::BaseField::zero()
-            );
-            let y = NonNativeUintVar::inputize(
-                C::BaseField::zero()
-            );
+            let x = NonNativeUintVar::inputize(C::BaseField::zero());
+            let y = NonNativeUintVar::inputize(C::BaseField::zero());
             return Ok((x, y));
         }
 

--- a/folding-schemes/src/folding/circuits/nonnative/affine.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/affine.rs
@@ -96,19 +96,17 @@ where
         let affine = p.into_affine();
         if affine.is_zero() {
             let x = NonNativeUintVar::inputize(
-                &(C::ScalarField::zero()).into(),
-                C::ScalarField::MODULUS_BIT_SIZE as usize,
+                C::BaseField::zero()
             );
             let y = NonNativeUintVar::inputize(
-                &(C::ScalarField::zero()).into(),
-                C::ScalarField::MODULUS_BIT_SIZE as usize,
+                C::BaseField::zero()
             );
             return Ok((x, y));
         }
 
         let (x, y) = affine.xy().unwrap();
-        let x = NonNativeUintVar::inputize(&(*x).into(), C::ScalarField::MODULUS_BIT_SIZE as usize);
-        let y = NonNativeUintVar::inputize(&(*y).into(), C::ScalarField::MODULUS_BIT_SIZE as usize);
+        let x = NonNativeUintVar::inputize(*x);
+        let y = NonNativeUintVar::inputize(*y);
         Ok((x, y))
     }
 }

--- a/folding-schemes/src/folding/circuits/nonnative/uint.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/uint.rs
@@ -256,10 +256,8 @@ impl<F: PrimeField, G: PrimeField> AllocVar<G, F> for NonNativeUintVar<F> {
 }
 
 impl<F: PrimeField> NonNativeUintVar<F> {
-    pub fn inputize(x: &BigUint, l: usize) -> Vec<F> {
-        (0..l)
-            .map(|i| x.bit(i as u64))
-            .collect::<Vec<_>>()
+    pub fn inputize<T: PrimeField>(x: T) -> Vec<F> {
+        x.into_bigint().to_bits_le()
             .chunks(Self::bits_per_limb())
             .map(|chunk| F::from_bigint(F::BigInt::from_bits_le(chunk)).unwrap())
             .collect()

--- a/folding-schemes/src/folding/circuits/nonnative/uint.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/uint.rs
@@ -257,7 +257,8 @@ impl<F: PrimeField, G: PrimeField> AllocVar<G, F> for NonNativeUintVar<F> {
 
 impl<F: PrimeField> NonNativeUintVar<F> {
     pub fn inputize<T: PrimeField>(x: T) -> Vec<F> {
-        x.into_bigint().to_bits_le()
+        x.into_bigint()
+            .to_bits_le()
             .chunks(Self::bits_per_limb())
             .map(|chunk| F::from_bigint(F::BigInt::from_bits_le(chunk)).unwrap())
             .collect()


### PR DESCRIPTION
#88 incorrectly sets the bit-length of an element in `BaseField` to `ScalarField::MODULUS_BIT_SIZE` in `NonNativeAffineVar::inputize`. This works for Pasta curves and BN254, but is problematic for curves with `ScalarField::MODULUS_BIT_SIZE != BaseField::MODULUS_BIT_SIZE`, e.g., the test below will fail for BLS12_381.

```rs
#[test]
fn test_inputize() {
    let cs = ConstraintSystem::<ark_bls12_381::Fr>::new_ref();

    // check that point_to_nonnative_limbs returns the expected values
    let mut rng = ark_std::test_rng();
    let p = ark_bls12_381::G1Projective::rand(&mut rng);
    let pVar = NonNativeAffineVar::<ark_bls12_381::G1Projective>::new_witness(cs.clone(), || Ok(p)).unwrap();
    let (x, y) = NonNativeAffineVar::inputize(p).unwrap();

    assert_eq!(pVar.x.0.value().unwrap(), x);
    assert_eq!(pVar.y.0.value().unwrap(), y);
}
```

This PR is a hotfix that ensures it works correctly.