### PR TITLE
Circuit compute_c reduce constraints

### DIFF
--- a/folding-schemes/src/folding/circuits/nonnative/affine.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/affine.rs
@@ -1,4 +1,5 @@
 use ark_ec::{AffineRepr, CurveGroup};
+use ark_ff::PrimeField;
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     fields::fp::FpVar,
@@ -16,7 +17,7 @@ use super::uint::{nonnative_field_to_field_elements, NonNativeUintVar};
 #[derive(Debug, Clone)]
 pub struct NonNativeAffineVar<C: CurveGroup>
 where
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+    <C as CurveGroup>::BaseField: PrimeField,
 {
     pub x: NonNativeUintVar<C::ScalarField>,
     pub y: NonNativeUintVar<C::ScalarField>,
@@ -25,7 +26,7 @@ where
 impl<C> AllocVar<C, C::ScalarField> for NonNativeAffineVar<C>
 where
     C: CurveGroup,
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+    <C as CurveGroup>::BaseField: PrimeField,
 {
     fn new_variable<T: Borrow<C>>(
         cs: impl Into<Namespace<C::ScalarField>>,
@@ -49,7 +50,7 @@ where
 
 impl<C: CurveGroup> ToConstraintFieldGadget<C::ScalarField> for NonNativeAffineVar<C>
 where
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+    <C as CurveGroup>::BaseField: PrimeField,
 {
     // Used for converting `NonNativeAffineVar` to a vector of `FpVar` with minimum length in
     // the circuit.
@@ -66,7 +67,7 @@ pub fn nonnative_affine_to_field_elements<C: CurveGroup>(
     p: C,
 ) -> Result<(Vec<C::ScalarField>, Vec<C::ScalarField>), SynthesisError>
 where
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+    <C as CurveGroup>::BaseField: PrimeField,
 {
     let affine = p.into_affine();
     if affine.is_zero() {
@@ -83,7 +84,7 @@ where
 
 impl<C: CurveGroup> NonNativeAffineVar<C>
 where
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
+    <C as CurveGroup>::BaseField: PrimeField,
 {
     // A wrapper of `point_to_nonnative_limbs_custom_opt` with constraints-focused optimization
     // type (which is the default optimization type for arkworks' Groth16).

--- a/folding-schemes/src/folding/circuits/sum_check.rs
+++ b/folding-schemes/src/folding/circuits/sum_check.rs
@@ -1,10 +1,7 @@
 use crate::utils::espresso::sum_check::SumCheck;
 use crate::utils::virtual_polynomial::VPAuxInfo;
 use crate::{
-    transcript::{
-        poseidon::{PoseidonTranscript, PoseidonTranscriptVar},
-        TranscriptVar,
-    },
+    transcript::{poseidon::PoseidonTranscript, TranscriptVar},
     utils::sum_check::{structs::IOPProof, IOPSumCheck},
 };
 use ark_crypto_primitives::sponge::Absorb;
@@ -150,7 +147,7 @@ impl<C: CurveGroup> SumCheckVerifierGadget<C> {
     pub fn verify(
         iop_proof_var: &IOPProofVar<C>,
         poly_aux_info_var: &VPAuxInfoVar<C::ScalarField>,
-        transcript_var: &mut PoseidonTranscriptVar<C::ScalarField>,
+        transcript_var: &mut impl TranscriptVar<C::ScalarField>,
     ) -> Result<(Vec<FpVar<C::ScalarField>>, Vec<FpVar<C::ScalarField>>), SynthesisError> {
         let mut e_vars = vec![iop_proof_var.claim.clone()];
         let mut r_vars: Vec<FpVar<C::ScalarField>> = Vec::new();

--- a/folding-schemes/src/folding/circuits/utils.rs
+++ b/folding-schemes/src/folding/circuits/utils.rs
@@ -12,7 +12,7 @@ pub struct EqEvalGadget<F: PrimeField> {
 impl<F: PrimeField> EqEvalGadget<F> {
     /// Gadget to evaluate eq polynomial.
     /// Follows the implementation of `eq_eval` found in this crate.
-    pub fn eq_eval(x: Vec<FpVar<F>>, y: Vec<FpVar<F>>) -> Result<FpVar<F>, SynthesisError> {
+    pub fn eq_eval(x: &[FpVar<F>], y: &[FpVar<F>]) -> Result<FpVar<F>, SynthesisError> {
         if x.len() != y.len() {
             return Err(SynthesisError::Unsatisfiable);
         }
@@ -30,15 +30,14 @@ impl<F: PrimeField> EqEvalGadget<F> {
 
 #[cfg(test)]
 mod tests {
-
-    use crate::utils::virtual_polynomial::eq_eval;
-
-    use super::EqEvalGadget;
     use ark_ff::Field;
     use ark_pallas::Fr;
     use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};
+
+    use super::EqEvalGadget;
+    use crate::utils::virtual_polynomial::eq_eval;
 
     #[test]
     pub fn test_eq_eval_gadget() {
@@ -57,19 +56,19 @@ mod tests {
                 .map(|y| FpVar::<Fr>::new_witness(cs.clone(), || Ok(y)).unwrap())
                 .collect();
             let expected_eq_eval = eq_eval::<Fr>(&x_vec, &y_vec).unwrap();
-            let gadget_eq_eval: FpVar<Fr> = EqEvalGadget::<Fr>::eq_eval(x, y).unwrap();
+            let gadget_eq_eval: FpVar<Fr> = EqEvalGadget::<Fr>::eq_eval(&x, &y).unwrap();
             assert_eq!(expected_eq_eval, gadget_eq_eval.value().unwrap());
         }
 
         let x: Vec<FpVar<Fr>> = vec![];
         let y: Vec<FpVar<Fr>> = vec![];
-        let gadget_eq_eval = EqEvalGadget::<Fr>::eq_eval(x, y);
+        let gadget_eq_eval = EqEvalGadget::<Fr>::eq_eval(&x, &y);
         assert!(gadget_eq_eval.is_err());
 
         let x: Vec<FpVar<Fr>> = vec![];
         let y: Vec<FpVar<Fr>> =
             vec![FpVar::<Fr>::new_witness(cs.clone(), || Ok(&Fr::ONE)).unwrap()];
-        let gadget_eq_eval = EqEvalGadget::<Fr>::eq_eval(x, y);
+        let gadget_eq_eval = EqEvalGadget::<Fr>::eq_eval(&x, &y);
         assert!(gadget_eq_eval.is_err());
     }
 }

--- a/folding-schemes/src/folding/hypernova/circuit.rs
+++ b/folding-schemes/src/folding/hypernova/circuit.rs
@@ -1,251 +1,85 @@
-// hypernova nimfs verifier circuit
-// see section 5 in https://eprint.iacr.org/2023/573.pdf
-
-use crate::{ccs::CCS, folding::circuits::utils::EqEvalGadget};
+/// Implementation of [HyperNova](https://eprint.iacr.org/2023/573.pdf) NIMFS verifier circuit
 use ark_ff::PrimeField;
 use ark_r1cs_std::{
     alloc::AllocVar,
     fields::{fp::FpVar, FieldVar},
-    ToBitsGadget,
 };
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use std::marker::PhantomData;
 
-/// Gadget to compute $\sum_{j \in [t]} \gamma^{j} \cdot e_1 \cdot \sigma_j + \gamma^{t+1} \cdot e_2 \cdot \sum_{i=1}^{q} c_i * \prod_{j \in S_i} \theta_j$.
-/// This is the sum computed by the verifier and laid out in section 5, step 5 of "A multi-folding scheme for CCS".
-pub struct ComputeCFromSigmasAndThetasGadget<F: PrimeField> {
-    _f: PhantomData<F>,
-}
+use crate::ccs::CCS;
+use crate::folding::circuits::utils::EqEvalGadget;
 
-impl<F: PrimeField> ComputeCFromSigmasAndThetasGadget<F> {
-    /// Computes the sum $\sum_{j}^{j + n} \gamma^{j} \cdot eq_eval \cdot \sigma_{j}$, where $n$ is the length of the `sigmas` vector
-    /// It corresponds to the first term of the sum that $\mathcal{V}$ has to compute at section 5, step 5 of "A multi-folding scheme for CCS".
-    ///
-    /// # Arguments
-    /// - `sigmas`: vector of $\sigma_j$ values
-    /// - `eq_eval`: the value of $\tilde{eq}(x_j, x^{\prime})$
-    /// - `gamma`: value $\gamma$
-    /// - `j`: the power at which we start to compute $\gamma^{j}$. This is needed in the context of multifolding.
-    ///
-    /// # Notes
-    /// In the context of multifolding, `j` corresponds to `ccs.t` in `compute_c_from_sigmas_and_thetas`
-    fn sum_muls_gamma_pows_eq_sigma(
-        gamma: FpVar<F>,
-        eq_eval: FpVar<F>,
-        sigmas: Vec<FpVar<F>>,
-        j: FpVar<F>,
-    ) -> Result<FpVar<F>, SynthesisError> {
-        let mut result = FpVar::<F>::zero();
-        let mut gamma_pow = gamma.pow_le(&j.to_bits_le()?)?;
-        for sigma in sigmas {
-            result += gamma_pow.clone() * eq_eval.clone() * sigma;
-            gamma_pow *= gamma.clone();
-        }
-        Ok(result)
+/// computes c from the step 5 in section 5 of HyperNova, adapted to multiple LCCCS & CCCS
+/// instances:
+/// $$
+/// c = \sum_{i \in [\mu]} \left(\sum_{j \in [t]} \gamma^{i \cdot t + j} \cdot e_i \cdot \sigma_{i,j} \right)
+/// + \sum_{k \in [\nu]} \gamma^{\mu \cdot t+k} \cdot e_k \cdot \left( \sum_{i=1}^q c_i \cdot \prod_{j \in S_i}
+/// \theta_{k,j} \right)
+/// $$
+#[allow(dead_code)] // TMP while the other circuits are not ready
+#[allow(clippy::too_many_arguments)]
+fn compute_c_gadget<F: PrimeField>(
+    cs: ConstraintSystemRef<F>,
+    ccs: &CCS<F>,
+    vec_sigmas: Vec<Vec<FpVar<F>>>,
+    vec_thetas: Vec<Vec<FpVar<F>>>,
+    gamma: FpVar<F>,
+    beta: Vec<FpVar<F>>,
+    vec_r_x: Vec<Vec<FpVar<F>>>,
+    vec_r_x_prime: Vec<FpVar<F>>,
+) -> Result<FpVar<F>, SynthesisError> {
+    let mut e_lcccs = Vec::new();
+    for r_x in vec_r_x.iter() {
+        let e_1 = EqEvalGadget::eq_eval(r_x.to_vec(), vec_r_x_prime.to_vec())?;
+        e_lcccs.push(e_1);
     }
 
-    /// Computes $\sum_{i=1}^{q} c_i * \prod_{j \in S_i} theta_j$
-    ///
-    /// # Arguments
-    /// - `c_i`: vector of $c_i$ values
-    /// - `thetas`: vector of pre-processed $\thetas[j]$ values corresponding to a particular `ccs.S[i]`
-    ///
-    /// # Notes
-    /// This is a part of the second term of the sum that $\mathcal{V}$ has to compute at section 5, step 5 of "A multi-folding scheme for CCS".
-    /// The first term is computed by `SumMulsGammaPowsEqSigmaGadget::sum_muls_gamma_pows_eq_sigma`.
-    /// This is a doct product between a vector of c_i values and a vector of pre-processed $\theta_j$ values, where $j$ is a value from $S_i$.
-    /// Hence, this requires some pre-processing of the $\theta_j$ values, before running this gadget.
-    fn sum_ci_mul_prod_thetaj(
-        c_i: Vec<FpVar<F>>,
-        thetas: Vec<Vec<FpVar<F>>>,
-    ) -> Result<FpVar<F>, SynthesisError> {
-        let mut result = FpVar::<F>::zero();
-        for (i, c_i) in c_i.iter().enumerate() {
-            let prod = &thetas[i].iter().fold(FpVar::one(), |acc, e| acc * e);
-            result += c_i * prod;
+    let mut c = FpVar::<F>::zero();
+    let mut current_gamma = FpVar::<F>::one();
+    for i in 0..vec_sigmas.len() {
+        for j in 0..ccs.t {
+            c += current_gamma.clone() * e_lcccs[i].clone() * vec_sigmas[i][j].clone();
+            current_gamma *= gamma.clone();
         }
-        Ok(result)
     }
 
-    /// Computes the sum that the verifier has to compute at section 5, step 5 of "A multi-folding scheme for CCS".
-    ///
-    /// # Arguments
-    /// - `cs`: constraint system
-    /// - `ccs`: the CCS instance
-    /// - `vec_sigmas`: vector of $\sigma_j$ values
-    /// - `vec_thetas`: vector of $\theta_j$ values
-    /// - `gamma`: value $\gamma$
-    /// - `beta`: vector of $\beta_j$ values
-    /// - `vec_r_x`: vector of $r_{x_j}$ values
-    /// - `vec_r_x_prime`: vector of $r_{x_j}^{\prime}$ values
-    ///
-    /// # Notes
-    /// Arguments to this function are *almost* the same as the arguments to `compute_c_from_sigmas_and_thetas` in `utils.rs`.
-    #[allow(clippy::too_many_arguments)]
-    pub fn compute_c_from_sigmas_and_thetas(
-        cs: ConstraintSystemRef<F>,
-        ccs: &CCS<F>,
-        vec_sigmas: Vec<Vec<FpVar<F>>>,
-        vec_thetas: Vec<Vec<FpVar<F>>>,
-        gamma: FpVar<F>,
-        beta: Vec<FpVar<F>>,
-        vec_r_x: Vec<Vec<FpVar<F>>>,
-        vec_r_x_prime: Vec<FpVar<F>>,
-    ) -> Result<FpVar<F>, SynthesisError> {
-        let mut c = FpVar::<F>::new_witness(cs.clone(), || Ok(F::zero()))?;
-        let t = FpVar::<F>::new_witness(cs.clone(), || Ok(F::from(ccs.t as u64)))?;
-
-        let mut e_lcccs = Vec::new();
-        for r_x in vec_r_x.iter() {
-            let e_1 = EqEvalGadget::eq_eval(r_x.to_vec(), vec_r_x_prime.to_vec())?;
-            e_lcccs.push(e_1);
-        }
-
-        for (i, sigmas) in vec_sigmas.iter().enumerate() {
-            let i_var = FpVar::<F>::new_witness(cs.clone(), || Ok(F::from(i as u64)))?;
-            let pow = i_var * t.clone();
-            c += Self::sum_muls_gamma_pows_eq_sigma(
-                gamma.clone(),
-                e_lcccs[i].clone(),
-                sigmas.to_vec(),
-                pow,
-            )?;
-        }
-
-        let mu = FpVar::<F>::new_witness(cs.clone(), || Ok(F::from(vec_sigmas.len() as u64)))?;
-        let e_2 = EqEvalGadget::eq_eval(beta, vec_r_x_prime)?;
-        for (k, thetas) in vec_thetas.iter().enumerate() {
-            // get prepared thetas. only step different from original `compute_c_from_sigmas_and_thetas`
-            let mut prepared_thetas = Vec::new();
-            for i in 0..ccs.q {
-                let prepared: Vec<FpVar<F>> = ccs.S[i].iter().map(|j| thetas[*j].clone()).collect();
-                prepared_thetas.push(prepared.to_vec());
+    let ccs_c = Vec::<FpVar<F>>::new_constant(cs.clone(), ccs.c.clone())?;
+    let e_k = EqEvalGadget::eq_eval(beta, vec_r_x_prime)?;
+    #[allow(clippy::needless_range_loop)]
+    for k in 0..vec_thetas.len() {
+        let mut sum = FpVar::<F>::zero();
+        for i in 0..ccs.q {
+            let mut prod = FpVar::<F>::one();
+            for j in ccs.S[i].clone() {
+                prod *= vec_thetas[k][j].clone();
             }
-
-            let c_i = Vec::<FpVar<F>>::new_witness(cs.clone(), || Ok(ccs.c.clone())).unwrap();
-            let lhs = Self::sum_ci_mul_prod_thetaj(c_i.clone(), prepared_thetas.clone())?;
-
-            // compute gamma^(t+1)
-            let pow = mu.clone() * t.clone()
-                + FpVar::<F>::new_witness(cs.clone(), || Ok(F::from(k as u64)))?;
-            let gamma_t1 = gamma.pow_le(&pow.to_bits_le()?)?;
-
-            c += gamma_t1.clone() * e_2.clone() * lhs.clone();
+            sum += ccs_c[i].clone() * prod;
         }
-
-        Ok(c)
+        c += current_gamma.clone() * e_k.clone() * sum;
+        current_gamma *= gamma.clone();
     }
+    Ok(c)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::ComputeCFromSigmasAndThetasGadget;
+    use ark_pallas::{Fr, Projective};
+    use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar, R1CSVar};
+    use ark_relations::r1cs::ConstraintSystem;
+    use ark_std::{test_rng, UniformRand};
+
+    use super::*;
     use crate::{
         ccs::{
             tests::{get_test_ccs, get_test_z},
             CCS,
         },
         commitment::{pedersen::Pedersen, CommitmentScheme},
-        folding::hypernova::utils::{
-            compute_c_from_sigmas_and_thetas, compute_sigmas_and_thetas, sum_ci_mul_prod_thetaj,
-            sum_muls_gamma_pows_eq_sigma,
-        },
-        utils::virtual_polynomial::eq_eval,
+        folding::hypernova::utils::{compute_c, compute_sigmas_and_thetas},
     };
-    use ark_pallas::{Fr, Projective};
-    use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar, R1CSVar};
-    use ark_relations::r1cs::ConstraintSystem;
-    use ark_std::{test_rng, UniformRand};
 
     #[test]
-    pub fn test_sum_muls_gamma_pow_eq_sigma_gadget() {
-        let mut rng = test_rng();
-        let ccs: CCS<Fr> = get_test_ccs();
-        let z1 = get_test_z(3);
-        let z2 = get_test_z(4);
-
-        let gamma: Fr = Fr::rand(&mut rng);
-        let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
-
-        // Initialize a multifolding object
-        let (pedersen_params, _) =
-            Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
-        let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
-        let sigmas_thetas =
-            compute_sigmas_and_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime);
-
-        let mut e_lcccs = Vec::new();
-        for r_x in &vec![lcccs_instance.r_x] {
-            e_lcccs.push(eq_eval(r_x, &r_x_prime).unwrap());
-        }
-
-        // Initialize cs and gamma
-        let cs = ConstraintSystem::<Fr>::new_ref();
-        let gamma_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(gamma)).unwrap();
-
-        for (i, sigmas) in sigmas_thetas.0.iter().enumerate() {
-            let expected =
-                sum_muls_gamma_pows_eq_sigma(gamma, e_lcccs[i], sigmas, (i * ccs.t) as u64);
-            let sigmas_var =
-                Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(sigmas.clone())).unwrap();
-            let eq_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(e_lcccs[i])).unwrap();
-            let pow =
-                FpVar::<Fr>::new_witness(cs.clone(), || Ok(Fr::from((i * ccs.t) as u64))).unwrap();
-            let computed = ComputeCFromSigmasAndThetasGadget::<Fr>::sum_muls_gamma_pows_eq_sigma(
-                gamma_var.clone(),
-                eq_var,
-                sigmas_var,
-                pow,
-            )
-            .unwrap();
-            assert_eq!(expected, computed.value().unwrap());
-        }
-    }
-
-    #[test]
-    pub fn test_sum_ci_mul_prod_thetaj_gadget() {
-        let mut rng = test_rng();
-        let ccs: CCS<Fr> = get_test_ccs();
-        let z1 = get_test_z(3);
-        let z2 = get_test_z(4);
-
-        let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
-
-        // Initialize a multifolding object
-        let (pedersen_params, _) =
-            Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
-        let (lcccs_instance, _) = ccs.to_lcccs(&mut rng, &pedersen_params, &z1).unwrap();
-        let sigmas_thetas =
-            compute_sigmas_and_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime);
-
-        let mut e_lcccs = Vec::new();
-        for r_x in &vec![lcccs_instance.r_x] {
-            e_lcccs.push(eq_eval(r_x, &r_x_prime).unwrap());
-        }
-
-        // Initialize cs
-        let cs = ConstraintSystem::<Fr>::new_ref();
-        let vec_thetas = sigmas_thetas.1;
-        for thetas in vec_thetas.iter() {
-            // sum c_i * prod theta_j
-            let expected = sum_ci_mul_prod_thetaj(&ccs, thetas); // from `compute_c_from_sigmas_and_thetas`
-            let mut prepared_thetas = Vec::new();
-            for i in 0..ccs.q {
-                let prepared: Vec<Fr> = ccs.S[i].iter().map(|j| thetas[*j]).collect();
-                prepared_thetas
-                    .push(Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(prepared)).unwrap());
-            }
-            let computed = ComputeCFromSigmasAndThetasGadget::<Fr>::sum_ci_mul_prod_thetaj(
-                Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(ccs.c.clone())).unwrap(),
-                prepared_thetas,
-            )
-            .unwrap();
-            assert_eq!(expected, computed.value().unwrap());
-        }
-    }
-
-    #[test]
-    pub fn test_compute_c_from_sigmas_and_thetas_gadget() {
+    pub fn test_compute_c_gadget() {
         // number of LCCCS & CCCS instances to fold in a single step
         let mu = 32;
         let nu = 42;
@@ -286,7 +120,7 @@ mod tests {
 
         let sigmas_thetas = compute_sigmas_and_thetas(&ccs, &z_lcccs, &z_cccs, &r_x_prime);
 
-        let expected_c = compute_c_from_sigmas_and_thetas(
+        let expected_c = compute_c(
             &ccs,
             &sigmas_thetas,
             gamma,
@@ -319,7 +153,7 @@ mod tests {
             Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(r_x_prime.clone())).unwrap();
         let gamma_var = FpVar::<Fr>::new_witness(cs.clone(), || Ok(gamma)).unwrap();
         let beta_var = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(beta.clone())).unwrap();
-        let computed_c = ComputeCFromSigmasAndThetasGadget::compute_c_from_sigmas_and_thetas(
+        let computed_c = compute_c_gadget(
             cs.clone(),
             &ccs,
             vec_sigmas,
@@ -331,7 +165,6 @@ mod tests {
         )
         .unwrap();
 
-        dbg!(cs.num_constraints());
         assert_eq!(expected_c, computed_c.value().unwrap());
     }
 }

--- a/folding-schemes/src/folding/hypernova/circuit.rs
+++ b/folding-schemes/src/folding/hypernova/circuit.rs
@@ -30,8 +30,7 @@ fn compute_c_gadget<F: PrimeField>(
 ) -> Result<FpVar<F>, SynthesisError> {
     let mut e_lcccs = Vec::new();
     for r_x in vec_r_x.iter() {
-        let e_1 = EqEvalGadget::eq_eval(r_x.to_vec(), vec_r_x_prime.to_vec())?;
-        e_lcccs.push(e_1);
+        e_lcccs.push(EqEvalGadget::eq_eval(r_x, &vec_r_x_prime)?);
     }
 
     let mut c = FpVar::<F>::zero();
@@ -44,7 +43,7 @@ fn compute_c_gadget<F: PrimeField>(
     }
 
     let ccs_c = Vec::<FpVar<F>>::new_constant(cs.clone(), ccs.c.clone())?;
-    let e_k = EqEvalGadget::eq_eval(beta, vec_r_x_prime)?;
+    let e_k = EqEvalGadget::eq_eval(&beta, &vec_r_x_prime)?;
     #[allow(clippy::needless_range_loop)]
     for k in 0..vec_thetas.len() {
         let mut sum = FpVar::<F>::zero();

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -1,9 +1,10 @@
 use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
 use ark_poly::DenseMultilinearExtension;
 use ark_std::One;
 use std::sync::Arc;
 
-use ark_std::{rand::Rng, UniformRand};
+use ark_std::rand::Rng;
 
 use super::cccs::Witness;
 use super::utils::{compute_all_sum_Mz_evals, compute_sum_Mz};
@@ -31,19 +32,23 @@ pub struct LCCCS<C: CurveGroup> {
     pub v: Vec<C::ScalarField>,
 }
 
-impl<C: CurveGroup> CCS<C> {
+impl<F: PrimeField> CCS<F> {
     /// Compute v_j values of the linearized committed CCS form
     /// Given `r`, compute:  \sum_{y \in {0,1}^s'} M_j(r, y) * z(y)
-    fn compute_v_j(&self, z: &[C::ScalarField], r: &[C::ScalarField]) -> Vec<C::ScalarField> {
+    fn compute_v_j(&self, z: &[F], r: &[F]) -> Vec<F> {
         compute_all_sum_Mz_evals(&self.M, &z.to_vec(), r, self.s_prime)
     }
 
-    pub fn to_lcccs<R: Rng>(
+    pub fn to_lcccs<R: Rng, C: CurveGroup>(
         &self,
         rng: &mut R,
         pedersen_params: &PedersenParams<C>,
         z: &[C::ScalarField],
-    ) -> Result<(LCCCS<C>, Witness<C::ScalarField>), Error> {
+    ) -> Result<(LCCCS<C>, Witness<C::ScalarField>), Error>
+    where
+        // enforce that CCS's F is the C::ScalarField
+        C: CurveGroup<ScalarField = F>,
+    {
         let w: Vec<C::ScalarField> = z[(1 + self.l)..].to_vec();
         let r_w = C::ScalarField::rand(rng);
         let C = Pedersen::<C, true>::commit(pedersen_params, &w, &r_w)?;
@@ -68,7 +73,7 @@ impl<C: CurveGroup> LCCCS<C> {
     /// Compute all L_j(x) polynomials
     pub fn compute_Ls(
         &self,
-        ccs: &CCS<C>,
+        ccs: &CCS<C::ScalarField>,
         z: &Vec<C::ScalarField>,
     ) -> Vec<VirtualPolynomial<C::ScalarField>> {
         let z_mle = vec_to_mle(ccs.s_prime, z);
@@ -92,7 +97,7 @@ impl<C: CurveGroup> LCCCS<C> {
     pub fn check_relation(
         &self,
         pedersen_params: &PedersenParams<C>,
-        ccs: &CCS<C>,
+        ccs: &CCS<C::ScalarField>,
         w: &Witness<C::ScalarField>,
     ) -> Result<(), Error> {
         // check that C is the commitment of w. Notice that this is not verifying a Pedersen

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -7,7 +7,7 @@ use ark_std::{One, Zero};
 
 use super::cccs::{Witness, CCCS};
 use super::lcccs::LCCCS;
-use super::utils::{compute_c_from_sigmas_and_thetas, compute_g, compute_sigmas_and_thetas};
+use super::utils::{compute_c, compute_g, compute_sigmas_and_thetas};
 use crate::ccs::CCS;
 use crate::transcript::Transcript;
 use crate::utils::hypercube::BooleanHypercube;
@@ -20,13 +20,13 @@ use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// Proof defines a multifolding proof
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Proof<C: CurveGroup> {
     pub sc_proof: SumCheckProof<C::ScalarField>,
     pub sigmas_thetas: SigmasThetas<C::ScalarField>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SigmasThetas<F: PrimeField>(pub Vec<Vec<F>>, pub Vec<Vec<F>>);
 
 #[derive(Debug)]
@@ -325,7 +325,7 @@ where
         let r_x_prime = sumcheck_subclaim.point.clone();
 
         // Step 5: Finish verifying sumcheck (verify the claim c)
-        let c = compute_c_from_sigmas_and_thetas(
+        let c = compute_c(
             ccs,
             &proof.sigmas_thetas,
             gamma,
@@ -336,6 +336,7 @@ where
                 .collect(),
             &r_x_prime,
         );
+
         // check that the g(r_x') from the sumcheck proof is equal to the computed c from sigmas&thetas
         if c != sumcheck_subclaim.expected_evaluation {
             return Err(Error::NotEqual);

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -151,7 +151,7 @@ where
     #[allow(clippy::type_complexity)]
     pub fn prove(
         transcript: &mut impl Transcript<C>,
-        ccs: &CCS<C>,
+        ccs: &CCS<C::ScalarField>,
         running_instances: &[LCCCS<C>],
         new_instances: &[CCCS<C>],
         w_lcccs: &[Witness<C::ScalarField>],
@@ -277,7 +277,7 @@ where
     /// Returns the folded LCCCS instance.
     pub fn verify(
         transcript: &mut impl Transcript<C>,
-        ccs: &CCS<C>,
+        ccs: &CCS<C::ScalarField>,
         running_instances: &[LCCCS<C>],
         new_instances: &[CCCS<C>],
         proof: Proof<C>,
@@ -430,7 +430,7 @@ pub mod tests {
         let mut rng = test_rng();
 
         // Create a basic CCS circuit
-        let ccs = get_test_ccs::<Projective>();
+        let ccs = get_test_ccs::<Fr>();
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
 
@@ -489,7 +489,7 @@ pub mod tests {
     pub fn test_multifolding_two_instances_multiple_steps() {
         let mut rng = test_rng();
 
-        let ccs = get_test_ccs::<Projective>();
+        let ccs = get_test_ccs::<Fr>();
 
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
@@ -559,7 +559,7 @@ pub mod tests {
         let mut rng = test_rng();
 
         // Create a basic CCS circuit
-        let ccs = get_test_ccs::<Projective>();
+        let ccs = get_test_ccs::<Fr>();
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
 
@@ -642,7 +642,7 @@ pub mod tests {
         let mut rng = test_rng();
 
         // Create a basic CCS circuit
-        let ccs = get_test_ccs::<Projective>();
+        let ccs = get_test_ccs::<Fr>();
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
 

--- a/folding-schemes/src/utils/espresso/sum_check/verifier.rs
+++ b/folding-schemes/src/utils/espresso/sum_check/verifier.rs
@@ -140,7 +140,6 @@ impl<C: CurveGroup> SumCheckVerifier<C> for IOPVerifierState<C> {
             let eval_at_zero: C::ScalarField = poly.coeffs[0];
             let eval = eval_at_one + eval_at_zero;
 
-            println!("evaluations: {:?}, expected: {:?}", eval, expected);
             // the deferred check during the interactive phase:
             // 1. check if the received 'P(0) + P(1) = expected`.
             if eval != expected {


### PR DESCRIPTION
- migrate from `C: CurveGroup` to `F: PrimeField` in hypernova & ccs when curve whas not needed to simplify the code
- refactor test of compute_c circuit to use multiple LCCCS&CCCS instances
- refactor hypernova's *compute_c_gadget* circuit (old *compute_c_from_sigmas_and_thetas*) to a more circuit-friendly approach

Now when folding for example 32 LCCCS and 42 CCCS instances in a single fold, the circuit got reduced from `110635` to `553` constraints (`~200x` reduction).