### PR TITLE
Circom external inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,10 +79,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
+      - name: Download Circom
+        run: |
+          mkdir -p $HOME/bin
+          curl -sSfL https://github.com/iden3/circom/releases/download/v2.1.6/circom-linux-amd64 -o $HOME/bin/circom
+          chmod +x $HOME/bin/circom
+          echo "$HOME/bin" >> $GITHUB_PATH
       - name: Download solc
         run: |
           curl -sSfL https://github.com/ethereum/solidity/releases/download/v0.8.4/solc-static-linux -o /usr/local/bin/solc
           chmod +x /usr/local/bin/solc
+      - name: Execute compile.sh to generate .r1cs and .wasm from .circom
+        run: bash ./folding-schemes/src/frontend/circom/test_folder/compile.sh
       - name: Run examples tests
         run: cargo test --examples
       - name: Run examples

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,10 @@
 Cargo.lock
 
 # Circom generated files
-folding-schemes/src/frontend/circom/test_folder/cubic_circuit.r1cs
 folding-schemes/src/frontend/circom/test_folder/cubic_circuit_js/
+folding-schemes/src/frontend/circom/test_folder/external_inputs_js/
+*.r1cs
+*.sym
 
 # generated contracts at test time
 solidity-verifiers/generated

--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -63,7 +63,7 @@ fn main() {
     );
 
     let f_circuit_params = (r1cs_path, wasm_path, 1, 2);
-    let f_circuit = CircomFCircuit::<Fr>::new(f_circuit_params);
+    let f_circuit = CircomFCircuit::<Fr>::new(f_circuit_params).unwrap();
 
     let (fs_prover_params, kzg_vk, g16_pk, g16_vk) =
         init_ivc_and_decider_params::<CircomFCircuit<Fr>>(f_circuit.clone());

--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -12,8 +12,7 @@
 use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
 use ark_crypto_primitives::snark::SNARK;
 use ark_ff::PrimeField;
-use ark_groth16::VerifyingKey as G16VerifierKey;
-use ark_groth16::{Groth16, ProvingKey};
+use ark_groth16::{Groth16, ProvingKey, VerifyingKey as G16VerifierKey};
 use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
 use ark_poly_commit::kzg10::VerifierKey as KZGVerifierKey;
 use ark_r1cs_std::alloc::AllocVar;
@@ -21,10 +20,8 @@ use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use ark_std::Zero;
 use std::marker::PhantomData;
+use std::path::PathBuf;
 use std::time::Instant;
