### PR TITLE
Unify the computation of digests and challenges in different folding schemes

### DIFF
--- a/folding-schemes/src/arith/ccs.rs
+++ b/folding-schemes/src/arith/ccs.rs
@@ -114,7 +114,6 @@ impl<F: PrimeField> CCS<F> {
 pub mod tests {
     use super::*;
     use crate::arith::r1cs::tests::{get_test_r1cs, get_test_z as r1cs_get_test_z};
-    use ark_ff::PrimeField;
     use ark_pallas::Fr;
 
     pub fn get_test_ccs<F: PrimeField>() -> CCS<F> {

--- a/folding-schemes/src/arith/r1cs.rs
+++ b/folding-schemes/src/arith/r1cs.rs
@@ -140,7 +140,6 @@ pub mod tests {
     use super::*;
     use crate::utils::vec::tests::{to_F_matrix, to_F_vec};
 
-    use ark_ff::PrimeField;
     use ark_pallas::Fr;
 
     pub fn get_test_r1cs<F: PrimeField>() -> R1CS<F> {

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -131,7 +131,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
             r = vec![];
         }
 
-        transcript.absorb_point(P);
+        transcript.absorb_nonnative(P);
         let x = transcript.get_challenge(); // challenge value at which we evaluate
         let s = transcript.get_challenge();
         let U = C::generator().mul(s);
@@ -162,8 +162,8 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
                 R[j] = C::msm_unchecked(&G[..m], &a[m..]) + U.mul(inner_prod(&a[m..], &b[..m])?);
             }
             // get challenge for the j-th round
-            transcript.absorb_point(&L[j]);
-            transcript.absorb_point(&R[j]);
+            transcript.absorb_nonnative(&L[j]);
+            transcript.absorb_nonnative(&R[j]);
             u[j] = transcript.get_challenge();
 
             let uj = u[j];
@@ -232,14 +232,14 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
         let (p, _r) = (proof.0.clone(), proof.1);
         let k = p.L.len();
 
-        transcript.absorb_point(P);
+        transcript.absorb_nonnative(P);
         let x = transcript.get_challenge(); // challenge value at which we evaluate
         let s = transcript.get_challenge();
         let U = C::generator().mul(s);
         let mut u: Vec<C::ScalarField> = vec![C::ScalarField::zero(); k];
         for i in (0..k).rev() {
-            transcript.absorb_point(&p.L[i]);
-            transcript.absorb_point(&p.R[i]);
+            transcript.absorb_nonnative(&p.L[i]);
+            transcript.absorb_nonnative(&p.R[i]);
             u[i] = transcript.get_challenge();
         }
         let challenge = (x, U, u);
@@ -667,14 +667,14 @@ mod tests {
         let cs = ConstraintSystem::<Fq>::new_ref();
 
         let mut transcript_v = PoseidonSponge::<Fr>::new(&poseidon_config);
-        transcript_v.absorb_point(&cm);
+        transcript_v.absorb_nonnative(&cm);
         let challenge = transcript_v.get_challenge(); // challenge value at which we evaluate
         let s = transcript_v.get_challenge();
         let U = Projective::generator().mul(s);
         let mut u: Vec<Fr> = vec![Fr::zero(); k];
         for i in (0..k).rev() {
-            transcript_v.absorb_point(&proof.0.L[i]);
-            transcript_v.absorb_point(&proof.0.R[i]);
+            transcript_v.absorb_nonnative(&proof.0.L[i]);
+            transcript_v.absorb_nonnative(&proof.0.R[i]);
             u[i] = transcript_v.get_challenge();
         }
 

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -131,7 +131,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
             r = vec![];
         }
 
-        transcript.absorb_point(P)?;
+        transcript.absorb_point(P);
         let x = transcript.get_challenge(); // challenge value at which we evaluate
         let s = transcript.get_challenge();
         let U = C::generator().mul(s);
@@ -162,8 +162,8 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
                 R[j] = C::msm_unchecked(&G[..m], &a[m..]) + U.mul(inner_prod(&a[m..], &b[..m])?);
             }
             // get challenge for the j-th round
-            transcript.absorb_point(&L[j])?;
-            transcript.absorb_point(&R[j])?;
+            transcript.absorb_point(&L[j]);
+            transcript.absorb_point(&R[j]);
             u[j] = transcript.get_challenge();
 
             let uj = u[j];
@@ -232,14 +232,14 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
         let (p, _r) = (proof.0.clone(), proof.1);
         let k = p.L.len();
 
-        transcript.absorb_point(P)?;
+        transcript.absorb_point(P);
         let x = transcript.get_challenge(); // challenge value at which we evaluate
         let s = transcript.get_challenge();
         let U = C::generator().mul(s);
         let mut u: Vec<C::ScalarField> = vec![C::ScalarField::zero(); k];
         for i in (0..k).rev() {
-            transcript.absorb_point(&p.L[i])?;
-            transcript.absorb_point(&p.R[i])?;
+            transcript.absorb_point(&p.L[i]);
+            transcript.absorb_point(&p.R[i]);
             u[i] = transcript.get_challenge();
         }
         let challenge = (x, U, u);
@@ -667,14 +667,14 @@ mod tests {
         let cs = ConstraintSystem::<Fq>::new_ref();
 
         let mut transcript_v = PoseidonSponge::<Fr>::new(&poseidon_config);
-        transcript_v.absorb_point(&cm).unwrap();
+        transcript_v.absorb_point(&cm);
         let challenge = transcript_v.get_challenge(); // challenge value at which we evaluate
         let s = transcript_v.get_challenge();
         let U = Projective::generator().mul(s);
         let mut u: Vec<Fr> = vec![Fr::zero(); k];
         for i in (0..k).rev() {
-            transcript_v.absorb_point(&proof.0.L[i]).unwrap();
-            transcript_v.absorb_point(&proof.0.R[i]).unwrap();
+            transcript_v.absorb_point(&proof.0.L[i]);
+            transcript_v.absorb_point(&proof.0.R[i]);
             u[i] = transcript_v.get_challenge();
         }
 

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -156,7 +156,7 @@ where
     /// the Pairing trait.
     fn prove(
         params: &Self::ProverParams,
-        transcript: &mut impl Transcript<E::G1>,
+        transcript: &mut impl Transcript<E::ScalarField>,
         cm: &E::G1,
         v: &[E::ScalarField],
         _blind: &E::ScalarField,
@@ -214,7 +214,7 @@ where
 
     fn verify(
         params: &Self::VerifierParams,
-        transcript: &mut impl Transcript<E::G1>,
+        transcript: &mut impl Transcript<E::ScalarField>,
         cm: &E::G1,
         proof: &Self::Proof,
     ) -> Result<(), Error> {
@@ -286,17 +286,18 @@ fn convert_to_bigints<F: PrimeField>(p: &[F]) -> Vec<F::BigInt> {
 #[cfg(test)]
 mod tests {
     use ark_bn254::{Bn254, Fr, G1Projective as G1};
+    use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
     use ark_std::{test_rng, UniformRand};
 
     use super::*;
-    use crate::transcript::poseidon::{poseidon_canonical_config, PoseidonTranscript};
+    use crate::transcript::poseidon::poseidon_canonical_config;
 
     #[test]
     fn test_kzg_commitment_scheme() {
         let mut rng = &mut test_rng();
         let poseidon_config = poseidon_canonical_config::<Fr>();
-        let transcript_p = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
-        let transcript_v = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
+        let transcript_p = &mut PoseidonSponge::<Fr>::new(&poseidon_config);
+        let transcript_v = &mut PoseidonSponge::<Fr>::new(&poseidon_config);
 
         let n = 10;
         let (pk, vk): (ProverKey<G1>, VerifierKey<Bn254>) =

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -162,7 +162,7 @@ where
         _blind: &E::ScalarField,
         _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Error> {
-        transcript.absorb_point(cm)?;
+        transcript.absorb_point(cm);
         let challenge = transcript.get_challenge();
         Self::prove_with_challenge(params, challenge, v, _blind, _rng)
     }
@@ -218,7 +218,7 @@ where
         cm: &E::G1,
         proof: &Self::Proof,
     ) -> Result<(), Error> {
-        transcript.absorb_point(cm)?;
+        transcript.absorb_point(cm);
         let challenge = transcript.get_challenge();
         Self::verify_with_challenge(params, challenge, cm, proof)
     }

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -162,7 +162,7 @@ where
         _blind: &E::ScalarField,
         _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Error> {
-        transcript.absorb_point(cm);
+        transcript.absorb_nonnative(cm);
         let challenge = transcript.get_challenge();
         Self::prove_with_challenge(params, challenge, v, _blind, _rng)
     }
@@ -218,7 +218,7 @@ where
         cm: &E::G1,
         proof: &Self::Proof,
     ) -> Result<(), Error> {
-        transcript.absorb_point(cm);
+        transcript.absorb_nonnative(cm);
         let challenge = transcript.get_challenge();
         Self::verify_with_challenge(params, challenge, cm, proof)
     }

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -81,7 +81,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
 
     fn prove(
         params: &Self::ProverParams,
-        transcript: &mut impl Transcript<C>,
+        transcript: &mut impl Transcript<C::ScalarField>,
         cm: &C,
         v: &[C::ScalarField],
         r: &C::ScalarField, // blinding factor
@@ -133,7 +133,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
 
     fn verify(
         params: &Self::VerifierParams,
-        transcript: &mut impl Transcript<C>,
+        transcript: &mut impl Transcript<C::ScalarField>,
         cm: &C,
         proof: &Proof<C>,
     ) -> Result<(), Error> {
@@ -217,14 +217,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
     use ark_ff::{BigInteger, PrimeField};
     use ark_pallas::{constraints::GVar, Fq, Fr, Projective};
     use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget};
     use ark_relations::r1cs::ConstraintSystem;
-    use ark_std::UniformRand;
 
     use super::*;
-    use crate::transcript::poseidon::{poseidon_canonical_config, PoseidonTranscript};
+    use crate::transcript::poseidon::poseidon_canonical_config;
 
     #[test]
     fn test_pedersen() {
@@ -240,9 +240,9 @@ mod tests {
         let poseidon_config = poseidon_canonical_config::<Fr>();
 
         // init Prover's transcript
-        let mut transcript_p = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p = PoseidonSponge::<Fr>::new(&poseidon_config);
         // init Verifier's transcript
-        let mut transcript_v = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_v = PoseidonSponge::<Fr>::new(&poseidon_config);
 
         let v: Vec<Fr> = std::iter::repeat_with(|| Fr::rand(&mut rng))
             .take(n)

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -87,7 +87,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
         r: &C::ScalarField, // blinding factor
         _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Error> {
-        transcript.absorb_point(cm)?;
+        transcript.absorb_point(cm);
         let r1 = transcript.get_challenge();
         let d = transcript.get_challenges(v.len());
 
@@ -98,7 +98,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
             R += params.h.mul(r1);
         }
 
-        transcript.absorb_point(&R)?;
+        transcript.absorb_point(&R);
         let e = transcript.get_challenge();
 
         let challenge = (r1, d, R, e);
@@ -137,10 +137,10 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
         cm: &C,
         proof: &Proof<C>,
     ) -> Result<(), Error> {
-        transcript.absorb_point(cm)?;
+        transcript.absorb_point(cm);
         transcript.get_challenge(); // r_1
         transcript.get_challenges(proof.u.len()); // d
-        transcript.absorb_point(&proof.R)?;
+        transcript.absorb_point(&proof.R);
         let e = transcript.get_challenge();
         Self::verify_with_challenge(params, e, cm, proof)
     }

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -87,7 +87,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
         r: &C::ScalarField, // blinding factor
         _rng: Option<&mut dyn RngCore>,
     ) -> Result<Self::Proof, Error> {
-        transcript.absorb_point(cm);
+        transcript.absorb_nonnative(cm);
         let r1 = transcript.get_challenge();
         let d = transcript.get_challenges(v.len());
 
@@ -98,7 +98,7 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
             R += params.h.mul(r1);
         }
 
-        transcript.absorb_point(&R);
+        transcript.absorb_nonnative(&R);
         let e = transcript.get_challenge();
 
         let challenge = (r1, d, R, e);
@@ -137,10 +137,10 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
         cm: &C,
         proof: &Proof<C>,
     ) -> Result<(), Error> {
-        transcript.absorb_point(cm);
+        transcript.absorb_nonnative(cm);
         transcript.get_challenge(); // r_1
         transcript.get_challenges(proof.u.len()); // d
-        transcript.absorb_point(&proof.R);
+        transcript.absorb_nonnative(&proof.R);
         let e = transcript.get_challenge();
         Self::verify_with_challenge(params, e, cm, proof)
     }

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -11,7 +11,7 @@ use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     boolean::Boolean,
     eq::EqGadget,
-    fields::{fp::FpVar, FieldVar},
+    fields::fp::FpVar,
     groups::GroupOpsBounds,
     prelude::CurveVar,
     ToConstraintFieldGadget,
@@ -86,21 +86,20 @@ where
         let mut cmE_elems = self.cmE.to_constraint_field()?;
         let mut cmW_elems = self.cmW.to_constraint_field()?;
 
-        let cmE_is_inf = cmE_elems.pop().unwrap();
-        let cmW_is_inf = cmW_elems.pop().unwrap();
-        // Concatenate `cmE_is_inf` and `cmW_is_inf` to save constraints for CRHGadget::evaluate
-        let is_inf = cmE_is_inf.double()? + cmW_is_inf;
+        // See `transcript/poseidon.rs: TranscriptVar::absorb_point` for details
+        // why the last element is unnecessary.
+        cmE_elems.pop();
+        cmW_elems.pop();
 
         Ok([
-            self.u.to_constraint_field()?,
+            self.u.to_native_sponge_field_elements()?,
             self.x
                 .iter()
-                .map(|i| i.to_constraint_field())
+                .map(|i| i.to_native_sponge_field_elements())
                 .collect::<Result<Vec<_>, _>>()?
                 .concat(),
             cmE_elems,
             cmW_elems,
-            vec![is_inf],
         ]
         .concat())
     }

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -1,6 +1,6 @@
 /// Contains [CycleFold](https://eprint.iacr.org/2023/1192.pdf) related circuits and functions that
 /// are shared across the different folding schemes
-use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, Absorb, CryptographicSponge};
+use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge};
 use ark_ec::{CurveGroup, Group};
 use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::{
@@ -422,7 +422,8 @@ where
 pub mod tests {
     use ark_bn254::{constraints::GVar, Fq, Fr, G1Projective as Projective};
     use ark_crypto_primitives::sponge::{
-        constraints::CryptographicSpongeVar, poseidon::constraints::PoseidonSpongeVar,
+        constraints::CryptographicSpongeVar,
+        poseidon::{constraints::PoseidonSpongeVar, PoseidonSponge},
     };
     use ark_r1cs_std::R1CSVar;
     use ark_std::UniformRand;

--- a/folding-schemes/src/folding/circuits/nonnative/affine.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/affine.rs
@@ -70,9 +70,7 @@ fn nonnative_affine_to_field_elements<C: CurveGroup>(
 }
 
 impl<C: CurveGroup> NonNativeAffineVar<C> {
-    // A wrapper of `point_to_nonnative_limbs_custom_opt` with constraints-focused optimization
-    // type (which is the default optimization type for arkworks' Groth16).
-    // Used for extracting a list of field elements of type `C::ScalarField` from the public input
+    // Extracts a list of field elements of type `C::ScalarField` from the public input
     // `p`, in exactly the same way as how `NonNativeAffineVar` is represented as limbs of type
     // `FpVar` in-circuit.
     #[allow(clippy::type_complexity)]

--- a/folding-schemes/src/folding/circuits/nonnative/affine.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/affine.rs
@@ -57,14 +57,14 @@ impl<C: CurveGroup> ToConstraintFieldGadget<C::ScalarField> for NonNativeAffineV
 #[allow(clippy::type_complexity)]
 pub fn nonnative_affine_to_field_elements<C: CurveGroup>(
     p: C,
-) -> Result<(Vec<C::ScalarField>, Vec<C::ScalarField>), SynthesisError> {
+) -> (Vec<C::ScalarField>, Vec<C::ScalarField>) {
     let affine = p.into_affine();
     let zero = (&C::BaseField::zero(), &C::BaseField::zero());
     let (x, y) = affine.xy().unwrap_or(zero);
 
     let x = nonnative_field_to_field_elements(x);
     let y = nonnative_field_to_field_elements(y);
-    Ok((x, y))
+    (x, y)
 }
 
 impl<C: CurveGroup> NonNativeAffineVar<C> {
@@ -110,7 +110,7 @@ mod tests {
         let mut rng = ark_std::test_rng();
         let p = Projective::rand(&mut rng);
         let pVar = NonNativeAffineVar::<Projective>::new_witness(cs.clone(), || Ok(p)).unwrap();
-        let (x, y) = nonnative_affine_to_field_elements(p).unwrap();
+        let (x, y) = nonnative_affine_to_field_elements(p);
         assert_eq!(
             pVar.to_constraint_field().unwrap().value().unwrap(),
             [x, y].concat()

--- a/folding-schemes/src/folding/circuits/sum_check.rs
+++ b/folding-schemes/src/folding/circuits/sum_check.rs
@@ -3,8 +3,7 @@
 /// - Typings to better stick to ark_poly's API
 /// - Uses `folding-schemes`' own `TranscriptVar` trait and `PoseidonTranscriptVar` struct
 /// - API made closer to gadgets found in `folding-schemes`
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::{CurveGroup, Group};
+use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, Absorb, CryptographicSponge};
 use ark_ff::PrimeField;
 use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial};
 use ark_r1cs_std::{
@@ -19,7 +18,7 @@ use std::{borrow::Borrow, marker::PhantomData};
 use crate::utils::espresso::sum_check::SumCheck;
 use crate::utils::virtual_polynomial::VPAuxInfo;
 use crate::{
-    transcript::{poseidon::PoseidonTranscript, TranscriptVar},
+    transcript::TranscriptVar,
     utils::sum_check::{structs::IOPProof, IOPSumCheck},
 };
 
@@ -82,35 +81,27 @@ impl<F: PrimeField> DensePolynomialVar<F> {
 }
 
 #[derive(Clone, Debug)]
-pub struct IOPProofVar<C: CurveGroup> {
+pub struct IOPProofVar<F: PrimeField> {
     // We have to be generic over a CurveGroup because instantiating a IOPProofVar will call IOPSumCheck which requires a CurveGroup
-    pub proofs: Vec<DensePolynomialVar<C::ScalarField>>, // = IOPProof.proofs
-    pub claim: FpVar<C::ScalarField>,
+    pub proofs: Vec<DensePolynomialVar<F>>,
+    pub claim: FpVar<F>,
 }
 
-impl<C: CurveGroup> AllocVar<IOPProof<C::ScalarField>, C::ScalarField> for IOPProofVar<C>
-where
-    <C as Group>::ScalarField: Absorb,
-{
-    fn new_variable<T: Borrow<IOPProof<C::ScalarField>>>(
-        cs: impl Into<Namespace<C::ScalarField>>,
+impl<F: PrimeField + Absorb> AllocVar<IOPProof<F>, F> for IOPProofVar<F> {
+    fn new_variable<T: Borrow<IOPProof<F>>>(
+        cs: impl Into<Namespace<F>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
         mode: AllocationMode,
     ) -> Result<Self, SynthesisError> {
         f().and_then(|c| {
             let cs = cs.into();
-            let cp: &IOPProof<C::ScalarField> = c.borrow();
-            let claim = IOPSumCheck::<C, PoseidonTranscript<C>>::extract_sum(cp);
-            let claim = FpVar::<C::ScalarField>::new_variable(cs.clone(), || Ok(claim), mode)?;
-            let mut proofs =
-                Vec::<DensePolynomialVar<C::ScalarField>>::with_capacity(cp.proofs.len());
+            let cp: &IOPProof<F> = c.borrow();
+            let claim = IOPSumCheck::<F, PoseidonSponge<F>>::extract_sum(cp);
+            let claim = FpVar::<F>::new_variable(cs.clone(), || Ok(claim), mode)?;
+            let mut proofs = Vec::<DensePolynomialVar<F>>::with_capacity(cp.proofs.len());
             for proof in cp.proofs.iter() {
                 let poly = DensePolynomial::from_coefficients_slice(&proof.coeffs);
-                let proof = DensePolynomialVar::<C::ScalarField>::new_variable(
-                    cs.clone(),
-                    || Ok(poly),
-                    mode,
-                )?;
+                let proof = DensePolynomialVar::<F>::new_variable(cs.clone(), || Ok(poly), mode)?;
                 proofs.push(proof);
             }
             Ok(Self { proofs, claim })
@@ -149,20 +140,20 @@ impl<F: PrimeField> AllocVar<VPAuxInfo<F>, F> for VPAuxInfoVar<F> {
 }
 
 #[derive(Debug, Clone)]
-pub struct SumCheckVerifierGadget<C: CurveGroup> {
-    _f: PhantomData<C>,
+pub struct SumCheckVerifierGadget<F: PrimeField> {
+    _f: PhantomData<F>,
 }
 
-impl<C: CurveGroup> SumCheckVerifierGadget<C> {
+impl<F: PrimeField> SumCheckVerifierGadget<F> {
     #[allow(clippy::type_complexity)]
-    pub fn verify(
-        iop_proof_var: &IOPProofVar<C>,
-        poly_aux_info_var: &VPAuxInfoVar<C::ScalarField>,
-        transcript_var: &mut impl TranscriptVar<C::ScalarField>,
-        enabled: Boolean<C::ScalarField>,
-    ) -> Result<(Vec<FpVar<C::ScalarField>>, Vec<FpVar<C::ScalarField>>), SynthesisError> {
+    pub fn verify<S: CryptographicSponge, T: TranscriptVar<F, S>>(
+        iop_proof_var: &IOPProofVar<F>,
+        poly_aux_info_var: &VPAuxInfoVar<F>,
+        transcript_var: &mut T,
+        enabled: Boolean<F>,
+    ) -> Result<(Vec<FpVar<F>>, Vec<FpVar<F>>), SynthesisError> {
         let mut e_vars = vec![iop_proof_var.claim.clone()];
-        let mut r_vars: Vec<FpVar<C::ScalarField>> = Vec::new();
+        let mut r_vars: Vec<FpVar<F>> = Vec::new();
         transcript_var.absorb(&poly_aux_info_var.num_variables)?;
         transcript_var.absorb(&poly_aux_info_var.max_degree)?;
 
@@ -170,7 +161,7 @@ impl<C: CurveGroup> SumCheckVerifierGadget<C> {
             let res = poly_var.eval_at_one() + poly_var.eval_at_zero();
             let e_var = e_vars.last().ok_or(SynthesisError::Unsatisfiable)?;
             res.conditional_enforce_equal(e_var, &enabled)?;
-            transcript_var.absorb_vec(&poly_var.coeffs)?;
+            transcript_var.absorb(&poly_var.coeffs)?;
             let r_i_var = transcript_var.get_challenge()?;
             e_vars.push(poly_var.evaluate(&r_i_var));
             r_vars.push(r_i_var);
@@ -182,49 +173,35 @@ impl<C: CurveGroup> SumCheckVerifierGadget<C> {
 
 #[cfg(test)]
 mod tests {
-    use ark_crypto_primitives::sponge::{poseidon::PoseidonConfig, Absorb};
-    use ark_ec::CurveGroup;
-    use ark_ff::Field;
-    use ark_pallas::{Fr, Projective};
-    use ark_poly::{
-        univariate::DensePolynomial, DenseMultilinearExtension, DenseUVPolynomial,
-        MultilinearExtension, Polynomial,
+    use ark_crypto_primitives::sponge::{
+        constraints::CryptographicSpongeVar,
+        poseidon::{constraints::PoseidonSpongeVar, PoseidonConfig},
     };
-    use ark_r1cs_std::{alloc::AllocVar, R1CSVar};
+    use ark_pallas::Fr;
+    use ark_poly::{DenseMultilinearExtension, MultilinearExtension, Polynomial};
+    use ark_r1cs_std::R1CSVar;
     use ark_relations::r1cs::ConstraintSystem;
     use std::sync::Arc;
 
     use super::*;
     use crate::{
-        folding::circuits::sum_check::{IOPProofVar, VPAuxInfoVar},
-        transcript::{
-            poseidon::{poseidon_canonical_config, PoseidonTranscript, PoseidonTranscriptVar},
-            Transcript, TranscriptVar,
-        },
-        utils::{
-            sum_check::{structs::IOPProof, IOPSumCheck, SumCheck},
-            virtual_polynomial::VirtualPolynomial,
-        },
+        transcript::poseidon::poseidon_canonical_config,
+        utils::virtual_polynomial::VirtualPolynomial,
     };
 
     pub type TestSumCheckProof<F> = (VirtualPolynomial<F>, PoseidonConfig<F>, IOPProof<F>);
 
     /// Primarily used for testing the sumcheck gadget
     /// Returns a random virtual polynomial, the poseidon config used and the associated sumcheck proof
-    pub fn get_test_sumcheck_proof<C: CurveGroup>(
+    pub fn get_test_sumcheck_proof<F: PrimeField + Absorb>(
         num_vars: usize,
-    ) -> TestSumCheckProof<C::ScalarField>
-    where
-        <C as ark_ec::Group>::ScalarField: Absorb,
-    {
+    ) -> TestSumCheckProof<F> {
         let mut rng = ark_std::test_rng();
-        let poseidon_config: PoseidonConfig<C::ScalarField> =
-            poseidon_canonical_config::<C::ScalarField>();
-        let mut poseidon_transcript_prove = PoseidonTranscript::<C>::new(&poseidon_config);
+        let poseidon_config: PoseidonConfig<F> = poseidon_canonical_config::<F>();
+        let mut poseidon_transcript_prove = PoseidonSponge::<F>::new(&poseidon_config);
         let poly_mle = DenseMultilinearExtension::rand(num_vars, &mut rng);
-        let virtual_poly =
-            VirtualPolynomial::new_from_mle(&Arc::new(poly_mle), C::ScalarField::ONE);
-        let sum_check: IOPProof<C::ScalarField> = IOPSumCheck::<C, PoseidonTranscript<C>>::prove(
+        let virtual_poly = VirtualPolynomial::new_from_mle(&Arc::new(poly_mle), F::ONE);
+        let sum_check: IOPProof<F> = IOPSumCheck::<F, PoseidonSponge<F>>::prove(
             &virtual_poly,
             &mut poseidon_transcript_prove,
         )
@@ -237,15 +214,15 @@ mod tests {
         for num_vars in 1..15 {
             let cs = ConstraintSystem::<Fr>::new_ref();
             let (virtual_poly, poseidon_config, sum_check) =
-                get_test_sumcheck_proof::<Projective>(num_vars);
-            let mut poseidon_var: PoseidonTranscriptVar<Fr> =
-                PoseidonTranscriptVar::new(cs.clone(), &poseidon_config);
+                get_test_sumcheck_proof::<Fr>(num_vars);
+            let mut poseidon_var: PoseidonSpongeVar<Fr> =
+                PoseidonSpongeVar::new(cs.clone(), &poseidon_config);
             let iop_proof_var =
-                IOPProofVar::<Projective>::new_witness(cs.clone(), || Ok(&sum_check)).unwrap();
+                IOPProofVar::<Fr>::new_witness(cs.clone(), || Ok(&sum_check)).unwrap();
             let poly_aux_info_var =
                 VPAuxInfoVar::<Fr>::new_witness(cs.clone(), || Ok(virtual_poly.aux_info)).unwrap();
             let enabled = Boolean::<Fr>::new_witness(cs.clone(), || Ok(true)).unwrap();
-            let res = SumCheckVerifierGadget::<Projective>::verify(
+            let res = SumCheckVerifierGadget::<Fr>::verify(
                 &iop_proof_var,
                 &poly_aux_info_var,
                 &mut poseidon_var,
@@ -256,8 +233,7 @@ mod tests {
             let (circuit_evals, r_challenges) = res.unwrap();
 
             // 1. assert claim from circuit is equal to the one from the sum-check
-            let claim: Fr =
-                IOPSumCheck::<Projective, PoseidonTranscript<Projective>>::extract_sum(&sum_check);
+            let claim: Fr = IOPSumCheck::<Fr, PoseidonSponge<Fr>>::extract_sum(&sum_check);
             assert_eq!(circuit_evals[0].value().unwrap(), claim);
 
             // 2. assert that all in-circuit evaluations are equal to the ones from the sum-check

--- a/folding-schemes/src/folding/circuits/sum_check.rs
+++ b/folding-schemes/src/folding/circuits/sum_check.rs
@@ -163,8 +163,8 @@ impl<C: CurveGroup> SumCheckVerifierGadget<C> {
     ) -> Result<(Vec<FpVar<C::ScalarField>>, Vec<FpVar<C::ScalarField>>), SynthesisError> {
         let mut e_vars = vec![iop_proof_var.claim.clone()];
         let mut r_vars: Vec<FpVar<C::ScalarField>> = Vec::new();
-        transcript_var.absorb(poly_aux_info_var.num_variables.clone())?;
-        transcript_var.absorb(poly_aux_info_var.max_degree.clone())?;
+        transcript_var.absorb(&poly_aux_info_var.num_variables)?;
+        transcript_var.absorb(&poly_aux_info_var.max_degree)?;
 
         for poly_var in iop_proof_var.proofs.iter() {
             let res = poly_var.eval_at_one() + poly_var.eval_at_zero();

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -9,10 +9,7 @@ use ark_std::rand::Rng;
 
 use super::Witness;
 use crate::arith::{ccs::CCS, Arith};
-use crate::commitment::{
-    pedersen::{Params as PedersenParams, Pedersen},
-    CommitmentScheme,
-};
+use crate::commitment::CommitmentScheme;
 use crate::transcript::AbsorbNonNative;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -120,7 +120,10 @@ impl<C: CurveGroup> CCCS<C> {
     }
 }
 
-impl<C: CurveGroup<ScalarField: Absorb>> Absorb for CCCS<C> {
+impl<C: CurveGroup> Absorb for CCCS<C>
+where
+    C::ScalarField: Absorb,
+{
     fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
         // This is never called
         unimplemented!()

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -255,13 +255,13 @@ where
         let gamma_scalar_raw = C::ScalarField::from_le_bytes_mod_order(b"gamma");
         let gamma_scalar: FpVar<CF1<C>> =
             FpVar::<CF1<C>>::new_constant(cs.clone(), gamma_scalar_raw)?;
-        transcript.absorb(gamma_scalar)?;
+        transcript.absorb(&gamma_scalar)?;
         let gamma: FpVar<CF1<C>> = transcript.get_challenge()?;
 
         let beta_scalar_raw = C::ScalarField::from_le_bytes_mod_order(b"beta");
         let beta_scalar: FpVar<CF1<C>> =
             FpVar::<CF1<C>>::new_constant(cs.clone(), beta_scalar_raw)?;
-        transcript.absorb(beta_scalar)?;
+        transcript.absorb(&beta_scalar)?;
         let beta: Vec<FpVar<CF1<C>>> = transcript.get_challenges(ccs.s)?;
 
         let vp_aux_info_raw = VPAuxInfo::<C::ScalarField> {
@@ -312,7 +312,7 @@ where
         // get the folding challenge
         let rho_scalar_raw = C::ScalarField::from_le_bytes_mod_order(b"rho");
         let rho_scalar: FpVar<CF1<C>> = FpVar::<CF1<C>>::new_constant(cs.clone(), rho_scalar_raw)?;
-        transcript.absorb(rho_scalar)?;
+        transcript.absorb(&rho_scalar)?;
         let rho_bits: Vec<Boolean<CF1<C>>> = transcript.get_challenge_nbits(N_BITS_RO)?;
         let rho = Boolean::le_bits_to_fp_var(&rho_bits)?;
 

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -8,10 +8,7 @@ use ark_std::Zero;
 
 use super::Witness;
 use crate::arith::ccs::CCS;
-use crate::commitment::{
-    pedersen::{Params as PedersenParams, Pedersen},
-    CommitmentScheme,
-};
+use crate::commitment::CommitmentScheme;
 use crate::transcript::{AbsorbNonNative, Transcript};
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -1,7 +1,4 @@
-use ark_crypto_primitives::sponge::{
-    poseidon::{PoseidonConfig, PoseidonSponge},
-    Absorb, CryptographicSponge,
-};
+use ark_crypto_primitives::sponge::Absorb;
 use ark_ec::{CurveGroup, Group};
 use ark_ff::PrimeField;
 use ark_poly::DenseMultilinearExtension;
@@ -15,7 +12,7 @@ use crate::commitment::{
     pedersen::{Params as PedersenParams, Pedersen},
     CommitmentScheme,
 };
-use crate::transcript::AbsorbNonNative;
+use crate::transcript::{AbsorbNonNative, Transcript};
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
 use crate::Error;
@@ -149,15 +146,15 @@ where
     /// [`LCCCS`].hash implements the committed instance hash compatible with the gadget
     /// implemented in nova/circuits.rs::CommittedInstanceVar.hash.
     /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and `U_i` is the LCCCS.
-    pub fn hash(
+    pub fn hash<T: Transcript<C::ScalarField>>(
         &self,
-        poseidon_config: &PoseidonConfig<C::ScalarField>,
+        sponge: &T,
         pp_hash: C::ScalarField,
         i: C::ScalarField,
         z_0: Vec<C::ScalarField>,
         z_i: Vec<C::ScalarField>,
     ) -> C::ScalarField {
-        let mut sponge = PoseidonSponge::new(poseidon_config);
+        let mut sponge = sponge.clone();
         sponge.absorb(&pp_hash);
         sponge.absorb(&i);
         sponge.absorb(&z_0);
@@ -173,7 +170,6 @@ pub mod tests {
     use ark_std::test_rng;
     use ark_std::One;
     use ark_std::UniformRand;
-    use ark_std::Zero;
     use std::sync::Arc;
 
     use super::*;

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -134,7 +134,7 @@ where
         z_0: Vec<C::ScalarField>,
         z_i: Vec<C::ScalarField>,
     ) -> Result<C::ScalarField, Error> {
-        let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(self.C)?;
+        let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(self.C);
 
         CRH::<C::ScalarField>::evaluate(
             poseidon_config,

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -115,7 +115,10 @@ impl<C: CurveGroup> LCCCS<C> {
     }
 }
 
-impl<C: CurveGroup<ScalarField: Absorb>> Absorb for LCCCS<C> {
+impl<C: CurveGroup> Absorb for LCCCS<C>
+where
+    C::ScalarField: Absorb,
+{
     fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
         // This is never called
         unimplemented!()

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -263,8 +263,8 @@ where
                 C1::ScalarField::zero(),
                 z_0.clone(),
                 z_0.clone(),
-            )?,
-            cf_U_dummy.hash_cyclefold(&pp.poseidon_config, pp_hash)?,
+            ),
+            cf_U_dummy.hash_cyclefold(&pp.poseidon_config, pp_hash),
         ];
 
         // W_dummy=W_0 is a 'dummy witness', all zeroes, but with the size corresponding to the
@@ -344,13 +344,13 @@ where
                 C1::ScalarField::one(),
                 self.z_0.clone(),
                 z_i1.clone(),
-            )?;
+            );
 
             // hash the initial (dummy) CycleFold instance, which is used as the 2nd public
             // input in the AugmentedFCircuit
             cf_u_i1_x = self
                 .cf_U_i
-                .hash_cyclefold(&self.poseidon_config, self.pp_hash)?;
+                .hash_cyclefold(&self.poseidon_config, self.pp_hash);
 
             augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
                 _c2: PhantomData,
@@ -401,7 +401,7 @@ where
                 self.i + C1::ScalarField::one(),
                 self.z_0.clone(),
                 z_i1.clone(),
-            )?;
+            );
 
             let rho_Fq = C2::ScalarField::from_bigint(BigInteger::from_bits_le(&rho_bits))
                 .ok_or(Error::OutOfBounds)?;
@@ -436,7 +436,7 @@ where
                     cf_circuit,
                 )?;
 
-            cf_u_i1_x = cf_U_i1.hash_cyclefold(&self.poseidon_config, self.pp_hash)?;
+            cf_u_i1_x = cf_U_i1.hash_cyclefold(&self.poseidon_config, self.pp_hash);
 
             augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
                 _c2: PhantomData,
@@ -554,12 +554,12 @@ where
 
         // check that u_i's output points to the running instance
         // u_i.X[0] == H(i, z_0, z_i, U_i)
-        let expected_u_i_x = U_i.hash(&vp.poseidon_config, pp_hash, num_steps, z_0, z_i.clone())?;
+        let expected_u_i_x = U_i.hash(&vp.poseidon_config, pp_hash, num_steps, z_0, z_i.clone());
         if expected_u_i_x != u_i.x[0] {
             return Err(Error::IVCVerificationFail);
         }
         // u_i.X[1] == H(cf_U_i)
-        let expected_cf_u_i_x = cf_U_i.hash_cyclefold(&vp.poseidon_config, pp_hash)?;
+        let expected_cf_u_i_x = cf_U_i.hash_cyclefold(&vp.poseidon_config, pp_hash);
         if expected_cf_u_i_x != u_i.x[1] {
             return Err(Error::IVCVerificationFail);
         }

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -233,6 +233,8 @@ where
         z_0: Vec<C1::ScalarField>,
     ) -> Result<Self, Error> {
         let (pp, vp) = params;
+        // `sponge` is for digest computation.
+        let sponge = PoseidonSponge::<C1::ScalarField>::new(&pp.poseidon_config);
 
         // prepare the HyperNova's AugmentedFCircuit and CycleFold's circuits and obtain its CCS
         // and R1CS respectively
@@ -264,7 +266,7 @@ where
                 z_0.clone(),
                 z_0.clone(),
             ),
-            cf_U_dummy.hash_cyclefold(&pp.poseidon_config, pp_hash),
+            cf_U_dummy.hash_cyclefold(&sponge, pp_hash),
         ];
 
         // W_dummy=W_0 is a 'dummy witness', all zeroes, but with the size corresponding to the
@@ -299,6 +301,9 @@ where
         mut rng: impl RngCore,
         external_inputs: Vec<C1::ScalarField>,
     ) -> Result<(), Error> {
+        // `sponge` is for digest computation.
+        let sponge = PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
+
         let augmented_f_circuit: AugmentedFCircuit<C1, C2, GC2, FC>;
 
         if self.z_i.len() != self.F.state_len() {
@@ -348,9 +353,7 @@ where
 
             // hash the initial (dummy) CycleFold instance, which is used as the 2nd public
             // input in the AugmentedFCircuit
-            cf_u_i1_x = self
-                .cf_U_i
-                .hash_cyclefold(&self.poseidon_config, self.pp_hash);
+            cf_u_i1_x = self.cf_U_i.hash_cyclefold(&sponge, self.pp_hash);
 
             augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
                 _c2: PhantomData,
@@ -426,7 +429,7 @@ where
 
             let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
                 fold_cyclefold_circuit::<C1, GC1, C2, GC2, FC, CS1, CS2>(
-                    &self.poseidon_config,
+                    &mut transcript_p,
                     self.cf_r1cs.clone(),
                     self.cf_cs_params.clone(),
                     self.pp_hash,
@@ -436,7 +439,7 @@ where
                     cf_circuit,
                 )?;
 
-            cf_u_i1_x = cf_U_i1.hash_cyclefold(&self.poseidon_config, self.pp_hash);
+            cf_u_i1_x = cf_U_i1.hash_cyclefold(&sponge, self.pp_hash);
 
             augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
                 _c2: PhantomData,
@@ -542,6 +545,8 @@ where
             }
             return Ok(());
         }
+        // `sponge` is for digest computation.
+        let sponge = PoseidonSponge::<C1::ScalarField>::new(&vp.poseidon_config);
 
         let (U_i, W_i) = running_instance;
         let (u_i, w_i) = incoming_instance;
@@ -559,7 +564,7 @@ where
             return Err(Error::IVCVerificationFail);
         }
         // u_i.X[1] == H(cf_U_i)
-        let expected_cf_u_i_x = cf_U_i.hash_cyclefold(&vp.poseidon_config, pp_hash);
+        let expected_cf_u_i_x = cf_U_i.hash_cyclefold(&sponge, pp_hash);
         if expected_cf_u_i_x != u_i.x[1] {
             return Err(Error::IVCVerificationFail);
         }

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -260,7 +260,7 @@ where
             cf_r1cs.dummy_instance();
         u_dummy.x = vec![
             U_dummy.hash(
-                &pp.poseidon_config,
+                &sponge,
                 pp_hash,
                 C1::ScalarField::zero(),
                 z_0.clone(),
@@ -344,7 +344,7 @@ where
             U_i1 = LCCCS::dummy(self.ccs.l, self.ccs.t, self.ccs.s);
 
             let u_i1_x = U_i1.hash(
-                &self.poseidon_config,
+                &sponge,
                 self.pp_hash,
                 C1::ScalarField::one(),
                 self.z_0.clone(),
@@ -399,7 +399,7 @@ where
             U_i1.check_relation(&self.ccs, &W_i1)?;
 
             let u_i1_x = U_i1.hash(
-                &self.poseidon_config,
+                &sponge,
                 self.pp_hash,
                 self.i + C1::ScalarField::one(),
                 self.z_0.clone(),
@@ -559,7 +559,7 @@ where
 
         // check that u_i's output points to the running instance
         // u_i.X[0] == H(i, z_0, z_i, U_i)
-        let expected_u_i_x = U_i.hash(&vp.poseidon_config, pp_hash, num_steps, z_0, z_i.clone());
+        let expected_u_i_x = U_i.hash(&sponge, pp_hash, num_steps, z_0, z_i.clone());
         if expected_u_i_x != u_i.x[0] {
             return Err(Error::IVCVerificationFail);
         }

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -13,7 +13,6 @@ use super::{
 };
 use crate::arith::ccs::CCS;
 use crate::constants::N_BITS_RO;
-use crate::folding::circuits::nonnative::affine::nonnative_affine_to_field_elements;
 use crate::transcript::Transcript;
 use crate::utils::sum_check::structs::{IOPProof as SumCheckProof, IOPProverMessage};
 use crate::utils::sum_check::{IOPSumCheck, SumCheck};
@@ -186,24 +185,8 @@ where
         w_cccs: &[Witness<C::ScalarField>],
     ) -> Result<(NIMFSProof<C>, LCCCS<C>, Witness<C::ScalarField>, Vec<bool>), Error> {
         // absorb instances to transcript
-        for U_i in running_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(U_i.C);
-            let v = [
-                C_x,
-                C_y,
-                vec![U_i.u],
-                U_i.x.clone(),
-                U_i.r_x.clone(),
-                U_i.v.clone(),
-            ]
-            .concat();
-            transcript.absorb(&v);
-        }
-        for u_i in new_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C);
-            let v = [C_x, C_y, u_i.x.clone()].concat();
-            transcript.absorb(&v);
-        }
+        transcript.absorb(&running_instances);
+        transcript.absorb(&new_instances);
 
         if running_instances.is_empty() {
             return Err(Error::Empty);
@@ -297,24 +280,8 @@ where
         proof: NIMFSProof<C>,
     ) -> Result<LCCCS<C>, Error> {
         // absorb instances to transcript
-        for U_i in running_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(U_i.C);
-            let v = [
-                C_x,
-                C_y,
-                vec![U_i.u],
-                U_i.x.clone(),
-                U_i.r_x.clone(),
-                U_i.v.clone(),
-            ]
-            .concat();
-            transcript.absorb(&v);
-        }
-        for u_i in new_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C);
-            let v = [C_x, C_y, u_i.x.clone()].concat();
-            transcript.absorb(&v);
-        }
+        transcript.absorb(&running_instances);
+        transcript.absorb(&new_instances);
 
         if running_instances.is_empty() {
             return Err(Error::Empty);

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -187,7 +187,7 @@ where
     ) -> Result<(NIMFSProof<C>, LCCCS<C>, Witness<C::ScalarField>, Vec<bool>), Error> {
         // absorb instances to transcript
         for U_i in running_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(U_i.C)?;
+            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(U_i.C);
             let v = [
                 C_x,
                 C_y,
@@ -200,7 +200,7 @@ where
             transcript.absorb(&v);
         }
         for u_i in new_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C)?;
+            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C);
             let v = [C_x, C_y, u_i.x.clone()].concat();
             transcript.absorb(&v);
         }
@@ -298,7 +298,7 @@ where
     ) -> Result<LCCCS<C>, Error> {
         // absorb instances to transcript
         for U_i in running_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(U_i.C)?;
+            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(U_i.C);
             let v = [
                 C_x,
                 C_y,
@@ -311,7 +311,7 @@ where
             transcript.absorb(&v);
         }
         for u_i in new_instances {
-            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C)?;
+            let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C);
             let v = [C_x, C_y, u_i.x.clone()].concat();
             transcript.absorb(&v);
         }

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -58,12 +58,12 @@ pub struct SigmasThetas<F: PrimeField>(pub Vec<Vec<F>>, pub Vec<Vec<F>>);
 #[derive(Debug)]
 /// Implements the Non-Interactive Multi Folding Scheme described in section 5 of
 /// [HyperNova](https://eprint.iacr.org/2023/573.pdf)
-pub struct NIMFS<C: CurveGroup, T: Transcript<C>> {
+pub struct NIMFS<C: CurveGroup, T: Transcript<C::ScalarField>> {
     pub _c: PhantomData<C>,
     pub _t: PhantomData<T>,
 }
 
-impl<C: CurveGroup, T: Transcript<C>> NIMFS<C, T>
+impl<C: CurveGroup, T: Transcript<C::ScalarField>> NIMFS<C, T>
 where
     <C as Group>::ScalarField: Absorb,
     C::BaseField: PrimeField,
@@ -178,7 +178,7 @@ where
     /// contains the sumcheck proof and the helper sumcheck claim sigmas and thetas.
     #[allow(clippy::type_complexity)]
     pub fn prove(
-        transcript: &mut impl Transcript<C>,
+        transcript: &mut impl Transcript<C::ScalarField>,
         ccs: &CCS<C::ScalarField>,
         running_instances: &[LCCCS<C>],
         new_instances: &[CCCS<C>],
@@ -197,12 +197,12 @@ where
                 U_i.v.clone(),
             ]
             .concat();
-            transcript.absorb_vec(&v);
+            transcript.absorb(&v);
         }
         for u_i in new_instances {
             let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C)?;
             let v = [C_x, C_y, u_i.x.clone()].concat();
-            transcript.absorb_vec(&v);
+            transcript.absorb(&v);
         }
 
         if running_instances.is_empty() {
@@ -247,7 +247,7 @@ where
         let g = compute_g(ccs, running_instances, &z_lcccs, &z_cccs, gamma, &beta)?;
 
         // Step 3: Run the sumcheck prover
-        let sumcheck_proof = IOPSumCheck::<C, T>::prove(&g, transcript)
+        let sumcheck_proof = IOPSumCheck::<C::ScalarField, T>::prove(&g, transcript)
             .map_err(|err| Error::SumCheckProveError(err.to_string()))?;
 
         // Step 2: dig into the sumcheck and extract r_x_prime
@@ -290,7 +290,7 @@ where
     /// into a single LCCCS instance.
     /// Returns the folded LCCCS instance.
     pub fn verify(
-        transcript: &mut impl Transcript<C>,
+        transcript: &mut impl Transcript<C::ScalarField>,
         ccs: &CCS<C::ScalarField>,
         running_instances: &[LCCCS<C>],
         new_instances: &[CCCS<C>],
@@ -308,12 +308,12 @@ where
                 U_i.v.clone(),
             ]
             .concat();
-            transcript.absorb_vec(&v);
+            transcript.absorb(&v);
         }
         for u_i in new_instances {
             let (C_x, C_y) = nonnative_affine_to_field_elements::<C>(u_i.C)?;
             let v = [C_x, C_y, u_i.x.clone()].concat();
-            transcript.absorb_vec(&v);
+            transcript.absorb(&v);
         }
 
         if running_instances.is_empty() {
@@ -349,9 +349,13 @@ where
         }
 
         // Verify the interactive part of the sumcheck
-        let sumcheck_subclaim =
-            IOPSumCheck::<C, T>::verify(sum_v_j_gamma, &proof.sc_proof, &vp_aux_info, transcript)
-                .map_err(|err| Error::SumCheckVerifyError(err.to_string()))?;
+        let sumcheck_subclaim = IOPSumCheck::<C::ScalarField, T>::verify(
+            sum_v_j_gamma,
+            &proof.sc_proof,
+            &vp_aux_info,
+            transcript,
+        )
+        .map_err(|err| Error::SumCheckVerifyError(err.to_string()))?;
 
         // Step 2: Dig into the sumcheck claim and extract the randomness used
         let r_x_prime = sumcheck_subclaim.point.clone();
@@ -413,7 +417,8 @@ pub mod tests {
         Arith,
     };
     use crate::transcript::poseidon::poseidon_canonical_config;
-    use crate::transcript::poseidon::PoseidonTranscript;
+    use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
+    use ark_crypto_primitives::sponge::CryptographicSponge;
     use ark_std::test_rng;
     use ark_std::UniformRand;
 
@@ -450,7 +455,7 @@ pub mod tests {
         let mut rng = test_rng();
         let rho = Fr::rand(&mut rng);
 
-        let folded = NIMFS::<Projective, PoseidonTranscript<Projective>>::fold(
+        let folded = NIMFS::<Projective, PoseidonSponge<Fr>>::fold(
             &[lcccs],
             &[cccs],
             &sigmas_thetas,
@@ -458,8 +463,7 @@ pub mod tests {
             rho,
         );
 
-        let w_folded =
-            NIMFS::<Projective, PoseidonTranscript<Projective>>::fold_witness(&[w1], &[w2], rho);
+        let w_folded = NIMFS::<Projective, PoseidonSponge<Fr>>::fold_witness(&[w1], &[w2], rho);
 
         // check lcccs relation
         folded.check_relation(&ccs, &w_folded).unwrap();
@@ -491,13 +495,12 @@ pub mod tests {
 
         // Prover's transcript
         let poseidon_config = poseidon_canonical_config::<Fr>();
-        let mut transcript_p: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_p.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         // Run the prover side of the multifolding
         let (proof, folded_lcccs, folded_witness, _) =
-            NIMFS::<Projective, PoseidonTranscript<Projective>>::prove(
+            NIMFS::<Projective, PoseidonSponge<Fr>>::prove(
                 &mut transcript_p,
                 &ccs,
                 &[running_instance.clone()],
@@ -508,12 +511,11 @@ pub mod tests {
             .unwrap();
 
         // Verifier's transcript
-        let mut transcript_v: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_v: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_v.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         // Run the verifier side of the multifolding
-        let folded_lcccs_v = NIMFS::<Projective, PoseidonTranscript<Projective>>::verify(
+        let folded_lcccs_v = NIMFS::<Projective, PoseidonSponge<Fr>>::verify(
             &mut transcript_v,
             &ccs,
             &[running_instance.clone()],
@@ -545,12 +547,10 @@ pub mod tests {
 
         let poseidon_config = poseidon_canonical_config::<Fr>();
 
-        let mut transcript_p: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_p.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
-        let mut transcript_v: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_v: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_v.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         let n: usize = 10;
@@ -564,7 +564,7 @@ pub mod tests {
 
             // run the prover side of the multifolding
             let (proof, folded_lcccs, folded_witness, _) =
-                NIMFS::<Projective, PoseidonTranscript<Projective>>::prove(
+                NIMFS::<Projective, PoseidonSponge<Fr>>::prove(
                     &mut transcript_p,
                     &ccs,
                     &[running_instance.clone()],
@@ -575,7 +575,7 @@ pub mod tests {
                 .unwrap();
 
             // run the verifier side of the multifolding
-            let folded_lcccs_v = NIMFS::<Projective, PoseidonTranscript<Projective>>::verify(
+            let folded_lcccs_v = NIMFS::<Projective, PoseidonSponge<Fr>>::verify(
                 &mut transcript_v,
                 &ccs,
                 &[running_instance.clone()],
@@ -641,13 +641,12 @@ pub mod tests {
 
         // Prover's transcript
         let poseidon_config = poseidon_canonical_config::<Fr>();
-        let mut transcript_p: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_p.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         // Run the prover side of the multifolding
         let (proof, folded_lcccs, folded_witness, _) =
-            NIMFS::<Projective, PoseidonTranscript<Projective>>::prove(
+            NIMFS::<Projective, PoseidonSponge<Fr>>::prove(
                 &mut transcript_p,
                 &ccs,
                 &lcccs_instances,
@@ -658,12 +657,11 @@ pub mod tests {
             .unwrap();
 
         // Verifier's transcript
-        let mut transcript_v: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_v: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_v.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         // Run the verifier side of the multifolding
-        let folded_lcccs_v = NIMFS::<Projective, PoseidonTranscript<Projective>>::verify(
+        let folded_lcccs_v = NIMFS::<Projective, PoseidonSponge<Fr>>::verify(
             &mut transcript_v,
             &ccs,
             &lcccs_instances,
@@ -690,13 +688,11 @@ pub mod tests {
 
         let poseidon_config = poseidon_canonical_config::<Fr>();
         // Prover's transcript
-        let mut transcript_p: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_p.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         // Verifier's transcript
-        let mut transcript_v: PoseidonTranscript<Projective> =
-            PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_v: PoseidonSponge<Fr> = PoseidonSponge::<Fr>::new(&poseidon_config);
         transcript_v.absorb(&Fr::from_le_bytes_mod_order(b"init init"));
 
         let n_steps = 3;
@@ -741,7 +737,7 @@ pub mod tests {
 
             // Run the prover side of the multifolding
             let (proof, folded_lcccs, folded_witness, _) =
-                NIMFS::<Projective, PoseidonTranscript<Projective>>::prove(
+                NIMFS::<Projective, PoseidonSponge<Fr>>::prove(
                     &mut transcript_p,
                     &ccs,
                     &lcccs_instances,
@@ -752,7 +748,7 @@ pub mod tests {
                 .unwrap();
 
             // Run the verifier side of the multifolding
-            let folded_lcccs_v = NIMFS::<Projective, PoseidonTranscript<Projective>>::verify(
+            let folded_lcccs_v = NIMFS::<Projective, PoseidonSponge<Fr>>::verify(
                 &mut transcript_v,
                 &ccs,
                 &lcccs_instances,

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -176,7 +176,6 @@ pub mod tests {
     use crate::utils::hypercube::BooleanHypercube;
     use crate::utils::mle::matrix_to_dense_mle;
     use crate::utils::multilinear_polynomial::tests::fix_last_variables;
-    use crate::utils::virtual_polynomial::eq_eval;
 
     /// Given M(x,y) matrix and a random field element `r`, test that ~M(r,y) is is an s'-variable polynomial which
     /// compresses every column j of the M(x,y) matrix by performing a random linear combination between the elements

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -181,11 +181,11 @@ where
         u_i: CommittedInstance<C>,
         cmT: C,
     ) -> Result<Vec<bool>, SynthesisError> {
-        let (U_cmE_x, U_cmE_y) = nonnative_affine_to_field_elements::<C>(U_i.cmE)?;
-        let (U_cmW_x, U_cmW_y) = nonnative_affine_to_field_elements::<C>(U_i.cmW)?;
-        let (u_cmE_x, u_cmE_y) = nonnative_affine_to_field_elements::<C>(u_i.cmE)?;
-        let (u_cmW_x, u_cmW_y) = nonnative_affine_to_field_elements::<C>(u_i.cmW)?;
-        let (cmT_x, cmT_y) = nonnative_affine_to_field_elements::<C>(cmT)?;
+        let (U_cmE_x, U_cmE_y) = nonnative_affine_to_field_elements::<C>(U_i.cmE);
+        let (U_cmW_x, U_cmW_y) = nonnative_affine_to_field_elements::<C>(U_i.cmW);
+        let (u_cmE_x, u_cmE_y) = nonnative_affine_to_field_elements::<C>(u_i.cmE);
+        let (u_cmW_x, u_cmW_y) = nonnative_affine_to_field_elements::<C>(u_i.cmW);
+        let (cmT_x, cmT_y) = nonnative_affine_to_field_elements::<C>(cmT);
 
         let mut sponge = PoseidonSponge::<C::ScalarField>::new(poseidon_config);
         let input = vec![

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -317,13 +317,11 @@ fn point2_to_eth_format(p: ark_bn254::G2Affine) -> Result<Vec<u8>, Error> {
 
 #[cfg(test)]
 pub mod tests {
-    use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
-    use ark_groth16::Groth16;
+    use ark_bn254::{constraints::GVar, Fr, G1Projective as Projective};
     use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
     use std::time::Instant;
 
     use super::*;
-    use crate::commitment::kzg::KZG;
     use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::PreprocessorParam;
     use crate::frontend::tests::CubicFCircuit;

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -261,6 +261,8 @@ where
     pub fn from_nova<FC: FCircuit<C1::ScalarField>>(
         nova: Nova<C1, GC1, C2, GC2, FC, CS1, CS2>,
     ) -> Result<Self, Error> {
+        let mut transcript = PoseidonSponge::<C1::ScalarField>::new(&nova.poseidon_config);
+
         // compute the U_{i+1}, W_{i+1}
         let (T, cmT) = NIFS::<C1, CS1>::compute_cmT(
             &nova.cs_pp,
@@ -271,7 +273,7 @@ where
             &nova.U_i.clone(),
         )?;
         let r_bits = ChallengeGadget::<C1>::get_challenge_native(
-            &nova.poseidon_config,
+            &mut transcript,
             nova.pp_hash,
             nova.U_i.clone(),
             nova.u_i.clone(),
@@ -285,7 +287,7 @@ where
 
         // compute the KZG challenges used as inputs in the circuit
         let (kzg_challenge_W, kzg_challenge_E) =
-            KZGChallengesGadget::<C1>::get_challenges_native(&nova.poseidon_config, U_i1.clone())?;
+            KZGChallengesGadget::<C1>::get_challenges_native(&mut transcript, U_i1.clone());
 
         // get KZG evals
         let mut W = W_i1.W.clone();
@@ -407,7 +409,11 @@ where
             Ok(self.eval_E.unwrap_or_else(CF1::<C1>::zero))
         })?;
 
+        // `sponge` is for digest computation.
         let sponge = PoseidonSpongeVar::<C1::ScalarField>::new(cs.clone(), &self.poseidon_config);
+        // `transcript` is for challenge generation.
+        let mut transcript =
+            PoseidonSpongeVar::<C1::ScalarField>::new(cs.clone(), &self.poseidon_config);
 
         // 1. check RelaxedR1CS of U_{i+1}
         let z_U1: Vec<FpVar<CF1<C1>>> =
@@ -492,12 +498,23 @@ where
             RelaxedR1CSGadget::check_nonnative(cf_r1cs, cf_W_i.E, cf_U_i.u.clone(), cf_z_U)?;
         }
 
-        // 6. check KZG challenges
-        let (incircuit_c_W, incircuit_c_E) = KZGChallengesGadget::<C1>::get_challenges_gadget(
-            cs.clone(),
-            &self.poseidon_config,
-            U_i1.clone(),
+        // 8.a, 6.a compute NIFS.V and KZG challenges.
+        // We need to ensure the order of challenge generation is the same as
+        // the native counterpart, so we first compute the challenges here and
+        // do the actual checks later.
+        let cmT =
+            NonNativeAffineVar::new_input(cs.clone(), || Ok(self.cmT.unwrap_or_else(C1::zero)))?;
+        let r_bits = ChallengeGadget::<C1>::get_challenge_gadget(
+            &mut transcript,
+            pp_hash,
+            U_i_vec,
+            u_i.clone(),
+            cmT.clone(),
         )?;
+        let (incircuit_c_W, incircuit_c_E) =
+            KZGChallengesGadget::<C1>::get_challenges_gadget(&mut transcript, U_i1.clone())?;
+
+        // 6.b check KZG challenges
         incircuit_c_W.enforce_equal(&kzg_c_W)?;
         incircuit_c_E.enforce_equal(&kzg_c_E)?;
 
@@ -510,18 +527,8 @@ where
         // incircuit_eval_W.enforce_equal(&eval_W)?;
         // incircuit_eval_E.enforce_equal(&eval_E)?;
 
-        // 8. compute the NIFS.V challenge and check that matches the one from the public input (so we
+        // 8.b check the NIFS.V challenge matches the one from the public input (so we
         // avoid the verifier computing it)
-        let cmT =
-            NonNativeAffineVar::new_input(cs.clone(), || Ok(self.cmT.unwrap_or_else(C1::zero)))?;
-        let r_bits = ChallengeGadget::<C1>::get_challenge_gadget(
-            cs.clone(),
-            &self.poseidon_config,
-            pp_hash,
-            U_i_vec,
-            u_i.clone(),
-            cmT.clone(),
-        )?;
         let r_Fr = Boolean::le_bits_to_fp_var(&r_bits)?;
         // check that the in-circuit computed r is equal to the inputted r
         let r =
@@ -564,10 +571,9 @@ where
     C::ScalarField: Absorb,
 {
     pub fn get_challenges_native(
-        poseidon_config: &PoseidonConfig<C::ScalarField>,
+        transcript: &mut PoseidonSponge<C::ScalarField>,
         U_i: CommittedInstance<C>,
-    ) -> Result<(C::ScalarField, C::ScalarField), Error> {
-        let transcript = &mut PoseidonSponge::<C::ScalarField>::new(poseidon_config);
+    ) -> (C::ScalarField, C::ScalarField) {
         // compute the KZG challenges, which are computed in-circuit and checked that it matches
         // the inputted one
         transcript.absorb_nonnative(&U_i.cmW);
@@ -575,16 +581,13 @@ where
         transcript.absorb_nonnative(&U_i.cmE);
         let challenge_E = transcript.get_challenge();
 
-        Ok((challenge_W, challenge_E))
+        (challenge_W, challenge_E)
     }
     // compatible with the native get_challenges_native
     pub fn get_challenges_gadget(
-        cs: ConstraintSystemRef<C::ScalarField>,
-        poseidon_config: &PoseidonConfig<C::ScalarField>,
+        transcript: &mut PoseidonSpongeVar<CF1<C>>,
         U_i: CommittedInstanceVar<C>,
     ) -> Result<(FpVar<C::ScalarField>, FpVar<C::ScalarField>), SynthesisError> {
-        let mut transcript = PoseidonSpongeVar::<CF1<C>>::new(cs.clone(), &poseidon_config.clone());
-
         transcript.absorb(&U_i.cmW.to_constraint_field()?)?;
         let challenge_W = transcript.get_challenge()?;
 
@@ -840,6 +843,7 @@ pub mod tests {
     fn test_kzg_challenge_gadget() {
         let mut rng = ark_std::test_rng();
         let poseidon_config = poseidon_canonical_config::<Fr>();
+        let mut transcript = PoseidonSponge::<Fr>::new(&poseidon_config);
 
         let U_i = CommittedInstance::<Projective> {
             cmE: Projective::rand(&mut rng),
@@ -850,21 +854,17 @@ pub mod tests {
 
         // compute the challenge natively
         let (challenge_W, challenge_E) =
-            KZGChallengesGadget::<Projective>::get_challenges_native(&poseidon_config, U_i.clone())
-                .unwrap();
+            KZGChallengesGadget::<Projective>::get_challenges_native(&mut transcript, U_i.clone());
 
         let cs = ConstraintSystem::<Fr>::new_ref();
         let U_iVar =
             CommittedInstanceVar::<Projective>::new_witness(cs.clone(), || Ok(U_i.clone()))
                 .unwrap();
+        let mut transcript_var = PoseidonSpongeVar::<Fr>::new(cs.clone(), &poseidon_config);
 
         let (challenge_W_Var, challenge_E_Var) =
-            KZGChallengesGadget::<Projective>::get_challenges_gadget(
-                cs.clone(),
-                &poseidon_config,
-                U_iVar,
-            )
-            .unwrap();
+            KZGChallengesGadget::<Projective>::get_challenges_gadget(&mut transcript_var, U_iVar)
+                .unwrap();
         assert!(cs.is_satisfied().unwrap());
 
         // check that the natively computed and in-circuit computed hashes match

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -412,8 +412,7 @@ where
         // `sponge` is for digest computation.
         let sponge = PoseidonSpongeVar::<C1::ScalarField>::new(cs.clone(), &self.poseidon_config);
         // `transcript` is for challenge generation.
-        let mut transcript =
-            PoseidonSpongeVar::<C1::ScalarField>::new(cs.clone(), &self.poseidon_config);
+        let mut transcript = sponge.clone();
 
         // 1. check RelaxedR1CS of U_{i+1}
         let z_U1: Vec<FpVar<CF1<C1>>> =
@@ -570,8 +569,8 @@ where
     <C as CurveGroup>::BaseField: PrimeField,
     C::ScalarField: Absorb,
 {
-    pub fn get_challenges_native(
-        transcript: &mut PoseidonSponge<C::ScalarField>,
+    pub fn get_challenges_native<T: Transcript<C::ScalarField>>(
+        transcript: &mut T,
         U_i: CommittedInstance<C>,
     ) -> (C::ScalarField, C::ScalarField) {
         // compute the KZG challenges, which are computed in-circuit and checked that it matches
@@ -584,8 +583,8 @@ where
         (challenge_W, challenge_E)
     }
     // compatible with the native get_challenges_native
-    pub fn get_challenges_gadget(
-        transcript: &mut PoseidonSpongeVar<CF1<C>>,
+    pub fn get_challenges_gadget<S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>>(
+        transcript: &mut T,
         U_i: CommittedInstanceVar<C>,
     ) -> Result<(FpVar<C::ScalarField>, FpVar<C::ScalarField>), SynthesisError> {
         transcript.absorb(&U_i.cmW.to_constraint_field()?)?;

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -574,8 +574,8 @@ where
         poseidon_config: &PoseidonConfig<C::ScalarField>,
         U_i: CommittedInstance<C>,
     ) -> Result<(C::ScalarField, C::ScalarField), Error> {
-        let (cmE_x_limbs, cmE_y_limbs) = nonnative_affine_to_field_elements(U_i.cmE)?;
-        let (cmW_x_limbs, cmW_y_limbs) = nonnative_affine_to_field_elements(U_i.cmW)?;
+        let (cmE_x_limbs, cmE_y_limbs) = nonnative_affine_to_field_elements(U_i.cmE);
+        let (cmW_x_limbs, cmW_y_limbs) = nonnative_affine_to_field_elements(U_i.cmW);
 
         let transcript = &mut PoseidonSponge::<C::ScalarField>::new(poseidon_config);
         // compute the KZG challenges, which are computed in-circuit and checked that it matches

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -56,7 +56,10 @@ impl<C: CurveGroup> CommittedInstance<C> {
     }
 }
 
-impl<C: CurveGroup<ScalarField: Absorb>> Absorb for CommittedInstance<C> {
+impl<C: CurveGroup> Absorb for CommittedInstance<C>
+where
+    C::ScalarField: Absorb,
+{
     fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
         // This is never called
         unimplemented!()

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -110,9 +110,9 @@ where
     /// nova/circuits.rs::CommittedInstanceVar.hash.
     /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and `U_i` is the
     /// `CommittedInstance`.
-    pub fn hash(
+    pub fn hash<T: Transcript<C::ScalarField>>(
         &self,
-        sponge: &PoseidonSponge<C::ScalarField>,
+        sponge: &T,
         pp_hash: C::ScalarField, // public params hash
         i: C::ScalarField,
         z_0: Vec<C::ScalarField>,
@@ -135,9 +135,9 @@ where
     /// hash_cyclefold implements the committed instance hash compatible with the gadget implemented in
     /// nova/cyclefold.rs::CycleFoldCommittedInstanceVar.hash.
     /// Returns `H(U_i)`, where `U_i` is the `CommittedInstance` for CycleFold.
-    pub fn hash_cyclefold(
+    pub fn hash_cyclefold<T: Transcript<C::BaseField>>(
         &self,
-        sponge: &PoseidonSponge<C::BaseField>,
+        sponge: &T,
         pp_hash: C::BaseField, // public params hash
     ) -> C::BaseField {
         let mut sponge = sponge.clone();
@@ -798,9 +798,9 @@ where
 {
     // folds the given cyclefold circuit and its instances
     #[allow(clippy::type_complexity)]
-    fn fold_cyclefold_circuit(
+    fn fold_cyclefold_circuit<T: Transcript<C1::ScalarField>>(
         &self,
-        transcript: &mut PoseidonSponge<C1::ScalarField>,
+        transcript: &mut T,
         cf_W_i: Witness<C2>,           // witness of the running instance
         cf_U_i: CommittedInstance<C2>, // running instance
         cf_u_i_x: Vec<C2::ScalarField>,

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -74,8 +74,8 @@ where
         z_0: Vec<C::ScalarField>,
         z_i: Vec<C::ScalarField>,
     ) -> Result<C::ScalarField, Error> {
-        let (cmE_x, cmE_y) = nonnative_affine_to_field_elements::<C>(self.cmE)?;
-        let (cmW_x, cmW_y) = nonnative_affine_to_field_elements::<C>(self.cmW)?;
+        let (cmE_x, cmE_y) = nonnative_affine_to_field_elements::<C>(self.cmE);
+        let (cmW_x, cmW_y) = nonnative_affine_to_field_elements::<C>(self.cmW);
 
         CRH::<C::ScalarField>::evaluate(
             poseidon_config,

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -183,7 +183,7 @@ where
     }
 
     pub fn prove_commitments(
-        tr: &mut impl Transcript<C>,
+        tr: &mut impl Transcript<C::ScalarField>,
         cs_prover_params: &CS::ProverParams,
         w: &Witness<C>,
         ci: &CommittedInstance<C>,
@@ -200,7 +200,10 @@ where
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
+    use ark_crypto_primitives::sponge::{
+        poseidon::{PoseidonConfig, PoseidonSponge},
+        CryptographicSponge,
+    };
     use ark_ff::{BigInteger, PrimeField};
     use ark_pallas::{Fr, Projective};
     use ark_std::{ops::Mul, UniformRand};
@@ -209,7 +212,7 @@ pub mod tests {
     use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
     use crate::folding::nova::circuits::ChallengeGadget;
     use crate::folding::nova::traits::NovaR1CS;
-    use crate::transcript::poseidon::{poseidon_canonical_config, PoseidonTranscript};
+    use crate::transcript::poseidon::poseidon_canonical_config;
 
     #[allow(clippy::type_complexity)]
     pub(crate) fn prepare_simple_fold_inputs<C>() -> (
@@ -364,9 +367,9 @@ pub mod tests {
             .unwrap();
 
         // init Prover's transcript
-        let mut transcript_p = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p = PoseidonSponge::<Fr>::new(&poseidon_config);
         // init Verifier's transcript
-        let mut transcript_v = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_v = PoseidonSponge::<Fr>::new(&poseidon_config);
 
         // prove the ci3.cmE, ci3.cmW, cmT commitments
         let cm_proofs = NIFS::<Projective, Pedersen<Projective>>::prove_commitments(

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -261,10 +261,11 @@ pub mod tests {
                 .unwrap();
 
         let poseidon_config = poseidon_canonical_config::<C::ScalarField>();
+        let mut transcript = PoseidonSponge::<C::ScalarField>::new(&poseidon_config);
 
         let pp_hash = C::ScalarField::from(42u32); // only for test
         let r_bits = ChallengeGadget::<C>::get_challenge_native(
-            &poseidon_config,
+            &mut transcript,
             pp_hash,
             ci1.clone(),
             ci2.clone(),

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -269,8 +269,7 @@ pub mod tests {
             ci1.clone(),
             ci2.clone(),
             cmT,
-        )
-        .unwrap();
+        );
         let r_Fr = C::ScalarField::from_bigint(BigInteger::from_bits_le(&r_bits)).unwrap();
 
         let (w3, ci3) =

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -6,12 +6,10 @@ use ark_poly::{
     univariate::{DensePolynomial, SparsePolynomial},
     DenseUVPolynomial, EvaluationDomain, Evaluations, GeneralEvaluationDomain, Polynomial,
 };
-use ark_std::log2;
-use ark_std::{cfg_into_iter, Zero};
+use ark_std::{cfg_into_iter, log2, Zero};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::marker::PhantomData;
 
-use super::traits::ProtoGalaxyTranscript;
 use super::utils::{all_powers, betas_star, exponential_powers};
 use super::ProtoGalaxyError;
 use super::{CommittedInstance, Witness};
@@ -36,7 +34,7 @@ where
     #![allow(clippy::type_complexity)]
     /// implements the non-interactive Prover from the folding scheme described in section 4
     pub fn prove(
-        transcript: &mut (impl Transcript<C> + ProtoGalaxyTranscript<C>),
+        transcript: &mut impl Transcript<C::ScalarField>,
         r1cs: &R1CS<C::ScalarField>,
         // running instance
         instance: &CommittedInstance<C>,
@@ -81,8 +79,8 @@ where
         }
 
         // absorb the committed instances
-        transcript.absorb_committed_instance(instance)?;
-        transcript.absorb_committed_instances(&vec_instances)?;
+        transcript.absorb(instance);
+        transcript.absorb(&vec_instances);
 
         let delta = transcript.get_challenge();
         let deltas = exponential_powers(delta, t);
@@ -93,7 +91,7 @@ where
         let F_X: SparsePolynomial<C::ScalarField> =
             calc_f_from_btree(&f_w, &instance.betas, &deltas).expect("Error calculating F[x]");
         let F_X_dense = DensePolynomial::from(F_X.clone());
-        transcript.absorb_vec(&F_X_dense.coeffs);
+        transcript.absorb(&F_X_dense.coeffs);
 
         let alpha = transcript.get_challenge();
 
@@ -185,7 +183,7 @@ where
             return Err(Error::ProtoGalaxy(ProtoGalaxyError::RemainderNotZero));
         }
 
-        transcript.absorb_vec(&K_X.coeffs);
+        transcript.absorb(&K_X.coeffs);
 
         let gamma = transcript.get_challenge();
 
@@ -221,7 +219,7 @@ where
 
     /// implements the non-interactive Verifier from the folding scheme described in section 4
     pub fn verify(
-        transcript: &mut (impl Transcript<C> + ProtoGalaxyTranscript<C>),
+        transcript: &mut impl Transcript<C::ScalarField>,
         r1cs: &R1CS<C::ScalarField>,
         // running instance
         instance: &CommittedInstance<C>,
@@ -235,13 +233,13 @@ where
         let n = r1cs.A.n_cols;
 
         // absorb the committed instances
-        transcript.absorb_committed_instance(instance)?;
-        transcript.absorb_committed_instances(&vec_instances)?;
+        transcript.absorb(instance);
+        transcript.absorb(&vec_instances);
 
         let delta = transcript.get_challenge();
         let deltas = exponential_powers(delta, t);
 
-        transcript.absorb_vec(&F_coeffs);
+        transcript.absorb(&F_coeffs);
 
         let alpha = transcript.get_challenge();
         let alphas = all_powers(alpha, n);
@@ -262,7 +260,7 @@ where
         let K_X: DensePolynomial<C::ScalarField> =
             DensePolynomial::<C::ScalarField>::from_coefficients_vec(K_coeffs);
 
-        transcript.absorb_vec(&K_X.coeffs);
+        transcript.absorb(&K_X.coeffs);
 
         let gamma = transcript.get_challenge();
 
@@ -376,12 +374,14 @@ fn eval_f<F: PrimeField>(r1cs: &R1CS<F>, w: &[F]) -> Result<Vec<F>, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
+    use ark_crypto_primitives::sponge::CryptographicSponge;
     use ark_pallas::{Fr, Projective};
     use ark_std::UniformRand;
 
     use crate::arith::r1cs::tests::{get_test_r1cs, get_test_z};
     use crate::commitment::{pedersen::Pedersen, CommitmentScheme};
-    use crate::transcript::poseidon::{poseidon_canonical_config, PoseidonTranscript};
+    use crate::transcript::poseidon::poseidon_canonical_config;
 
     pub(crate) fn check_instance<C: CurveGroup>(
         r1cs: &R1CS<C::ScalarField>,
@@ -509,8 +509,8 @@ mod tests {
 
         // init Prover & Verifier's transcript
         let poseidon_config = poseidon_canonical_config::<Fr>();
-        let mut transcript_p = PoseidonTranscript::<Projective>::new(&poseidon_config);
-        let mut transcript_v = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p = PoseidonSponge::<Fr>::new(&poseidon_config);
+        let mut transcript_v = PoseidonSponge::<Fr>::new(&poseidon_config);
 
         let (folded_instance, folded_witness, F_coeffs, K_coeffs) = Folding::<Projective>::prove(
             &mut transcript_p,
@@ -549,8 +549,8 @@ mod tests {
 
         // init Prover & Verifier's transcript
         let poseidon_config = poseidon_canonical_config::<Fr>();
-        let mut transcript_p = PoseidonTranscript::<Projective>::new(&poseidon_config);
-        let mut transcript_v = PoseidonTranscript::<Projective>::new(&poseidon_config);
+        let mut transcript_p = PoseidonSponge::<Fr>::new(&poseidon_config);
+        let mut transcript_v = PoseidonSponge::<Fr>::new(&poseidon_config);
 
         let (mut running_witness, mut running_instance, _, _) = prepare_inputs(0);
 

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -82,9 +82,7 @@ where
 
         // absorb the committed instances
         transcript.absorb_committed_instance(instance)?;
-        for ci in vec_instances.iter() {
-            transcript.absorb_committed_instance(ci)?;
-        }
+        transcript.absorb_committed_instances(&vec_instances)?;
 
         let delta = transcript.get_challenge();
         let deltas = exponential_powers(delta, t);
@@ -238,9 +236,7 @@ where
 
         // absorb the committed instances
         transcript.absorb_committed_instance(instance)?;
-        for ci in vec_instances.iter() {
-            transcript.absorb_committed_instance(ci)?;
-        }
+        transcript.absorb_committed_instances(&vec_instances)?;
 
         let delta = transcript.get_challenge();
         let deltas = exponential_powers(delta, t);

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -495,7 +495,7 @@ mod tests {
             .unwrap();
             let instance_i = CommittedInstance::<Projective> {
                 phi: phi_i,
-                betas: betas.clone(),
+                betas: vec![],
                 e: Fr::zero(),
             };
             witnesses.push(witness_i);

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -1,7 +1,10 @@
 /// Implements the scheme described in [ProtoGalaxy](https://eprint.iacr.org/2023/1106.pdf)
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
+use ark_r1cs_std::fields::fp::FpVar;
 use thiserror::Error;
+
+use super::circuits::nonnative::affine::NonNativeAffineVar;
 
 pub mod folding;
 pub mod traits;
@@ -12,6 +15,13 @@ pub struct CommittedInstance<C: CurveGroup> {
     phi: C,
     betas: Vec<C::ScalarField>,
     e: C::ScalarField,
+}
+
+#[derive(Clone, Debug)]
+pub struct CommittedInstanceVar<C: CurveGroup> {
+    phi: NonNativeAffineVar<C>,
+    betas: Vec<FpVar<C::ScalarField>>,
+    e: FpVar<C::ScalarField>,
 }
 
 #[derive(Clone, Debug)]

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -1,7 +1,10 @@
 use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::{CurveGroup, Group};
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
 
-use super::CommittedInstance;
+use super::{CommittedInstance, CommittedInstanceVar};
+use crate::transcript::poseidon::PoseidonTranscriptVar;
+use crate::transcript::TranscriptVar;
 use crate::transcript::{poseidon::PoseidonTranscript, Transcript};
 use crate::Error;
 
@@ -17,7 +20,18 @@ pub trait ProtoGalaxyTranscript<C: CurveGroup>: Transcript<C> {
 }
 
 // Implements ProtoGalaxyTranscript for PoseidonTranscript
-impl<C: CurveGroup> ProtoGalaxyTranscript<C> for PoseidonTranscript<C> where
-    <C as Group>::ScalarField: Absorb
-{
+impl<C: CurveGroup> ProtoGalaxyTranscript<C> for PoseidonTranscript<C> where C::ScalarField: Absorb {}
+
+pub trait ProtoGalaxyTranscriptVar<F: PrimeField>: TranscriptVar<F> {
+    fn absorb_committed_instance<C: CurveGroup<ScalarField = F>>(
+        &mut self,
+        ci: &CommittedInstanceVar<C>,
+    ) -> Result<(), Error> {
+        self.absorb_point(&ci.phi)?;
+        self.absorb_vec(&ci.betas)?;
+        self.absorb(&ci.e)?;
+        Ok(())
+    }
 }
+
+impl<F: PrimeField> ProtoGalaxyTranscriptVar<F> for PoseidonTranscriptVar<F> {}

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -17,6 +17,13 @@ pub trait ProtoGalaxyTranscript<C: CurveGroup>: Transcript<C> {
         self.absorb(&ci.e);
         Ok(())
     }
+
+    fn absorb_committed_instances(&mut self, cis: &[CommittedInstance<C>]) -> Result<(), Error> {
+        for ci in cis {
+            self.absorb_committed_instance(ci)?;
+        }
+        Ok(())
+    }
 }
 
 // Implements ProtoGalaxyTranscript for PoseidonTranscript
@@ -30,6 +37,16 @@ pub trait ProtoGalaxyTranscriptVar<F: PrimeField>: TranscriptVar<F> {
         self.absorb_point(&ci.phi)?;
         self.absorb_vec(&ci.betas)?;
         self.absorb(&ci.e)?;
+        Ok(())
+    }
+
+    fn absorb_committed_instances<C: CurveGroup<ScalarField = F>>(
+        &mut self,
+        cis: &[CommittedInstanceVar<C>],
+    ) -> Result<(), Error> {
+        for ci in cis {
+            self.absorb_committed_instance(ci)?;
+        }
         Ok(())
     }
 }

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -5,7 +5,7 @@ use ark_r1cs_std::{fields::fp::FpVar, uint8::UInt8, ToConstraintFieldGadget};
 use ark_relations::r1cs::SynthesisError;
 
 use super::{CommittedInstance, CommittedInstanceVar};
-use crate::folding::circuits::nonnative::affine::nonnative_affine_to_field_elements;
+use crate::transcript::AbsorbNonNative;
 
 // Implements the trait for absorbing ProtoGalaxy's CommittedInstance.
 impl<C: CurveGroup<ScalarField: Absorb>> Absorb for CommittedInstance<C> {
@@ -14,9 +14,9 @@ impl<C: CurveGroup<ScalarField: Absorb>> Absorb for CommittedInstance<C> {
     }
 
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
-        let (x, y) = nonnative_affine_to_field_elements(self.phi);
-        x.to_sponge_field_elements(dest);
-        y.to_sponge_field_elements(dest);
+        self.phi
+            .to_native_sponge_field_elements_as_vec()
+            .to_sponge_field_elements(dest);
         self.betas.to_sponge_field_elements(dest);
         self.e.to_sponge_field_elements(dest);
     }

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -14,7 +14,7 @@ impl<C: CurveGroup<ScalarField: Absorb>> Absorb for CommittedInstance<C> {
     }
 
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
-        let (x, y) = nonnative_affine_to_field_elements(self.phi).unwrap();
+        let (x, y) = nonnative_affine_to_field_elements(self.phi);
         x.to_sponge_field_elements(dest);
         y.to_sponge_field_elements(dest);
         self.betas.to_sponge_field_elements(dest);

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -8,7 +8,10 @@ use super::{CommittedInstance, CommittedInstanceVar};
 use crate::transcript::AbsorbNonNative;
 
 // Implements the trait for absorbing ProtoGalaxy's CommittedInstance.
-impl<C: CurveGroup<ScalarField: Absorb>> Absorb for CommittedInstance<C> {
+impl<C: CurveGroup> Absorb for CommittedInstance<C>
+where
+    C::ScalarField: Absorb,
+{
     fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
         unimplemented!()
     }

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -1,6 +1,7 @@
 use ark_crypto_primitives::sponge::Absorb;
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
+use ark_relations::r1cs::SynthesisError;
 
 use super::{CommittedInstance, CommittedInstanceVar};
 use crate::transcript::poseidon::PoseidonTranscriptVar;
@@ -33,7 +34,7 @@ pub trait ProtoGalaxyTranscriptVar<F: PrimeField>: TranscriptVar<F> {
     fn absorb_committed_instance<C: CurveGroup<ScalarField = F>>(
         &mut self,
         ci: &CommittedInstanceVar<C>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), SynthesisError> {
         self.absorb_point(&ci.phi)?;
         self.absorb_vec(&ci.betas)?;
         self.absorb(&ci.e)?;
@@ -43,7 +44,7 @@ pub trait ProtoGalaxyTranscriptVar<F: PrimeField>: TranscriptVar<F> {
     fn absorb_committed_instances<C: CurveGroup<ScalarField = F>>(
         &mut self,
         cis: &[CommittedInstanceVar<C>],
-    ) -> Result<(), Error> {
+    ) -> Result<(), SynthesisError> {
         for ci in cis {
             self.absorb_committed_instance(ci)?;
         }

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -207,8 +207,7 @@ impl<F: PrimeField> CircomFCircuit<F> {
 pub mod tests {
     use super::*;
     use ark_bn254::Fr;
-    use ark_r1cs_std::alloc::AllocVar;
-    use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
+    use ark_relations::r1cs::ConstraintSystem;
 
     // Tests the step_native function of CircomFCircuit.
     #[test]

--- a/folding-schemes/src/frontend/circom/utils.rs
+++ b/folding-schemes/src/frontend/circom/utils.rs
@@ -110,7 +110,6 @@ mod tests {
     use ark_circom::circom::{CircomBuilder, CircomConfig};
     use ark_circom::CircomCircuit;
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
-    use std::path::PathBuf;
 
     //To generate .r1cs and .wasm files, run the below command in the terminal.
     //bash ./folding-schemes/src/frontend/circom/test_folder/compile.sh

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -52,9 +52,7 @@ pub mod tests {
     use super::*;
     use ark_bn254::Fr;
     use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget};
-    use ark_relations::r1cs::{
-        ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, SynthesisError,
-    };
+    use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
     use core::marker::PhantomData;
 
     /// CubicFCircuit is a struct that implements the FCircuit trait, for the R1CS example circuit

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -1,4 +1,4 @@
-use crate::{folding::circuits::nonnative::affine::NonNativeAffineVar, Error};
+use crate::folding::circuits::nonnative::affine::NonNativeAffineVar;
 use ark_crypto_primitives::sponge::{constraints::CryptographicSpongeVar, CryptographicSponge};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
@@ -8,7 +8,7 @@ use ark_relations::r1cs::SynthesisError;
 pub mod poseidon;
 
 pub trait Transcript<F: PrimeField>: CryptographicSponge {
-    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, v: &C) -> Result<(), Error>;
+    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, v: &C);
 
     fn get_challenge(&mut self) -> F;
     /// get_challenge_nbits returns a field element of size nbits

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -1,14 +1,39 @@
-use crate::folding::circuits::nonnative::affine::NonNativeAffineVar;
 use ark_crypto_primitives::sponge::{constraints::CryptographicSpongeVar, CryptographicSponge};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
-use ark_r1cs_std::{boolean::Boolean, fields::fp::FpVar};
+use ark_r1cs_std::{
+    boolean::Boolean, fields::fp::FpVar, groups::CurveVar, ToConstraintFieldGadget,
+};
 use ark_relations::r1cs::SynthesisError;
 
 pub mod poseidon;
 
+pub trait AbsorbNonNative<F: PrimeField> {
+    /// Converts the object into field elements that can be absorbed by a `CryptographicSponge`.
+    /// Append the list to `dest`
+    fn to_native_sponge_field_elements(&self, dest: &mut Vec<F>);
+
+    /// Converts the object into field elements that can be absorbed by a `CryptographicSponge`.
+    /// Return the list as `Vec`
+    fn to_native_sponge_field_elements_as_vec(&self) -> Vec<F> {
+        let mut result = Vec::new();
+        self.to_native_sponge_field_elements(&mut result);
+        result
+    }
+}
+
+pub trait AbsorbNonNativeGadget<F: PrimeField> {
+    /// Converts the object into field elements that can be absorbed by a `CryptographicSpongeVar`.
+    fn to_native_sponge_field_elements(&self) -> Result<Vec<FpVar<F>>, SynthesisError>;
+}
+
 pub trait Transcript<F: PrimeField>: CryptographicSponge {
-    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, v: &C);
+    /// `absorb_point` is only for points whose `BaseField` is the field of the
+    /// sponge.
+    ///
+    /// If sponge field is `C::ScalarField`, call `absorb_nonnative` instead.
+    fn absorb_point<C: CurveGroup<BaseField = F>>(&mut self, v: &C);
+    fn absorb_nonnative<V: AbsorbNonNative<F>>(&mut self, v: &V);
 
     fn get_challenge(&mut self) -> F;
     /// get_challenge_nbits returns a field element of size nbits
@@ -19,9 +44,17 @@ pub trait Transcript<F: PrimeField>: CryptographicSponge {
 pub trait TranscriptVar<F: PrimeField, S: CryptographicSponge>:
     CryptographicSpongeVar<F, S>
 {
-    fn absorb_point<C: CurveGroup<ScalarField = F>>(
+    /// `absorb_point` is only for points whose `BaseField` is the field of the
+    /// sponge.
+    ///
+    /// If sponge field is `C::ScalarField`, call `absorb_nonnative` instead.
+    fn absorb_point<C: CurveGroup<BaseField = F>, GC: CurveVar<C, F> + ToConstraintFieldGadget<F>>(
         &mut self,
-        v: &NonNativeAffineVar<C>,
+        v: &GC,
+    ) -> Result<(), SynthesisError>;
+    fn absorb_nonnative<V: AbsorbNonNativeGadget<F>>(
+        &mut self,
+        v: &V,
     ) -> Result<(), SynthesisError>;
 
     fn get_challenge(&mut self) -> Result<FpVar<F>, SynthesisError>;

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -1,35 +1,29 @@
 use crate::{folding::circuits::nonnative::affine::NonNativeAffineVar, Error};
+use ark_crypto_primitives::sponge::{constraints::CryptographicSpongeVar, CryptographicSponge};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_r1cs_std::{boolean::Boolean, fields::fp::FpVar};
-use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use ark_std::fmt::Debug;
+use ark_relations::r1cs::SynthesisError;
 
 pub mod poseidon;
 
-pub trait Transcript<C: CurveGroup> {
-    type TranscriptConfig: Debug;
+pub trait Transcript<F: PrimeField>: CryptographicSponge {
+    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, v: &C) -> Result<(), Error>;
 
-    fn new(config: &Self::TranscriptConfig) -> Self;
-    fn absorb(&mut self, v: &C::ScalarField);
-    fn absorb_vec(&mut self, v: &[C::ScalarField]);
-    fn absorb_point(&mut self, v: &C) -> Result<(), Error>;
-    fn get_challenge(&mut self) -> C::ScalarField;
+    fn get_challenge(&mut self) -> F;
     /// get_challenge_nbits returns a field element of size nbits
     fn get_challenge_nbits(&mut self, nbits: usize) -> Vec<bool>;
-    fn get_challenges(&mut self, n: usize) -> Vec<C::ScalarField>;
+    fn get_challenges(&mut self, n: usize) -> Vec<F>;
 }
 
-pub trait TranscriptVar<F: PrimeField> {
-    type TranscriptVarConfig: Debug;
-
-    fn new(cs: ConstraintSystemRef<F>, poseidon_config: &Self::TranscriptVarConfig) -> Self;
-    fn absorb(&mut self, v: &FpVar<F>) -> Result<(), SynthesisError>;
-    fn absorb_vec(&mut self, v: &[FpVar<F>]) -> Result<(), SynthesisError>;
+pub trait TranscriptVar<F: PrimeField, S: CryptographicSponge>:
+    CryptographicSpongeVar<F, S>
+{
     fn absorb_point<C: CurveGroup<ScalarField = F>>(
         &mut self,
         v: &NonNativeAffineVar<C>,
     ) -> Result<(), SynthesisError>;
+
     fn get_challenge(&mut self) -> Result<FpVar<F>, SynthesisError>;
     /// returns the bit representation of the challenge, we use its output in-circuit for the
     /// `GC.scalar_mul_le` method.

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -35,11 +35,28 @@ pub trait AbsorbNonNativeGadget<F: PrimeField> {
 }
 
 pub trait Transcript<F: PrimeField>: CryptographicSponge {
-    /// `absorb_point` is only for points whose `BaseField` is the field of the
-    /// sponge.
+    /// `absorb_point` is for absorbing points whose `BaseField` is the field of
+    /// the sponge, i.e., the type `C` of these points should satisfy
+    /// `C::BaseField = F`.
     ///
-    /// If sponge field is `C::ScalarField`, call `absorb_nonnative` instead.
+    /// If the sponge field `F` is `C::ScalarField`, call `absorb_nonnative`
+    /// instead.
     fn absorb_point<C: CurveGroup<BaseField = F>>(&mut self, v: &C);
+    /// `absorb_nonnative` is for structs that contain non-native (field or
+    /// group) elements, including:
+    ///
+    /// - A field element of type `T: PrimeField` that will be absorbed into a
+    ///   sponge that operates in another field `F != T`.
+    /// - A group element of type `C: CurveGroup` that will be absorbed into a
+    ///   sponge that operates in another field `F != C::BaseField`, e.g.,
+    ///   `F = C::ScalarField`.
+    /// - A `CommittedInstance` on the secondary curve (used for CycleFold) that
+    ///   will be absorbed into a sponge that operates in the (scalar field of
+    ///   the) primary curve.
+    ///
+    ///   Note that although a `CommittedInstance` for `AugmentedFCircuit` on
+    ///   the primary curve also contains non-native elements, we still regard
+    ///   it as native, because the sponge is on the same curve.
     fn absorb_nonnative<V: AbsorbNonNative<F>>(&mut self, v: &V);
 
     fn get_challenge(&mut self) -> F;
@@ -51,14 +68,31 @@ pub trait Transcript<F: PrimeField>: CryptographicSponge {
 pub trait TranscriptVar<F: PrimeField, S: CryptographicSponge>:
     CryptographicSpongeVar<F, S>
 {
-    /// `absorb_point` is only for points whose `BaseField` is the field of the
-    /// sponge.
+    /// `absorb_point` is for absorbing points whose `BaseField` is the field of
+    /// the sponge, i.e., the type `C` of these points should satisfy
+    /// `C::BaseField = F`.
     ///
-    /// If sponge field is `C::ScalarField`, call `absorb_nonnative` instead.
+    /// If the sponge field `F` is `C::ScalarField`, call `absorb_nonnative`
+    /// instead.
     fn absorb_point<C: CurveGroup<BaseField = F>, GC: CurveVar<C, F> + ToConstraintFieldGadget<F>>(
         &mut self,
         v: &GC,
     ) -> Result<(), SynthesisError>;
+    /// `absorb_nonnative` is for structs that contain non-native (field or
+    /// group) elements, including:
+    ///
+    /// - A field element of type `T: PrimeField` that will be absorbed into a
+    ///   sponge that operates in another field `F != T`.
+    /// - A group element of type `C: CurveGroup` that will be absorbed into a
+    ///   sponge that operates in another field `F != C::BaseField`, e.g.,
+    ///   `F = C::ScalarField`.
+    /// - A `CommittedInstance` on the secondary curve (used for CycleFold) that
+    ///   will be absorbed into a sponge that operates in the (scalar field of
+    ///   the) primary curve.
+    ///
+    ///   Note that although a `CommittedInstance` for `AugmentedFCircuit` on
+    ///   the primary curve also contains non-native elements, we still regard
+    ///   it as native, because the sponge is on the same curve.
     fn absorb_nonnative<V: AbsorbNonNativeGadget<F>>(
         &mut self,
         v: &V,

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -8,12 +8,15 @@ use ark_relations::r1cs::SynthesisError;
 
 pub mod poseidon;
 
+/// An interface for objects that can be absorbed by a `Transcript`.
+///
+/// Matches `Absorb` in `ark-crypto-primitives`.
 pub trait AbsorbNonNative<F: PrimeField> {
-    /// Converts the object into field elements that can be absorbed by a `CryptographicSponge`.
+    /// Converts the object into field elements that can be absorbed by a `Transcript`.
     /// Append the list to `dest`
     fn to_native_sponge_field_elements(&self, dest: &mut Vec<F>);
 
-    /// Converts the object into field elements that can be absorbed by a `CryptographicSponge`.
+    /// Converts the object into field elements that can be absorbed by a `Transcript`.
     /// Return the list as `Vec`
     fn to_native_sponge_field_elements_as_vec(&self) -> Vec<F> {
         let mut result = Vec::new();
@@ -22,8 +25,12 @@ pub trait AbsorbNonNative<F: PrimeField> {
     }
 }
 
+/// An interface for objects that can be absorbed by a `TranscriptVar` whose constraint field
+/// is `F`.
+///
+/// Matches `AbsorbGadget` in `ark-crypto-primitives`.
 pub trait AbsorbNonNativeGadget<F: PrimeField> {
-    /// Converts the object into field elements that can be absorbed by a `CryptographicSpongeVar`.
+    /// Converts the object into field elements that can be absorbed by a `TranscriptVar`.
     fn to_native_sponge_field_elements(&self) -> Result<Vec<FpVar<F>>, SynthesisError>;
 }
 

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{folding::circuits::nonnative::affine::NonNativeAffineVar, Error};
 use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_r1cs_std::{boolean::Boolean, fields::fp::FpVar};
@@ -24,8 +24,12 @@ pub trait TranscriptVar<F: PrimeField> {
     type TranscriptVarConfig: Debug;
 
     fn new(cs: ConstraintSystemRef<F>, poseidon_config: &Self::TranscriptVarConfig) -> Self;
-    fn absorb(&mut self, v: FpVar<F>) -> Result<(), SynthesisError>;
+    fn absorb(&mut self, v: &FpVar<F>) -> Result<(), SynthesisError>;
     fn absorb_vec(&mut self, v: &[FpVar<F>]) -> Result<(), SynthesisError>;
+    fn absorb_point<C: CurveGroup<ScalarField = F>>(
+        &mut self,
+        v: &NonNativeAffineVar<C>,
+    ) -> Result<(), SynthesisError>;
     fn get_challenge(&mut self) -> Result<FpVar<F>, SynthesisError>;
     /// returns the bit representation of the challenge, we use its output in-circuit for the
     /// `GC.scalar_mul_le` method.

--- a/folding-schemes/src/transcript/poseidon.rs
+++ b/folding-schemes/src/transcript/poseidon.rs
@@ -3,10 +3,10 @@ use ark_crypto_primitives::sponge::{
     poseidon::{constraints::PoseidonSpongeVar, PoseidonConfig, PoseidonSponge},
     Absorb, CryptographicSponge,
 };
-use ark_ec::{CurveGroup, Group};
-use ark_ff::PrimeField;
+use ark_ec::CurveGroup;
+use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::{boolean::Boolean, fields::fp::FpVar, ToConstraintFieldGadget};
-use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+use ark_relations::r1cs::SynthesisError;
 
 use crate::{
     folding::circuits::nonnative::affine::{
@@ -17,93 +17,52 @@ use crate::{
 
 use super::{Transcript, TranscriptVar};
 
-/// PoseidonTranscript implements the Transcript trait using the Poseidon hash
-pub struct PoseidonTranscript<C: CurveGroup>
-where
-    <C as Group>::ScalarField: Absorb,
-{
-    sponge: PoseidonSponge<C::ScalarField>,
-}
-
-impl<C: CurveGroup> Transcript<C> for PoseidonTranscript<C>
-where
-    <C as Group>::ScalarField: Absorb,
-{
-    type TranscriptConfig = PoseidonConfig<C::ScalarField>;
-
-    fn new(poseidon_config: &Self::TranscriptConfig) -> Self {
-        let sponge = PoseidonSponge::<C::ScalarField>::new(poseidon_config);
-        Self { sponge }
-    }
-    fn absorb(&mut self, v: &C::ScalarField) {
-        self.sponge.absorb(&v);
-    }
-    fn absorb_vec(&mut self, v: &[C::ScalarField]) {
-        self.sponge.absorb(&v);
-    }
-    fn absorb_point(&mut self, p: &C) -> Result<(), Error> {
+impl<F: PrimeField + Absorb> Transcript<F> for PoseidonSponge<F> {
+    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, p: &C) -> Result<(), Error> {
         let (x, y) = nonnative_affine_to_field_elements(*p)?;
-        self.sponge.absorb(&[x, y].concat());
+        self.absorb(&[x, y].concat());
         Ok(())
     }
-    fn get_challenge(&mut self) -> C::ScalarField {
-        let c = self.sponge.squeeze_field_elements(1);
-        self.sponge.absorb(&c[0]);
+    fn get_challenge(&mut self) -> F {
+        let c = self.squeeze_field_elements(1);
+        self.absorb(&c[0]);
         c[0]
     }
     fn get_challenge_nbits(&mut self, nbits: usize) -> Vec<bool> {
-        let bits = self.sponge.squeeze_bits(nbits);
-        self.sponge.absorb(&C::ScalarField::from(
-            <C::ScalarField as PrimeField>::BigInt::from_bits_le(&bits),
-        ));
+        let bits = self.squeeze_bits(nbits);
+        self.absorb(&F::from(F::BigInt::from_bits_le(&bits)));
         bits
     }
-    fn get_challenges(&mut self, n: usize) -> Vec<C::ScalarField> {
-        let c = self.sponge.squeeze_field_elements(n);
-        self.sponge.absorb(&c);
+    fn get_challenges(&mut self, n: usize) -> Vec<F> {
+        let c = self.squeeze_field_elements(n);
+        self.absorb(&c);
         c
     }
 }
 
-/// PoseidonTranscriptVar implements the gadget compatible with PoseidonTranscript
-pub struct PoseidonTranscriptVar<F: PrimeField> {
-    sponge: PoseidonSpongeVar<F>,
-}
-impl<F: PrimeField> TranscriptVar<F> for PoseidonTranscriptVar<F> {
-    type TranscriptVarConfig = PoseidonConfig<F>;
-
-    fn new(cs: ConstraintSystemRef<F>, poseidon_config: &Self::TranscriptVarConfig) -> Self {
-        let sponge = PoseidonSpongeVar::<F>::new(cs, poseidon_config);
-        Self { sponge }
-    }
-    fn absorb(&mut self, v: &FpVar<F>) -> Result<(), SynthesisError> {
-        self.sponge.absorb(v)
-    }
-    fn absorb_vec(&mut self, v: &[FpVar<F>]) -> Result<(), SynthesisError> {
-        self.sponge.absorb(&v)
-    }
+impl<F: PrimeField> TranscriptVar<F, PoseidonSponge<F>> for PoseidonSpongeVar<F> {
     fn absorb_point<C: CurveGroup<ScalarField = F>>(
         &mut self,
         v: &NonNativeAffineVar<C>,
     ) -> Result<(), SynthesisError> {
-        self.sponge.absorb(&v.to_constraint_field()?)
+        self.absorb(&v.to_constraint_field()?)
     }
     fn get_challenge(&mut self) -> Result<FpVar<F>, SynthesisError> {
-        let c = self.sponge.squeeze_field_elements(1)?;
-        self.sponge.absorb(&c[0])?;
+        let c = self.squeeze_field_elements(1)?;
+        self.absorb(&c[0])?;
         Ok(c[0].clone())
     }
 
     /// returns the bit representation of the challenge, we use its output in-circuit for the
     /// `GC.scalar_mul_le` method.
     fn get_challenge_nbits(&mut self, nbits: usize) -> Result<Vec<Boolean<F>>, SynthesisError> {
-        let bits = self.sponge.squeeze_bits(nbits)?;
-        self.sponge.absorb(&Boolean::le_bits_to_fp_var(&bits)?)?;
+        let bits = self.squeeze_bits(nbits)?;
+        self.absorb(&Boolean::le_bits_to_fp_var(&bits)?)?;
         Ok(bits)
     }
     fn get_challenges(&mut self, n: usize) -> Result<Vec<FpVar<F>>, SynthesisError> {
-        let c = self.sponge.squeeze_field_elements(n)?;
-        self.sponge.absorb(&c)?;
+        let c = self.squeeze_field_elements(n)?;
+        self.absorb(&c)?;
         Ok(c)
     }
 }
@@ -141,13 +100,13 @@ pub fn poseidon_canonical_config<F: PrimeField>() -> PoseidonConfig<F> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+
     use ark_bn254::{constraints::GVar, Fq, Fr, G1Projective as G1};
-    use ark_ff::{BigInteger, UniformRand};
-    use ark_grumpkin::Projective;
+    use ark_ec::Group;
+    use ark_ff::UniformRand;
     use ark_r1cs_std::{alloc::AllocVar, groups::CurveVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::test_rng;
-    use std::ops::Mul;
 
     // Test with value taken from https://github.com/iden3/circomlibjs/blob/43cc582b100fc3459cf78d903a6f538e5d7f38ee/test/poseidon.js#L32
     #[test]
@@ -177,7 +136,7 @@ pub mod tests {
     fn test_transcript_and_transcriptvar_absorb_point() {
         // use 'native' transcript
         let config = poseidon_canonical_config::<Fr>();
-        let mut tr = PoseidonTranscript::<G1>::new(&config);
+        let mut tr = PoseidonSponge::<Fr>::new(&config);
         let rng = &mut test_rng();
 
         let p = G1::rand(rng);
@@ -186,12 +145,10 @@ pub mod tests {
 
         // use 'gadget' transcript
         let cs = ConstraintSystem::<Fr>::new_ref();
-        let mut tr_var = PoseidonTranscriptVar::<Fr>::new(cs.clone(), &config);
-        let p_var = NonNativeAffineVar::<G1>::new_witness(
-            ConstraintSystem::<Fr>::new_ref(),
-            || Ok(p),
-        )
-        .unwrap();
+        let mut tr_var = PoseidonSpongeVar::<Fr>::new(cs.clone(), &config);
+        let p_var =
+            NonNativeAffineVar::<G1>::new_witness(ConstraintSystem::<Fr>::new_ref(), || Ok(p))
+                .unwrap();
         tr_var.absorb_point(&p_var).unwrap();
         let c_var = tr_var.get_challenge().unwrap();
 
@@ -203,13 +160,13 @@ pub mod tests {
     fn test_transcript_and_transcriptvar_get_challenge() {
         // use 'native' transcript
         let config = poseidon_canonical_config::<Fr>();
-        let mut tr = PoseidonTranscript::<G1>::new(&config);
+        let mut tr = PoseidonSponge::<Fr>::new(&config);
         tr.absorb(&Fr::from(42_u32));
         let c = tr.get_challenge();
 
         // use 'gadget' transcript
         let cs = ConstraintSystem::<Fr>::new_ref();
-        let mut tr_var = PoseidonTranscriptVar::<Fr>::new(cs.clone(), &config);
+        let mut tr_var = PoseidonSpongeVar::<Fr>::new(cs.clone(), &config);
         let v = FpVar::<Fr>::new_witness(cs.clone(), || Ok(Fr::from(42_u32))).unwrap();
         tr_var.absorb(&v).unwrap();
         let c_var = tr_var.get_challenge().unwrap();
@@ -224,7 +181,7 @@ pub mod tests {
 
         // use 'native' transcript
         let config = poseidon_canonical_config::<Fq>();
-        let mut tr = PoseidonTranscript::<Projective>::new(&config);
+        let mut tr = PoseidonSponge::<Fq>::new(&config);
         tr.absorb(&Fq::from(42_u32));
 
         // get challenge from native transcript
@@ -232,7 +189,7 @@ pub mod tests {
 
         // use 'gadget' transcript
         let cs = ConstraintSystem::<Fq>::new_ref();
-        let mut tr_var = PoseidonTranscriptVar::<Fq>::new(cs.clone(), &config);
+        let mut tr_var = PoseidonSpongeVar::<Fq>::new(cs.clone(), &config);
         let v = FpVar::<Fq>::new_witness(cs.clone(), || Ok(Fq::from(42_u32))).unwrap();
         tr_var.absorb(&v).unwrap();
 
@@ -247,7 +204,7 @@ pub mod tests {
 
         // native c*P
         let c_Fr = Fr::from_bigint(BigInteger::from_bits_le(&c_bits)).unwrap();
-        let cP_native = P.mul(c_Fr);
+        let cP_native = P * c_Fr;
 
         // native c*P using mul_bits_be (notice the .rev to convert the LE to BE)
         let cP_native_bits = P.mul_bits_be(c_bits.into_iter().rev());

--- a/folding-schemes/src/transcript/poseidon.rs
+++ b/folding-schemes/src/transcript/poseidon.rs
@@ -52,7 +52,11 @@ where
         c[0]
     }
     fn get_challenge_nbits(&mut self, nbits: usize) -> Vec<bool> {
-        self.sponge.squeeze_bits(nbits)
+        let bits = self.sponge.squeeze_bits(nbits);
+        self.sponge.absorb(&C::ScalarField::from(
+            <C::ScalarField as PrimeField>::BigInt::from_bits_le(&bits),
+        ));
+        bits
     }
     fn get_challenges(&mut self, n: usize) -> Vec<C::ScalarField> {
         let c = self.sponge.squeeze_field_elements(n);
@@ -93,7 +97,9 @@ impl<F: PrimeField> TranscriptVar<F> for PoseidonTranscriptVar<F> {
     /// returns the bit representation of the challenge, we use its output in-circuit for the
     /// `GC.scalar_mul_le` method.
     fn get_challenge_nbits(&mut self, nbits: usize) -> Result<Vec<Boolean<F>>, SynthesisError> {
-        self.sponge.squeeze_bits(nbits)
+        let bits = self.sponge.squeeze_bits(nbits)?;
+        self.sponge.absorb(&Boolean::le_bits_to_fp_var(&bits)?)?;
+        Ok(bits)
     }
     fn get_challenges(&mut self, n: usize) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let c = self.sponge.squeeze_field_elements(n)?;

--- a/folding-schemes/src/transcript/poseidon.rs
+++ b/folding-schemes/src/transcript/poseidon.rs
@@ -8,20 +8,16 @@ use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::{boolean::Boolean, fields::fp::FpVar, ToConstraintFieldGadget};
 use ark_relations::r1cs::SynthesisError;
 
-use crate::{
-    folding::circuits::nonnative::affine::{
-        nonnative_affine_to_field_elements, NonNativeAffineVar,
-    },
-    Error,
+use crate::folding::circuits::nonnative::affine::{
+    nonnative_affine_to_field_elements, NonNativeAffineVar,
 };
 
 use super::{Transcript, TranscriptVar};
 
 impl<F: PrimeField + Absorb> Transcript<F> for PoseidonSponge<F> {
-    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, p: &C) -> Result<(), Error> {
-        let (x, y) = nonnative_affine_to_field_elements(*p)?;
+    fn absorb_point<C: CurveGroup<ScalarField = F>>(&mut self, p: &C) {
+        let (x, y) = nonnative_affine_to_field_elements(*p);
         self.absorb(&[x, y].concat());
-        Ok(())
     }
     fn get_challenge(&mut self) -> F {
         let c = self.squeeze_field_elements(1);
@@ -140,7 +136,7 @@ pub mod tests {
         let rng = &mut test_rng();
 
         let p = G1::rand(rng);
-        tr.absorb_point(&p).unwrap();
+        tr.absorb_point(&p);
         let c = tr.get_challenge();
 
         // use 'gadget' transcript

--- a/folding-schemes/src/utils/espresso/sum_check/prover.rs
+++ b/folding-schemes/src/utils/espresso/sum_check/prover.rs
@@ -14,11 +14,9 @@ use crate::utils::{
     lagrange_poly::compute_lagrange_interpolated_poly, multilinear_polynomial::fix_variables,
     virtual_polynomial::VirtualPolynomial,
 };
-use ark_ec::CurveGroup;
-use ark_ff::Field;
 use ark_ff::{batch_inversion, PrimeField};
 use ark_poly::DenseMultilinearExtension;
-use ark_std::{cfg_into_iter, end_timer, start_timer, vec::Vec};
+use ark_std::{cfg_into_iter, end_timer, start_timer};
 use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator};
 use std::sync::Arc;
 
@@ -28,9 +26,9 @@ use espresso_subroutines::poly_iop::prelude::PolyIOPErrors;
 // #[cfg(feature = "parallel")]
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
-impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
-    type VirtualPolynomial = VirtualPolynomial<C::ScalarField>;
-    type ProverMessage = IOPProverMessage<C::ScalarField>;
+impl<F: PrimeField> SumCheckProver<F> for IOPProverState<F> {
+    type VirtualPolynomial = VirtualPolynomial<F>;
+    type ProverMessage = IOPProverMessage<F>;
 
     /// Initialize the prover state to argue for the sum of the input polynomial
     /// over {0,1}^`num_vars`.
@@ -49,9 +47,7 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
             poly: polynomial.clone(),
             extrapolation_aux: (1..polynomial.aux_info.max_degree)
                 .map(|degree| {
-                    let points = (0..1 + degree as u64)
-                        .map(C::ScalarField::from)
-                        .collect::<Vec<_>>();
+                    let points = (0..1 + degree as u64).map(F::from).collect::<Vec<_>>();
                     let weights = barycentric_weights(&points);
                     (points, weights)
                 })
@@ -65,7 +61,7 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
     /// Main algorithm used is from section 3.2 of [XZZPS19](https://eprint.iacr.org/2019/317.pdf#subsection.3.2).
     fn prove_round_and_update_state(
         &mut self,
-        challenge: &Option<C::ScalarField>,
+        challenge: &Option<F>,
     ) -> Result<Self::ProverMessage, PolyIOPErrors> {
         // let start =
         //     start_timer!(|| format!("sum check prove {}-th round and update state",
@@ -90,7 +86,7 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
         //    g(r_1, ..., r_{m-1}, x_m ... x_n)
         //
         // eval g over r_m, and mutate g to g(r_1, ... r_m,, x_{m+1}... x_n)
-        let mut flattened_ml_extensions: Vec<DenseMultilinearExtension<C::ScalarField>> = self
+        let mut flattened_ml_extensions: Vec<DenseMultilinearExtension<F>> = self
             .poly
             .flattened_ml_extensions
             .par_iter()
@@ -124,7 +120,7 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
         self.round += 1;
 
         let products_list = self.poly.products.clone();
-        let mut products_sum = vec![C::ScalarField::ZERO; self.poly.aux_info.max_degree + 1];
+        let mut products_sum = vec![F::ZERO; self.poly.aux_info.max_degree + 1];
 
         // Step 2: generate sum for the partial evaluated polynomial:
         // f(r_1, ... r_m,, x_{m+1}... x_n)
@@ -134,8 +130,8 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
                 .fold(
                     || {
                         (
-                            vec![(C::ScalarField::ZERO, C::ScalarField::ZERO); products.len()],
-                            vec![C::ScalarField::ZERO; products.len() + 1],
+                            vec![(F::ZERO, F::ZERO); products.len()],
+                            vec![F::ZERO; products.len() + 1],
                         )
                     },
                     |(mut buf, mut acc), b| {
@@ -146,17 +142,17 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
                                 *eval = table[b << 1];
                                 *step = table[(b << 1) + 1] - table[b << 1];
                             });
-                        acc[0] += buf.iter().map(|(eval, _)| eval).product::<C::ScalarField>();
+                        acc[0] += buf.iter().map(|(eval, _)| eval).product::<F>();
                         acc[1..].iter_mut().for_each(|acc| {
                             buf.iter_mut().for_each(|(eval, step)| *eval += step as &_);
-                            *acc += buf.iter().map(|(eval, _)| eval).product::<C::ScalarField>();
+                            *acc += buf.iter().map(|(eval, _)| eval).product::<F>();
                         });
                         (buf, acc)
                     },
                 )
                 .map(|(_, partial)| partial)
                 .reduce(
-                    || vec![C::ScalarField::ZERO; products.len() + 1],
+                    || vec![F::ZERO; products.len() + 1],
                     |mut sum, partial| {
                         sum.iter_mut()
                             .zip(partial.iter())
@@ -168,7 +164,7 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
             let extraploation = cfg_into_iter!(0..self.poly.aux_info.max_degree - products.len())
                 .map(|i| {
                     let (points, weights) = &self.extrapolation_aux[products.len() - 1];
-                    let at = C::ScalarField::from((products.len() + 1 + i) as u64);
+                    let at = F::from((products.len() + 1 + i) as u64);
                     extrapolate(points, weights, &sum, &at)
                 })
                 .collect::<Vec<_>>();
@@ -184,7 +180,7 @@ impl<C: CurveGroup> SumCheckProver<C> for IOPProverState<C> {
             .map(|x| Arc::new(x.clone()))
             .collect();
 
-        let prover_poly = compute_lagrange_interpolated_poly::<C::ScalarField>(&products_sum);
+        let prover_poly = compute_lagrange_interpolated_poly::<F>(&products_sum);
         Ok(IOPProverMessage {
             coeffs: prover_poly.coeffs,
         })

--- a/folding-schemes/src/utils/espresso/sum_check/structs.rs
+++ b/folding-schemes/src/utils/espresso/sum_check/structs.rs
@@ -10,7 +10,6 @@
 //! This module defines structs that are shared by all sub protocols.
 
 use crate::utils::virtual_polynomial::VirtualPolynomial;
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
 
@@ -33,28 +32,28 @@ pub struct IOPProverMessage<F: PrimeField> {
 
 /// Prover State of a PolyIOP.
 #[derive(Debug)]
-pub struct IOPProverState<C: CurveGroup> {
+pub struct IOPProverState<F: PrimeField> {
     /// sampled randomness given by the verifier
-    pub challenges: Vec<C::ScalarField>,
+    pub challenges: Vec<F>,
     /// the current round number
     pub(crate) round: usize,
     /// pointer to the virtual polynomial
-    pub(crate) poly: VirtualPolynomial<C::ScalarField>,
+    pub(crate) poly: VirtualPolynomial<F>,
     /// points with precomputed barycentric weights for extrapolating smaller
     /// degree uni-polys to `max_degree + 1` evaluations.
     #[allow(clippy::type_complexity)]
-    pub(crate) extrapolation_aux: Vec<(Vec<C::ScalarField>, Vec<C::ScalarField>)>,
+    pub(crate) extrapolation_aux: Vec<(Vec<F>, Vec<F>)>,
 }
 
 /// Verifier State of a PolyIOP, generic over a curve group
 #[derive(Debug)]
-pub struct IOPVerifierState<C: CurveGroup> {
+pub struct IOPVerifierState<F: PrimeField> {
     pub(crate) round: usize,
     pub(crate) num_vars: usize,
     pub(crate) finished: bool,
     /// a list storing the univariate polynomial in evaluation form sent by the
     /// prover at each round
-    pub(crate) polynomials_received: Vec<Vec<C::ScalarField>>,
+    pub(crate) polynomials_received: Vec<Vec<F>>,
     /// a list storing the randomness sampled by the verifier at each round
-    pub(crate) challenges: Vec<C::ScalarField>,
+    pub(crate) challenges: Vec<F>,
 }

--- a/folding-schemes/src/utils/espresso/virtual_polynomial.rs
+++ b/folding-schemes/src/utils/espresso/virtual_polynomial.rs
@@ -18,8 +18,6 @@ use rayon::prelude::*;
 use std::{cmp::max, collections::HashMap, marker::PhantomData, ops::Add, sync::Arc};
 use thiserror::Error;
 
-use ark_std::string::String;
-
 //-- aritherrors
 /// A `enum` specifying the possible failure modes of the arithmetics.
 #[derive(Error, Debug)]

--- a/folding-schemes/src/utils/lagrange_poly.rs
+++ b/folding-schemes/src/utils/lagrange_poly.rs
@@ -52,7 +52,7 @@ mod tests {
     use crate::utils::lagrange_poly::compute_lagrange_interpolated_poly;
     use ark_pallas::Fr;
     use ark_poly::{univariate::DensePolynomial, DenseUVPolynomial, Polynomial};
-    use ark_std::{vec::Vec, UniformRand};
+    use ark_std::UniformRand;
     use espresso_subroutines::poly_iop::prelude::PolyIOPErrors;
 
     #[test]

--- a/solidity-verifiers/src/verifiers/kzg.rs
+++ b/solidity-verifiers/src/verifiers/kzg.rs
@@ -78,7 +78,8 @@ mod tests {
         utils::HeaderInclusion,
         ProtocolVerifierKey,
     };
-    use ark_bn254::{Bn254, Fr, G1Projective as G1};
+    use ark_bn254::{Bn254, Fr};
+    use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
     use ark_ec::{AffineRepr, CurveGroup};
     use ark_ff::{BigInteger, PrimeField};
     use ark_std::rand::{RngCore, SeedableRng};
@@ -89,10 +90,7 @@ mod tests {
 
     use folding_schemes::{
         commitment::{kzg::KZG, CommitmentScheme},
-        transcript::{
-            poseidon::{poseidon_canonical_config, PoseidonTranscript},
-            Transcript,
-        },
+        transcript::{poseidon::poseidon_canonical_config, Transcript},
     };
 
     use super::KZG10Verifier;
@@ -133,8 +131,8 @@ mod tests {
     fn kzg_verifier_accepts_and_rejects_proofs() {
         let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(test_rng().next_u64());
         let poseidon_config = poseidon_canonical_config::<Fr>();
-        let transcript_p = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
-        let transcript_v = &mut PoseidonTranscript::<G1>::new(&poseidon_config);
+        let transcript_p = &mut PoseidonSponge::<Fr>::new(&poseidon_config);
+        let transcript_v = &mut PoseidonSponge::<Fr>::new(&poseidon_config);
 
         let (_, kzg_pk, kzg_vk, _, _, _) = setup(DEFAULT_SETUP_LEN);
         let kzg_vk = KZG10VerifierKey::from((kzg_vk.clone(), kzg_pk.powers_of_g[0..3].to_vec()));

--- a/solidity-verifiers/src/verifiers/kzg.rs
+++ b/solidity-verifiers/src/verifiers/kzg.rs
@@ -157,7 +157,7 @@ mod tests {
         let (x_proof, y_proof) = proof_affine.xy().unwrap();
         let y = proof.eval.into_bigint().to_bytes_be();
 
-        transcript_v.absorb_point(&cm).unwrap();
+        transcript_v.absorb_nonnative(&cm);
         let x = transcript_v.get_challenge();
 
         let x = x.into_bigint().to_bytes_be();


### PR DESCRIPTION
I observed that in Nova, we compute the challenges and digests by manually constructing the input vectors to `CRH{Var}::evaluate`, while in ProtoGalaxy, we have `ProtoGalaxyTranscript` for absorbing the inputs to a sponge.

It would be beneficial to unify the way we derive challenges and digests in different folding schemes, and thus I created this PR and made several changes in challenge generation and digest computation. Notably,

1. `PoseidonTranscript{Var}`, the wrappers of `PoseidonSponge{Var}`, are removed. Instead, `PoseidonSponge{Var}` now implements the `Transcript{Var}` traits directly and supports both digest computation and challenge generation.
    * Yet, this does not mean we can use a single instance of `PoseidonSponge{Var}` for both purposes. One still needs to create two separate instances, e.g., `sponge` and `transcript`, for digest computation and challenge generation respectively.
2.  The `Transcript{Var}` traits now allow absorbing any non-native values (e.g., integers, points, CycleFold instances), as long as they implement `AbsorbNonNative{Gadget}`.
3.  The `Transcript{Var}::absorb_point` method now is solely for absorbing native points (i.e., those whose base field is also the sponge's field), so some `absorb_point` calls are replaced with `absorb_nonnative`.
4. In Nova, `CommittedInstance{Var}::hash` and `{CycleFold}ChallengeGadget::get_challenge_{native, gadget}` now use the absorb methods provided by `PoseidonSponge{Var}` and `Transcript{Var}`.
5. In HyperNova, `Absorb` is implemented for `CCCS` and `LCCCS`, and `LCCCS::hash` also uses `PoseidonSponge::absorb`.
6. In ProtoGalaxy, `ProtoGalaxyTranscript` is removed in favor of implementing `Absorb{Gadget}` for `CommittedInstance{Var}`.

Yet, as this PR focuses on code quality and does not introduce bug fixes or new functionalities, we can lower the priority of merging it.