-
-mod utils;
-use utils::{init_params, init_test_prover_params};
 
 use folding_schemes::{
     commitment::{
@@ -37,7 +34,7 @@ use folding_schemes::{
         decider_eth_circuit::DeciderEthCircuit,
         get_cs_params_len, Nova, ProverParams,
     },
-    frontend::FCircuit,
+    frontend::{circom::CircomFCircuit, FCircuit},
     transcript::poseidon::poseidon_test_config,
     Decider, Error, FoldingScheme,
 };
@@ -48,59 +45,49 @@ use solidity_verifiers::{
     NovaCycleFoldVerifierKey,
 };
 
-/// Test circuit to be folded
-#[derive(Clone, Copy, Debug)]
-pub struct CubicFCircuit<F: PrimeField> {
-    _f: PhantomData<F>,
-}
-impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
-    type Params = ();
-    fn new(_params: Self::Params) -> Self {
-        Self { _f: PhantomData }
-    }
-    fn state_len(&self) -> usize {
-        1
-    }
-    fn external_inputs_len(&self) -> usize {
-        0
-    }
-    fn step_native(
-        &self,
-        _i: usize,
-        z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
-    }
-    fn generate_step_constraints(
-        &self,
-        cs: ConstraintSystemRef<F>,
-        _i: usize,
-        z_i: Vec<FpVar<F>>,
-        _external_inputs: Vec<FpVar<F>>,
-    ) -> Result<Vec<FpVar<F>>, SynthesisError> {
-        let five = FpVar::<F>::new_constant(cs.clone(), F::from(5u32))?;
-        let z_i = z_i[0].clone();
-
-        Ok(vec![&z_i * &z_i * &z_i + &z_i + &five])
-    }
-}
+mod utils;
+use utils::{init_params, init_test_prover_params};
 
 fn main() {
     let n_steps = 10;
     // set the initial state
     let z_0 = vec![Fr::from(3_u32)];
 
-    let f_circuit = CubicFCircuit::<Fr>::new(());
-    let (fs_prover_params, kzg_vk, g16_pk, g16_vk) = init_params::<CubicFCircuit<Fr>>(f_circuit);
+    // set the external inputs to be used at each step of the IVC
+    let external_inputs = vec![
+        vec![Fr::from(6u32), Fr::from(7u32)],
+        vec![Fr::from(8u32), Fr::from(9u32)],
+        vec![Fr::from(10u32), Fr::from(11u32)],
+        vec![Fr::from(12u32), Fr::from(13u32)],
+        vec![Fr::from(14u32), Fr::from(15u32)],
+        vec![Fr::from(6u32), Fr::from(7u32)],
+        vec![Fr::from(8u32), Fr::from(9u32)],
+        vec![Fr::from(10u32), Fr::from(11u32)],
+        vec![Fr::from(12u32), Fr::from(13u32)],
+        vec![Fr::from(14u32), Fr::from(15u32)],
+    ];
 
-    pub type NOVA = Nova<G1, GVar, G2, GVar2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
+    // initialize the Circom circuit
+    let r1cs_path =
+        PathBuf::from("./folding-schemes/src/frontend/circom/test_folder/external_inputs.r1cs");
+    let wasm_path = PathBuf::from(
+        "./folding-schemes/src/frontend/circom/test_folder/external_inputs_js/external_inputs.wasm",
+    );
+
+    let f_circuit_params = (r1cs_path, wasm_path, 1, 2);
+    let f_circuit = CircomFCircuit::<Fr>::new(f_circuit_params);
+
+    let (fs_prover_params, kzg_vk, g16_pk, g16_vk) =
+        init_params::<CircomFCircuit<Fr>>(f_circuit.clone());
+
+    pub type NOVA =
+        Nova<G1, GVar, G2, GVar2, CircomFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
     pub type DECIDERETH_FCircuit = DeciderEth<
         G1,
         GVar,
         G2,
         GVar2,
-        CubicFCircuit<Fr>,
+        CircomFCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<G2>,
         Groth16<Bn254>,
@@ -108,11 +95,11 @@ fn main() {
     >;
 
     // initialize the folding scheme engine, in our case we use Nova
-    let mut nova = NOVA::init(&fs_prover_params, f_circuit, z_0).unwrap();
+    let mut nova = NOVA::init(&fs_prover_params, f_circuit.clone(), z_0).unwrap();
     // run n steps of the folding iteration
     for i in 0..n_steps {
         let start = Instant::now();
-        nova.prove_step(vec![]).unwrap();
+        nova.prove_step(external_inputs[i].clone()).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -84,11 +84,11 @@ where
 {
     type Params = PoseidonConfig<F>;
 
-    fn new(params: Self::Params) -> Self {
-        Self {
+    fn new(params: Self::Params) -> Result<Self, Error> {
+        Ok(Self {
             _f: PhantomData,
             poseidon_config: params,
-        }
+        })
     }
     fn state_len(&self) -> usize {
         2
@@ -140,11 +140,13 @@ pub mod tests {
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circuit = ExternalInputsCircuits::<Fr>::new((poseidon_config, vec![Fr::from(3_u32)]));
+        let circuit = ExternalInputsCircuits::<Fr>::new(poseidon_config).unwrap();
         let z_i = vec![Fr::from(1_u32), Fr::zero()];
         let external_inputs = vec![Fr::from(3_u32)];
 
-        let z_i1 = circuit.step_native(0, z_i.clone()).unwrap();
+        let z_i1 = circuit
+            .step_native(0, z_i.clone(), external_inputs.clone())
+            .unwrap();
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i)).unwrap();
         let external_inputsVar =
@@ -173,7 +175,7 @@ fn main() {
     assert_eq!(external_inputs.len(), num_steps);
 
     let poseidon_config = poseidon_test_config::<Fr>();
-    let F_circuit = ExternalInputsCircuits::<Fr>::new(poseidon_config);
+    let F_circuit = ExternalInputsCircuits::<Fr>::new(poseidon_config).unwrap();
 
     println!("Prepare Nova ProverParams & VerifierParams");
     let (prover_params, verifier_params, _) =

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -3,6 +3,7 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
+use ark_bn254::{constraints::GVar, Fr, Projective};
 use ark_crypto_primitives::{
     crh::{
         poseidon::constraints::{CRHGadget, CRHParametersVar},
@@ -12,12 +13,11 @@ use ark_crypto_primitives::{
     sponge::{poseidon::PoseidonConfig, Absorb},
 };
 use ark_ff::PrimeField;
-use ark_pallas::{constraints::GVar, Fr, Projective};
+use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_r1cs_std::{alloc::AllocVar, fields::FieldVar};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use ark_std::Zero;
-use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
 use core::marker::PhantomData;
 use std::time::Instant;
 

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -45,8 +45,8 @@ pub struct CubicFCircuit<F: PrimeField> {
 }
 impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
     type Params = ();
-    fn new(_params: Self::Params) -> Self {
-        Self { _f: PhantomData }
+    fn new(_params: Self::Params) -> Result<Self, Error> {
+        Ok(Self { _f: PhantomData })
     }
     fn state_len(&self) -> usize {
         1
@@ -81,7 +81,7 @@ fn main() {
     // set the initial state
     let z_0 = vec![Fr::from(3_u32)];
 
-    let f_circuit = CubicFCircuit::<Fr>::new(());
+    let f_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
     let (fs_prover_params, kzg_vk, g16_pk, g16_vk) =
         init_ivc_and_decider_params::<CubicFCircuit<Fr>>(f_circuit);
 

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -58,7 +58,15 @@ impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
     fn state_len(&self) -> usize {
         1
     }
-    fn step_native(&self, _i: usize, z_i: Vec<F>) -> Result<Vec<F>, Error> {
+    fn external_inputs_len(&self) -> usize {
+        0
+    }
+    fn step_native(
+        &self,
+        _i: usize,
+        z_i: Vec<F>,
+        _external_inputs: Vec<F>,
+    ) -> Result<Vec<F>, Error> {
         Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
     }
     fn generate_step_constraints(
@@ -66,6 +74,7 @@ impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
         cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
+        _external_inputs: Vec<FpVar<F>>,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let five = FpVar::<F>::new_constant(cs.clone(), F::from(5u32))?;
         let z_i = z_i[0].clone();
@@ -153,7 +162,7 @@ fn main() {
     // run n steps of the folding iteration
     for i in 0..n_steps {
         let start = Instant::now();
-        nova.prove_step().unwrap();
+        nova.prove_step(vec![]).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -10,35 +10,25 @@
 /// - verify the proof in the EVM
 ///
 use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
-use ark_crypto_primitives::snark::SNARK;
 use ark_ff::PrimeField;
-use ark_groth16::VerifyingKey as G16VerifierKey;
-use ark_groth16::{Groth16, ProvingKey};
+use ark_groth16::Groth16;
 use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
-use ark_poly_commit::kzg10::VerifierKey as KZGVerifierKey;
 use ark_r1cs_std::alloc::AllocVar;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use ark_std::Zero;
 use std::marker::PhantomData;
 use std::time::Instant;
 
 mod utils;
-use utils::{init_params, init_test_prover_params};
+use utils::init_ivc_and_decider_params;
 
 use folding_schemes::{
-    commitment::{
-        kzg::{ProverKey as KZGProverKey, KZG},
-        pedersen::Pedersen,
-        CommitmentScheme,
-    },
+    commitment::{kzg::KZG, pedersen::Pedersen},
     folding::nova::{
         decider_eth::{prepare_calldata, Decider as DeciderEth},
-        decider_eth_circuit::DeciderEthCircuit,
-        get_cs_params_len, Nova, ProverParams,
+        Nova,
     },
     frontend::FCircuit,
-    transcript::poseidon::poseidon_test_config,
     Decider, Error, FoldingScheme,
 };
 use solidity_verifiers::{
@@ -92,7 +82,8 @@ fn main() {
     let z_0 = vec![Fr::from(3_u32)];
 
     let f_circuit = CubicFCircuit::<Fr>::new(());
-    let (fs_prover_params, kzg_vk, g16_pk, g16_vk) = init_params::<CubicFCircuit<Fr>>(f_circuit);
+    let (fs_prover_params, kzg_vk, g16_pk, g16_vk) =
+        init_ivc_and_decider_params::<CubicFCircuit<Fr>>(f_circuit);
 
     pub type NOVA = Nova<G1, GVar, G2, GVar2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
     pub type DECIDERETH_FCircuit = DeciderEth<

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -10,15 +10,15 @@ use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use ark_bn254::{constraints::GVar, Fr, Projective};
+use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
 use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
 
-use folding_schemes::commitment::pedersen::Pedersen;
+use folding_schemes::commitment::{kzg::KZG, pedersen::Pedersen};
 use folding_schemes::folding::nova::Nova;
 use folding_schemes::frontend::FCircuit;
 use folding_schemes::{Error, FoldingScheme};
 mod utils;
-use utils::test_nova_setup;
+use utils::init_nova_ivc_params;
 
 /// This is the circuit that we want to fold, it implements the FCircuit trait. The parameter z_i
 /// denotes the current state which contains 5 elements, and z_{i+1} denotes the next state which
@@ -125,7 +125,8 @@ fn main() {
     let F_circuit = MultiInputsFCircuit::<Fr>::new(());
 
     println!("Prepare Nova ProverParams & VerifierParams");
-    let (prover_params, verifier_params) = test_nova_setup::<MultiInputsFCircuit<Fr>>(F_circuit);
+    let (prover_params, verifier_params, _) =
+        init_nova_ivc_params::<MultiInputsFCircuit<Fr>>(F_circuit);
 
     /// The idea here is that eventually we could replace the next line chunk that defines the
     /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`
@@ -136,7 +137,7 @@ fn main() {
         Projective2,
         GVar2,
         MultiInputsFCircuit<Fr>,
-        Pedersen<Projective>,
+        KZG<'static, Bn254>,
         Pedersen<Projective2>,
     >;
 

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -32,8 +32,8 @@ pub struct MultiInputsFCircuit<F: PrimeField> {
 impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
     type Params = ();
 
-    fn new(_params: Self::Params) -> Self {
-        Self { _f: PhantomData }
+    fn new(_params: Self::Params) -> Result<Self, Error> {
+        Ok(Self { _f: PhantomData })
     }
     fn state_len(&self) -> usize {
         5
@@ -92,7 +92,7 @@ pub mod tests {
     fn test_f_circuit() {
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circuit = MultiInputsFCircuit::<Fr>::new(());
+        let circuit = MultiInputsFCircuit::<Fr>::new(()).unwrap();
         let z_i = vec![
             Fr::from(1_u32),
             Fr::from(1_u32),
@@ -101,11 +101,11 @@ pub mod tests {
             Fr::from(1_u32),
         ];
 
-        let z_i1 = circuit.step_native(0, z_i.clone()).unwrap();
+        let z_i1 = circuit.step_native(0, z_i.clone(), vec![]).unwrap();
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i)).unwrap();
         let computed_z_i1Var = circuit
-            .generate_step_constraints(cs.clone(), 0, z_iVar.clone())
+            .generate_step_constraints(cs.clone(), 0, z_iVar.clone(), vec![])
             .unwrap();
         assert_eq!(computed_z_i1Var.value().unwrap(), z_i1);
     }
@@ -122,7 +122,7 @@ fn main() {
         Fr::from(1_u32),
     ];
 
-    let F_circuit = MultiInputsFCircuit::<Fr>::new(());
+    let F_circuit = MultiInputsFCircuit::<Fr>::new(()).unwrap();
 
     println!("Prepare Nova ProverParams & VerifierParams");
     let (prover_params, verifier_params, _) =

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -10,8 +10,8 @@ use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use ark_pallas::{constraints::GVar, Fr, Projective};
-use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+use ark_bn254::{constraints::GVar, Fr, Projective};
+use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
 
 use folding_schemes::commitment::pedersen::Pedersen;
 use folding_schemes::folding::nova::Nova;

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -38,10 +38,18 @@ impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
     fn state_len(&self) -> usize {
         5
     }
+    fn external_inputs_len(&self) -> usize {
+        0
+    }
 
     /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
     /// z_{i+1}
-    fn step_native(&self, _i: usize, z_i: Vec<F>) -> Result<Vec<F>, Error> {
+    fn step_native(
+        &self,
+        _i: usize,
+        z_i: Vec<F>,
+        _external_inputs: Vec<F>,
+    ) -> Result<Vec<F>, Error> {
         let a = z_i[0] + F::from(4_u32);
         let b = z_i[1] + F::from(40_u32);
         let c = z_i[2] * F::from(4_u32);
@@ -57,6 +65,7 @@ impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
         cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
+        _external_inputs: Vec<FpVar<F>>,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let four = FpVar::<F>::new_constant(cs.clone(), F::from(4u32))?;
         let forty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
@@ -137,7 +146,7 @@ fn main() {
     // compute a step of the IVC
     for i in 0..num_steps {
         let start = Instant::now();
-        folding_scheme.prove_step().unwrap();
+        folding_scheme.prove_step(vec![]).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -44,10 +44,18 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
     fn state_len(&self) -> usize {
         1
     }
+    fn external_inputs_len(&self) -> usize {
+        0
+    }
 
     /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
     /// z_{i+1}
-    fn step_native(&self, _i: usize, z_i: Vec<F>) -> Result<Vec<F>, Error> {
+    fn step_native(
+        &self,
+        _i: usize,
+        z_i: Vec<F>,
+        _external_inputs: Vec<F>,
+    ) -> Result<Vec<F>, Error> {
         let out_bytes = Sha256::evaluate(&(), z_i[0].into_bigint().to_bytes_le()).unwrap();
         let out: Vec<F> = out_bytes.to_field_elements().unwrap();
 
@@ -60,6 +68,7 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
         _cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
+        _external_inputs: Vec<FpVar<F>>,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let unit_var = UnitVar::default();
         let out_bytes = Sha256Gadget::evaluate(&unit_var, &z_i[0].to_bytes()?)?;
@@ -122,7 +131,7 @@ fn main() {
     // compute a step of the IVC
     for i in 0..num_steps {
         let start = Instant::now();
-        folding_scheme.prove_step().unwrap();
+        folding_scheme.prove_step(vec![]).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -16,8 +16,8 @@ use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use ark_pallas::{constraints::GVar, Fr, Projective};
-use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+use ark_bn254::{constraints::GVar, Fr, Projective};
+use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
 
 use folding_schemes::commitment::pedersen::Pedersen;
 use folding_schemes::folding::nova::Nova;

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -38,8 +38,8 @@ pub struct Sha256FCircuit<F: PrimeField> {
 impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
     type Params = ();
 
-    fn new(_params: Self::Params) -> Self {
-        Self { _f: PhantomData }
+    fn new(_params: Self::Params) -> Result<Self, Error> {
+        Ok(Self { _f: PhantomData })
     }
     fn state_len(&self) -> usize {
         1
@@ -89,14 +89,14 @@ pub mod tests {
     fn test_f_circuit() {
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circuit = Sha256FCircuit::<Fr>::new(());
+        let circuit = Sha256FCircuit::<Fr>::new(()).unwrap();
         let z_i = vec![Fr::from(1_u32)];
 
-        let z_i1 = circuit.step_native(0, z_i.clone()).unwrap();
+        let z_i1 = circuit.step_native(0, z_i.clone(), vec![]).unwrap();
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i)).unwrap();
         let computed_z_i1Var = circuit
-            .generate_step_constraints(cs.clone(), 0, z_iVar.clone())
+            .generate_step_constraints(cs.clone(), 0, z_iVar.clone(), vec![])
             .unwrap();
         assert_eq!(computed_z_i1Var.value().unwrap(), z_i1);
     }
@@ -107,7 +107,7 @@ fn main() {
     let num_steps = 10;
     let initial_state = vec![Fr::from(1_u32)];
 
-    let F_circuit = Sha256FCircuit::<Fr>::new(());
+    let F_circuit = Sha256FCircuit::<Fr>::new(()).unwrap();
 
     println!("Prepare Nova ProverParams & VerifierParams");
     let (prover_params, verifier_params, _) = init_nova_ivc_params::<Sha256FCircuit<Fr>>(F_circuit);

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -16,15 +16,15 @@ use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use ark_bn254::{constraints::GVar, Fr, Projective};
+use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
 use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
 
-use folding_schemes::commitment::pedersen::Pedersen;
+use folding_schemes::commitment::{kzg::KZG, pedersen::Pedersen};
 use folding_schemes::folding::nova::Nova;
 use folding_schemes::frontend::FCircuit;
 use folding_schemes::{Error, FoldingScheme};
 mod utils;
-use utils::test_nova_setup;
+use utils::init_nova_ivc_params;
 
 /// This is the circuit that we want to fold, it implements the FCircuit trait.
 /// The parameter z_i denotes the current state, and z_{i+1} denotes the next state which we get by
@@ -110,7 +110,7 @@ fn main() {
     let F_circuit = Sha256FCircuit::<Fr>::new(());
 
     println!("Prepare Nova ProverParams & VerifierParams");
-    let (prover_params, verifier_params) = test_nova_setup::<Sha256FCircuit<Fr>>(F_circuit);
+    let (prover_params, verifier_params, _) = init_nova_ivc_params::<Sha256FCircuit<Fr>>(F_circuit);
 
     /// The idea here is that eventually we could replace the next line chunk that defines the
     /// `type NOVA = Nova<...>` by using another folding scheme that fulfills the `FoldingScheme`
@@ -121,7 +121,7 @@ fn main() {
         Projective2,
         GVar2,
         Sha256FCircuit<Fr>,
-        Pedersen<Projective>,
+        KZG<'static, Bn254>,
         Pedersen<Projective2>,
     >;
 

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -3,13 +3,29 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 #![allow(dead_code)]
-use ark_pallas::{constraints::GVar, Fr, Projective};
-use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
+use ark_crypto_primitives::snark::SNARK;
+use ark_groth16::{Groth16, ProvingKey, VerifyingKey as G16VerifierKey};
+use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
+use ark_poly_commit::kzg10::VerifierKey as KZGVerifierKey;
+use ark_std::Zero;
+use std::time::Instant;
 
-use folding_schemes::commitment::{pedersen::Pedersen, CommitmentScheme};
-use folding_schemes::folding::nova::{get_r1cs, ProverParams, VerifierParams};
-use folding_schemes::frontend::FCircuit;
-use folding_schemes::transcript::poseidon::poseidon_test_config;
+use folding_schemes::{
+    commitment::{
+        kzg::{ProverKey as KZGProverKey, KZG},
+        pedersen::Pedersen,
+        CommitmentScheme,
+    },
+    folding::nova::{
+        decider_eth::{prepare_calldata, Decider as DeciderEth},
+        decider_eth_circuit::DeciderEthCircuit,
+        get_cs_params_len, get_r1cs, Nova, ProverParams, VerifierParams,
+    },
+    frontend::FCircuit,
+    transcript::poseidon::poseidon_test_config,
+    FoldingScheme,
+};
 
 // This method computes the Nova's Prover & Verifier parameters for the example.
 // Warning: this method is only for testing purposes. For a real world use case those parameters
@@ -18,32 +34,87 @@ use folding_schemes::transcript::poseidon::poseidon_test_config;
 pub(crate) fn test_nova_setup<FC: FCircuit<Fr>>(
     F_circuit: FC,
 ) -> (
-    ProverParams<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>>,
-    VerifierParams<Projective, Projective2>,
+    ProverParams<G1, G2, Pedersen<G1>, Pedersen<G2>>,
+    VerifierParams<G1, G2>,
 ) {
     let mut rng = ark_std::test_rng();
     let poseidon_config = poseidon_test_config::<Fr>();
 
     // get the CM & CF_CM len
-    let (r1cs, cf_r1cs) =
-        get_r1cs::<Projective, GVar, Projective2, GVar2, FC>(&poseidon_config, F_circuit).unwrap();
+    let (r1cs, cf_r1cs) = get_r1cs::<G1, GVar, G2, GVar2, FC>(&poseidon_config, F_circuit).unwrap();
     let cf_len = r1cs.A.n_rows;
     let cf_cf_len = cf_r1cs.A.n_rows;
 
-    let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, cf_len).unwrap();
-    let (cf_pedersen_params, _) = Pedersen::<Projective2>::setup(&mut rng, cf_cf_len).unwrap();
+    let (pedersen_params, _) = Pedersen::<G1>::setup(&mut rng, cf_len).unwrap();
+    let (cf_pedersen_params, _) = Pedersen::<G2>::setup(&mut rng, cf_cf_len).unwrap();
 
-    let prover_params =
-        ProverParams::<Projective, Projective2, Pedersen<Projective>, Pedersen<Projective2>> {
-            poseidon_config: poseidon_config.clone(),
-            cs_params: pedersen_params,
-            cf_cs_params: cf_pedersen_params,
-        };
-    let verifier_params = VerifierParams::<Projective, Projective2> {
+    let prover_params = ProverParams::<G1, G2, Pedersen<G1>, Pedersen<G2>> {
+        poseidon_config: poseidon_config.clone(),
+        cs_params: pedersen_params,
+        cf_cs_params: cf_pedersen_params,
+    };
+    let verifier_params = VerifierParams::<G1, G2> {
         poseidon_config: poseidon_config.clone(),
         r1cs,
         cf_r1cs,
     };
     (prover_params, verifier_params)
 }
+
+#[allow(clippy::type_complexity)]
+pub(crate) fn init_test_prover_params<FC: FCircuit<Fr>>(
+    f_circuit: FC,
+) -> (
+    ProverParams<G1, G2, KZG<'static, Bn254>, Pedersen<G2>>,
+    KZGVerifierKey<Bn254>,
+) {
+    let mut rng = ark_std::test_rng();
+    let poseidon_config = poseidon_test_config::<Fr>();
+    let (cs_len, cf_cs_len) =
+        get_cs_params_len::<G1, GVar, G2, GVar2, FC>(&poseidon_config, f_circuit).unwrap();
+    let (kzg_pk, kzg_vk): (KZGProverKey<G1>, KZGVerifierKey<Bn254>) =
+        KZG::<Bn254>::setup(&mut rng, cs_len).unwrap();
+    let (cf_pedersen_params, _) = Pedersen::<G2>::setup(&mut rng, cf_cs_len).unwrap();
+    let fs_prover_params = ProverParams::<G1, G2, KZG<Bn254>, Pedersen<G2>> {
+        poseidon_config: poseidon_config.clone(),
+        cs_params: kzg_pk.clone(),
+        cf_cs_params: cf_pedersen_params,
+    };
+    (fs_prover_params, kzg_vk)
+}
+
+/// Initializes Nova parameters and DeciderEth parameters. Only for test purposes.
+#[allow(clippy::type_complexity)]
+pub(crate) fn init_params<FC: FCircuit<Fr>>(
+    f_circuit: FC,
+) -> (
+    ProverParams<G1, G2, KZG<'static, Bn254>, Pedersen<G2>>,
+    KZGVerifierKey<Bn254>,
+    ProvingKey<Bn254>,
+    G16VerifierKey<Bn254>,
+) {
+    let mut rng = rand::rngs::OsRng;
+    let start = Instant::now();
+    let (fs_prover_params, kzg_vk) = init_test_prover_params::<FC>(f_circuit.clone());
+    println!("generated Nova folding params: {:?}", start.elapsed());
+
+    pub type NOVA<FC> = Nova<G1, GVar, G2, GVar2, FC, KZG<'static, Bn254>, Pedersen<G2>>;
+    let z_0 = vec![Fr::zero(); f_circuit.state_len()];
+    let nova = NOVA::init(&fs_prover_params, f_circuit, z_0.clone()).unwrap();
+
+    let decider_circuit =
+        DeciderEthCircuit::<G1, GVar, G2, GVar2, KZG<Bn254>, Pedersen<G2>>::from_nova::<FC>(
+            nova.clone(),
+        )
+        .unwrap();
+    let start = Instant::now();
+    let (g16_pk, g16_vk) =
+        Groth16::<Bn254>::circuit_specific_setup(decider_circuit.clone(), &mut rng).unwrap();
+    println!(
+        "generated G16 (Decider circuit) params: {:?}",
+        start.elapsed()
+    );
+    (fs_prover_params, kzg_vk, g16_pk, g16_vk)
+}
+
 fn main() {}

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -366,7 +366,7 @@ where
         let i_usize = self.i_usize.unwrap_or(0);
         let z_i1 = self
             .F
-            .generate_step_constraints(cs.clone(), i_usize, z_i.clone())?;
+            .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), vec![])?; // TODO external_inputs instead of vec![]
 
         let is_basecase = i.is_zero()?;
 

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -373,7 +373,7 @@ where
         let i_usize = self.i_usize.unwrap_or(0);
         let z_i1 =
             self.F
-                .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), external_inputs)?; // TODO external_inputs instead of vec![]
+                .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), external_inputs)?;
 
         let is_basecase = i.is_zero()?;
 

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -258,6 +258,7 @@ pub struct AugmentedFCircuit<
     pub i_usize: Option<usize>,
     pub z_0: Option<Vec<C1::ScalarField>>,
     pub z_i: Option<Vec<C1::ScalarField>>,
+    pub external_inputs: Option<Vec<C1::ScalarField>>,
     pub u_i_cmW: Option<C1>,
     pub U_i: Option<CommittedInstance<C1>>,
     pub U_i1_cmE: Option<C1>,
@@ -290,6 +291,7 @@ where
             i_usize: None,
             z_0: None,
             z_i: None,
+            external_inputs: None,
             u_i_cmW: None,
             U_i: None,
             U_i1_cmE: None,
@@ -335,6 +337,11 @@ where
                 .z_i
                 .unwrap_or(vec![CF1::<C1>::zero(); self.F.state_len()]))
         })?;
+        let external_inputs = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || {
+            Ok(self
+                .external_inputs
+                .unwrap_or(vec![CF1::<C1>::zero(); self.F.external_inputs_len()]))
+        })?;
 
         let u_dummy = CommittedInstance::dummy(2);
         let U_i = CommittedInstanceVar::<C1>::new_witness(cs.clone(), || {
@@ -364,9 +371,9 @@ where
 
         // get z_{i+1} from the F circuit
         let i_usize = self.i_usize.unwrap_or(0);
-        let z_i1 = self
-            .F
-            .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), vec![])?; // TODO external_inputs instead of vec![]
+        let z_i1 =
+            self.F
+                .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), external_inputs)?; // TODO external_inputs instead of vec![]
 
         let is_basecase = i.is_zero()?;
 

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -321,7 +321,7 @@ pub mod tests {
         let mut rng = ark_std::test_rng();
         let poseidon_config = poseidon_test_config::<Fr>();
 
-        let F_circuit = CubicFCircuit::<Fr>::new(());
+        let F_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
         let z_0 = vec![Fr::from(3_u32)];
 
         let (cs_len, cf_cs_len) =

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -347,9 +347,9 @@ pub mod tests {
         let mut nova = NOVA::init(&prover_params, F_circuit, z_0.clone()).unwrap();
         println!("Nova initialized, {:?}", start.elapsed());
         let start = Instant::now();
-        nova.prove_step().unwrap();
+        nova.prove_step(vec![]).unwrap();
         println!("prove_step, {:?}", start.elapsed());
-        nova.prove_step().unwrap(); // do a 2nd step
+        nova.prove_step(vec![]).unwrap(); // do a 2nd step
 
         // generate Groth16 setup
         let circuit = DeciderEthCircuit::<

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -671,7 +671,7 @@ pub mod tests {
     #[test]
     fn test_relaxed_r1cs_small_gadget_arkworks() {
         let z_i = vec![Fr::from(3_u32)];
-        let cubic_circuit = CubicFCircuit::<Fr>::new(());
+        let cubic_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
         let circuit = WrapperCircuit::<Fr, CubicFCircuit<Fr>> {
             FC: cubic_circuit,
             z_i: Some(z_i.clone()),
@@ -713,7 +713,7 @@ pub mod tests {
     #[test]
     fn test_relaxed_r1cs_custom_circuit() {
         let n_constraints = 10_000;
-        let custom_circuit = CustomFCircuit::<Fr>::new(n_constraints);
+        let custom_circuit = CustomFCircuit::<Fr>::new(n_constraints).unwrap();
         let z_i = vec![Fr::from(5_u32)];
         let circuit = WrapperCircuit::<Fr, CustomFCircuit<Fr>> {
             FC: custom_circuit,
@@ -729,7 +729,7 @@ pub mod tests {
         // in practice we would use CycleFoldCircuit, but is a very big circuit (when computed
         // non-natively inside the RelaxedR1CS circuit), so in order to have a short test we use a
         // custom circuit.
-        let custom_circuit = CustomFCircuit::<Fq>::new(10);
+        let custom_circuit = CustomFCircuit::<Fq>::new(10).unwrap();
         let z_i = vec![Fq::from(5_u32)];
         let circuit = WrapperCircuit::<Fq, CustomFCircuit<Fq>> {
             FC: custom_circuit,
@@ -770,7 +770,7 @@ pub mod tests {
         let mut rng = ark_std::test_rng();
         let poseidon_config = poseidon_test_config::<Fr>();
 
-        let F_circuit = CubicFCircuit::<Fr>::new(());
+        let F_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
         let z_0 = vec![Fr::from(3_u32)];
 
         // get the CS & CF_CS len

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -802,7 +802,7 @@ pub mod tests {
 
         // generate a Nova instance and do a step of it
         let mut nova = NOVA::init(&prover_params, F_circuit, z_0.clone()).unwrap();
-        nova.prove_step().unwrap();
+        nova.prove_step(vec![]).unwrap();
         let ivc_v = nova.clone();
         let verifier_params = VerifierParams::<Projective, Projective2> {
             poseidon_config: poseidon_config.clone(),

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -675,7 +675,7 @@ pub mod tests {
         let circuit = WrapperCircuit::<Fr, CubicFCircuit<Fr>> {
             FC: cubic_circuit,
             z_i: Some(z_i.clone()),
-            z_i1: Some(cubic_circuit.step_native(0, z_i).unwrap()),
+            z_i1: Some(cubic_circuit.step_native(0, z_i, vec![]).unwrap()),
         };
 
         test_relaxed_r1cs_gadget(circuit);
@@ -718,7 +718,7 @@ pub mod tests {
         let circuit = WrapperCircuit::<Fr, CustomFCircuit<Fr>> {
             FC: custom_circuit,
             z_i: Some(z_i.clone()),
-            z_i1: Some(custom_circuit.step_native(0, z_i).unwrap()),
+            z_i1: Some(custom_circuit.step_native(0, z_i, vec![]).unwrap()),
         };
         test_relaxed_r1cs_gadget(circuit);
     }
@@ -734,7 +734,7 @@ pub mod tests {
         let circuit = WrapperCircuit::<Fq, CustomFCircuit<Fq>> {
             FC: custom_circuit,
             z_i: Some(z_i.clone()),
-            z_i1: Some(custom_circuit.step_native(0, z_i).unwrap()),
+            z_i1: Some(custom_circuit.step_native(0, z_i, vec![]).unwrap()),
         };
         circuit.generate_constraints(cs.clone()).unwrap();
         cs.finalize();

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -824,7 +824,7 @@ pub mod tests {
         let mut rng = ark_std::test_rng();
         let poseidon_config = poseidon_test_config::<Fr>();
 
-        let F_circuit = CubicFCircuit::<Fr>::new(());
+        let F_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
 
         let (cs_len, cf_cs_len) =
             get_cs_params_len::<Projective, GVar, Projective2, GVar2, CubicFCircuit<Fr>>(

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -349,7 +349,7 @@ where
         i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..8]);
         let i_usize: usize = usize::from_le_bytes(i_bytes);
 
-        let z_i1 = self.F.step_native(i_usize, self.z_i.clone())?;
+        let z_i1 = self.F.step_native(i_usize, self.z_i.clone(), vec![])?; // TODO external_inputs instead of vec![]
 
         // compute T and cmT for AugmentedFCircuit
         let (T, cmT) = self.compute_cmT()?;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -342,6 +342,14 @@ where
     fn prove_step(&mut self, external_inputs: Vec<C1::ScalarField>) -> Result<(), Error> {
         let augmented_F_circuit: AugmentedFCircuit<C1, C2, GC2, FC>;
 
+        if self.z_i.len() != self.F.state_len() {
+            return Err(Error::NotSameLength(
+                "z_i.len()".to_string(),
+                self.z_i.len(),
+                "F.state_len()".to_string(),
+                self.F.state_len(),
+            ));
+        }
         if external_inputs.len() != self.F.external_inputs_len() {
             return Err(Error::NotSameLength(
                 "F.external_inputs_len()".to_string(),
@@ -360,7 +368,7 @@ where
 
         let z_i1 = self
             .F
-            .step_native(i_usize, self.z_i.clone(), external_inputs.clone())?; // TODO external_inputs instead of vec![]
+            .step_native(i_usize, self.z_i.clone(), external_inputs.clone())?;
 
         // compute T and cmT for AugmentedFCircuit
         let (T, cmT) = self.compute_cmT()?;

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -60,7 +60,7 @@ impl<F: PrimeField> FCircuit<F> for CircomFCircuit<F> {
             .collect::<Vec<BigInt>>();
         let mut inputs_map = vec![("ivc_input".to_string(), inputs_bi)];
 
-        if external_inputs.len() > 0 {
+        if !external_inputs.is_empty() {
             let external_inputs_bi = external_inputs
                 .iter()
                 .map(|val| self.circom_wrapper.ark_primefield_to_num_bigint(*val))

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -18,23 +18,29 @@ use utils::CircomWrapper;
 #[derive(Clone, Debug)]
 pub struct CircomFCircuit<F: PrimeField> {
     circom_wrapper: CircomWrapper<F>,
+    state_len: usize,
+    external_inputs_len: usize,
 }
 
 impl<F: PrimeField> FCircuit<F> for CircomFCircuit<F> {
-    /// (r1cs_path, wasm_path)
-    type Params = (PathBuf, PathBuf);
+    /// (r1cs_path, wasm_path, state_len, external_inputs_len)
+    type Params = (PathBuf, PathBuf, usize, usize);
 
     fn new(params: Self::Params) -> Self {
-        let (r1cs_path, wasm_path) = params;
+        let (r1cs_path, wasm_path, state_len, external_inputs_len) = params;
         let circom_wrapper = CircomWrapper::new(r1cs_path, wasm_path);
-        Self { circom_wrapper }
+        Self {
+            circom_wrapper,
+            state_len,
+            external_inputs_len,
+        }
     }
 
     fn state_len(&self) -> usize {
-        1 // TODO adapt from ivc_input.len()
+        self.state_len
     }
     fn external_inputs_len(&self) -> usize {
-        1 // TODO adapt from external_inputs.len()
+        self.external_inputs_len
     }
 
     fn step_native(
@@ -148,7 +154,7 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path));
+        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)); // state_len:1, external_inputs_len:0
 
         let z_i = vec![Fr::from(3u32)];
         let z_i1 = circom_fcircuit.step_native(1, z_i, vec![]).unwrap();
@@ -162,7 +168,7 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path));
+        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)); // state_len:1, external_inputs_len:0
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 
@@ -184,7 +190,7 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path));
+        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)); // state_len:1, external_inputs_len:0
 
         // Allocates z_i1 by using step_native function.
         let z_i = vec![Fr::from(3_u32)];
@@ -210,7 +216,7 @@ pub mod tests {
             "./src/frontend/circom/test_folder/external_inputs_js/external_inputs.wasm",
         );
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path));
+        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 2)); // state_len:1, external_inputs_len:2
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -31,7 +31,10 @@ impl<F: PrimeField> FCircuit<F> for CircomFCircuit<F> {
     }
 
     fn state_len(&self) -> usize {
-        1
+        1 // TODO adapt
+    }
+    fn external_inputs_len(&self) -> usize {
+        1 // TODO adapt
     }
 
     fn step_native(

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -31,10 +31,10 @@ impl<F: PrimeField> FCircuit<F> for CircomFCircuit<F> {
     }
 
     fn state_len(&self) -> usize {
-        1 // TODO adapt
+        1 // TODO adapt from ivc_input.len()
     }
     fn external_inputs_len(&self) -> usize {
-        1 // TODO adapt
+        1 // TODO adapt from external_inputs.len()
     }
 
     fn step_native(

--- a/folding-schemes/src/frontend/circom/test_folder/compile.sh
+++ b/folding-schemes/src/frontend/circom/test_folder/compile.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-circom ./folding-schemes/src/frontend/circom/test_folder/cubic_circuit.circom --r1cs --wasm --prime bn128 --output ./folding-schemes/src/frontend/circom/test_folder/
+circom ./folding-schemes/src/frontend/circom/test_folder/cubic_circuit.circom --r1cs --sym --wasm --prime bn128 --output ./folding-schemes/src/frontend/circom/test_folder/
+
+circom ./folding-schemes/src/frontend/circom/test_folder/external_inputs.circom --r1cs --sym --wasm --prime bn128 --output ./folding-schemes/src/frontend/circom/test_folder/

--- a/folding-schemes/src/frontend/circom/test_folder/cubic_circuit.circom
+++ b/folding-schemes/src/frontend/circom/test_folder/cubic_circuit.circom
@@ -10,4 +10,3 @@ template Example () {
 }
 
 component main {public [ivc_input]} = Example();
-

--- a/folding-schemes/src/frontend/circom/test_folder/external_inputs.circom
+++ b/folding-schemes/src/frontend/circom/test_folder/external_inputs.circom
@@ -1,0 +1,21 @@
+pragma circom 2.0.3;
+
+/*
+    z_{i+1} == z_i^3 + z_i * external_input[0] + external_input[1]
+*/
+template Example () {
+    signal input ivc_input[1]; // IVC state
+    signal input external_inputs[2]; // not state
+
+    signal output ivc_output[1]; // next IVC state
+
+    signal temp1;
+    signal temp2;
+    
+    temp1 <== ivc_input[0] * ivc_input[0];
+    temp2 <== ivc_input[0] * external_inputs[0];
+    ivc_output[0] <== temp1 * ivc_input[0] + temp2 + external_inputs[1];
+}
+
+component main {public [ivc_input]} = Example();
+/* component main {public [ivc_input, external_inputs]} = Example(); */

--- a/folding-schemes/src/frontend/circom/test_folder/external_inputs.circom
+++ b/folding-schemes/src/frontend/circom/test_folder/external_inputs.circom
@@ -18,4 +18,3 @@ template Example () {
 }
 
 component main {public [ivc_input]} = Example();
-/* component main {public [ivc_input, external_inputs]} = Example(); */

--- a/folding-schemes/src/frontend/circom/utils.rs
+++ b/folding-schemes/src/frontend/circom/utils.rs
@@ -45,6 +45,13 @@ impl<F: PrimeField> CircomWrapper<F> {
         Ok((r1cs, Some(witness_vec)))
     }
 
+    pub fn extract_r1cs(&self) -> Result<R1CS<F>, Error> {
+        let file = File::open(&self.r1cs_filepath)?;
+        let reader = BufReader::new(file);
+        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(reader)?;
+        Ok(r1cs_reader::R1CS::<F>::from(r1cs_file))
+    }
+
     // Extracts the witness vector as a vector of PrimeField elements.
     pub fn extract_witness(&self, inputs: &[(String, Vec<BigInt>)]) -> Result<Vec<F>, Error> {
         let witness_bigint = self.calculate_witness(inputs)?;

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -20,6 +20,10 @@ pub trait FCircuit<F: PrimeField>: Clone + Debug {
     /// FCircuit inputs.
     fn state_len(&self) -> usize;
 
+    /// returns the number of elements in the external inputs used by the FCircuit. External inputs
+    /// are optional, and in case no external inputs are used, this method should return 0.
+    fn external_inputs_len(&self) -> usize;
+
     /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
     /// z_{i+1}
     fn step_native(
@@ -69,6 +73,9 @@ pub mod tests {
         fn state_len(&self) -> usize {
             1
         }
+        fn external_inputs_len(&self) -> usize {
+            0
+        }
         fn step_native(
             &self,
             _i: usize,
@@ -109,6 +116,9 @@ pub mod tests {
         }
         fn state_len(&self) -> usize {
             1
+        }
+        fn external_inputs_len(&self) -> usize {
+            0
         }
         fn step_native(
             &self,

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -14,7 +14,7 @@ pub trait FCircuit<F: PrimeField>: Clone + Debug {
     type Params: Debug;
 
     /// returns a new FCircuit instance
-    fn new(params: Self::Params) -> Self;
+    fn new(params: Self::Params) -> Result<Self, Error>;
 
     /// returns the number of elements in the state of the FCircuit, which corresponds to the
     /// FCircuit inputs.
@@ -67,8 +67,8 @@ pub mod tests {
     }
     impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
         type Params = ();
-        fn new(_params: Self::Params) -> Self {
-            Self { _f: PhantomData }
+        fn new(_params: Self::Params) -> Result<Self, Error> {
+            Ok(Self { _f: PhantomData })
         }
         fn state_len(&self) -> usize {
             1
@@ -108,11 +108,11 @@ pub mod tests {
     impl<F: PrimeField> FCircuit<F> for CustomFCircuit<F> {
         type Params = usize;
 
-        fn new(params: Self::Params) -> Self {
-            Self {
+        fn new(params: Self::Params) -> Result<Self, Error> {
+            Ok(Self {
                 _f: PhantomData,
                 n_constraints: params,
-            }
+            })
         }
         fn state_len(&self) -> usize {
             1
@@ -182,7 +182,7 @@ pub mod tests {
     #[test]
     fn test_testfcircuit() {
         let cs = ConstraintSystem::<Fr>::new_ref();
-        let F_circuit = CubicFCircuit::<Fr>::new(());
+        let F_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
 
         let wrapper_circuit = WrapperCircuit::<Fr, CubicFCircuit<Fr>> {
             FC: F_circuit,
@@ -197,7 +197,7 @@ pub mod tests {
     fn test_customtestfcircuit() {
         let cs = ConstraintSystem::<Fr>::new_ref();
         let n_constraints = 1000;
-        let custom_circuit = CustomFCircuit::<Fr>::new(n_constraints);
+        let custom_circuit = CustomFCircuit::<Fr>::new(n_constraints).unwrap();
         let z_i = vec![Fr::from(5_u32)];
         let wrapper_circuit = WrapperCircuit::<Fr, CustomFCircuit<Fr>> {
             FC: custom_circuit,

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -124,7 +124,7 @@ where
         z_0: Vec<C1::ScalarField>, // initial state
     ) -> Result<Self, Error>;
 
-    fn prove_step(&mut self) -> Result<(), Error>;
+    fn prove_step(&mut self, external_inputs: Vec<C1::ScalarField>) -> Result<(), Error>;
 
     // returns the state at the current step
     fn state(&self) -> Vec<C1::ScalarField>;

--- a/solidity-verifiers/Cargo.toml
+++ b/solidity-verifiers/Cargo.toml
@@ -43,4 +43,7 @@ parallel = [
 [[example]]
 name = "full_flow"
 path = "../examples/full_flow.rs"
-# required-features = ["light-test"]
+
+[[example]]
+name = "circom_full_flow"
+path = "../examples/circom_full_flow.rs"

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -162,8 +162,8 @@ mod tests {
     }
     impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
         type Params = ();
-        fn new(_params: Self::Params) -> Self {
-            Self { _f: PhantomData }
+        fn new(_params: Self::Params) -> Result<Self, Error> {
+            Ok(Self { _f: PhantomData })
         }
         fn state_len(&self) -> usize {
             1
@@ -205,8 +205,8 @@ mod tests {
     impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
         type Params = ();
 
-        fn new(_params: Self::Params) -> Self {
-            Self { _f: PhantomData }
+        fn new(_params: Self::Params) -> Result<Self, Error> {
+            Ok(Self { _f: PhantomData })
         }
         fn state_len(&self) -> usize {
             5
@@ -288,7 +288,7 @@ mod tests {
     ) {
         let mut rng = ark_std::test_rng();
         let poseidon_config = poseidon_test_config::<Fr>();
-        let f_circuit = FC::new(());
+        let f_circuit = FC::new(()).unwrap();
         let (cs_len, cf_cs_len) =
             get_cs_params_len::<G1, GVar, G2, GVar2, FC>(&poseidon_config, f_circuit).unwrap();
         let (kzg_pk, kzg_vk): (KZGProverKey<G1>, KZGVerifierKey<Bn254>) =
@@ -314,7 +314,7 @@ mod tests {
         let start = Instant::now();
         let (fs_prover_params, kzg_vk) = init_test_prover_params::<FC>();
         println!("generated Nova folding params: {:?}", start.elapsed());
-        let f_circuit = FC::new(());
+        let f_circuit = FC::new(()).unwrap();
 
         pub type NOVA_FCircuit<FC> =
             Nova<G1, GVar, G2, GVar2, FC, KZG<'static, Bn254>, Pedersen<G2>>;
@@ -369,7 +369,7 @@ mod tests {
             Groth16<Bn254>,
             NOVA_FCircuit<FC>,
         >;
-        let f_circuit = FC::new(());
+        let f_circuit = FC::new(()).unwrap();
 
         let nova_cyclefold_vk =
             NovaCycleFoldVerifierKey::from((g16_vk.clone(), kzg_vk.clone(), f_circuit.state_len()));

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -168,7 +168,15 @@ mod tests {
         fn state_len(&self) -> usize {
             1
         }
-        fn step_native(&self, _i: usize, z_i: Vec<F>) -> Result<Vec<F>, Error> {
+        fn external_inputs_len(&self) -> usize {
+            0
+        }
+        fn step_native(
+            &self,
+            _i: usize,
+            z_i: Vec<F>,
+            _external_inputs: Vec<F>,
+        ) -> Result<Vec<F>, Error> {
             Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
         }
         fn generate_step_constraints(
@@ -176,6 +184,7 @@ mod tests {
             cs: ConstraintSystemRef<F>,
             _i: usize,
             z_i: Vec<FpVar<F>>,
+            _external_inputs: Vec<FpVar<F>>,
         ) -> Result<Vec<FpVar<F>>, SynthesisError> {
             let five = FpVar::<F>::new_constant(cs.clone(), F::from(5u32))?;
             let z_i = z_i[0].clone();
@@ -202,10 +211,18 @@ mod tests {
         fn state_len(&self) -> usize {
             5
         }
+        fn external_inputs_len(&self) -> usize {
+            0
+        }
 
         /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
         /// z_{i+1}
-        fn step_native(&self, _i: usize, z_i: Vec<F>) -> Result<Vec<F>, Error> {
+        fn step_native(
+            &self,
+            _i: usize,
+            z_i: Vec<F>,
+            _external_inputs: Vec<F>,
+        ) -> Result<Vec<F>, Error> {
             let a = z_i[0] + F::from(4_u32);
             let b = z_i[1] + F::from(40_u32);
             let c = z_i[2] * F::from(4_u32);
@@ -221,6 +238,7 @@ mod tests {
             cs: ConstraintSystemRef<F>,
             _i: usize,
             z_i: Vec<FpVar<F>>,
+            _external_inputs: Vec<FpVar<F>>,
         ) -> Result<Vec<FpVar<F>>, SynthesisError> {
             let four = FpVar::<F>::new_constant(cs.clone(), F::from(4u32))?;
             let forty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
@@ -358,7 +376,7 @@ mod tests {
 
         let mut nova = NOVA_FCircuit::init(&fs_prover_params, f_circuit, z_0).unwrap();
         for _ in 0..n_steps {
-            nova.prove_step().unwrap();
+            nova.prove_step(vec![]).unwrap();
         }
 
         let rng = rand::rngs::OsRng;


### PR DESCRIPTION
- Updates the `FoldingScheme` trait (and `nova` impl) to accept `external_inputs` at each `.prove_step` call (instead of setting them at the initialization call)
- Add external inputs to Circom's frontend
- move circom R1CS file read at initializer instead of each ivc step
- add `examples/circom_full_flow.rs` containing an example that goes from setting a circom circuit and folding it to verifying the proof in the EVM (like the `full_flow.rs` but instead of arkworks frontend using circom frontend). To showcase how to use the lib in Circom's case.