### PR TITLE
Optimize native nimfs

### DIFF
--- a/folding-schemes/src/ccs/mod.rs
+++ b/folding-schemes/src/ccs/mod.rs
@@ -1,7 +1,7 @@
 use ark_ff::PrimeField;
 use ark_std::log2;
 
-use crate::utils::vec::*;
+use crate::utils::vec::{hadamard, mat_vec_mul, vec_add, vec_scalar_mul, SparseMatrix};
 use crate::Error;
 
 pub mod r1cs;
@@ -48,7 +48,7 @@ impl<F: PrimeField> CCS<F> {
             // complete the hadamard chain
             let mut hadamard_result = vec![F::one(); self.m];
             for M_j in vec_M_j.into_iter() {
-                hadamard_result = hadamard(&hadamard_result, &mat_vec_mul_sparse(M_j, z)?)?;
+                hadamard_result = hadamard(&hadamard_result, &mat_vec_mul(M_j, z)?)?;
             }
 
             // multiply by the coefficient of this step

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -14,8 +14,8 @@ use crate::commitment::{
     CommitmentScheme,
 };
 use crate::utils::hypercube::BooleanHypercube;
-use crate::utils::mle::matrix_to_mle;
-use crate::utils::mle::vec_to_mle;
+use crate::utils::mle::matrix_to_dense_mle;
+use crate::utils::mle::vec_to_dense_mle;
 use crate::utils::virtual_polynomial::VirtualPolynomial;
 use crate::Error;
 
@@ -62,13 +62,13 @@ impl<F: PrimeField> CCS<F> {
     /// Computes q(x) = \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
     /// polynomial over x
     pub fn compute_q(&self, z: &[F]) -> VirtualPolynomial<F> {
-        let z_mle = vec_to_mle(self.s_prime, z);
+        let z_mle = vec_to_dense_mle(self.s_prime, z);
         let mut q = VirtualPolynomial::<F>::new(self.s);
 
         for i in 0..self.q {
             let mut prod: VirtualPolynomial<F> = VirtualPolynomial::<F>::new(self.s);
             for j in self.S[i].clone() {
-                let M_j = matrix_to_mle(self.M[j].clone());
+                let M_j = matrix_to_dense_mle(self.M[j].clone());
 
                 let sum_Mz = compute_sum_Mz(M_j, &z_mle, self.s_prime);
 

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -2,12 +2,10 @@ use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_std::One;
 use ark_std::Zero;
-use std::ops::Add;
 use std::sync::Arc;
 
 use ark_std::rand::Rng;
 
-use super::utils::compute_sum_Mz;
 use crate::ccs::CCS;
 use crate::commitment::{
     pedersen::{Params as PedersenParams, Pedersen},
@@ -15,8 +13,6 @@ use crate::commitment::{
 };
 use crate::utils::hypercube::BooleanHypercube;
 use crate::utils::mle::dense_vec_to_dense_mle;
-use crate::utils::mle::matrix_to_dense_mle;
-use crate::utils::mle::vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
 use crate::utils::virtual_polynomial::{build_eq_x_r_vec, VirtualPolynomial};
 use crate::Error;
@@ -63,61 +59,35 @@ impl<F: PrimeField> CCS<F> {
 
     /// Computes q(x) = \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
     /// polynomial over x
-    pub fn compute_q(&self, z: &[F]) -> VirtualPolynomial<F> {
-        let z_mle = vec_to_dense_mle(self.s_prime, z);
-        let mut q = VirtualPolynomial::<F>::new(self.s);
-
+    pub fn compute_q(&self, z: &[F]) -> Result<VirtualPolynomial<F>, Error> {
+        let mut q_x = VirtualPolynomial::<F>::new(self.s);
         for i in 0..self.q {
-            let mut prod: VirtualPolynomial<F> = VirtualPolynomial::<F>::new(self.s);
-            for j in self.S[i].clone() {
-                let M_j = matrix_to_dense_mle(self.M[j].clone());
-
-                let sum_Mz = compute_sum_Mz(M_j, &z_mle, self.s_prime);
-
-                // Fold this sum into the running product
-                if prod.products.is_empty() {
-                    // If this is the first time we are adding something to this virtual polynomial, we need to
-                    // explicitly add the products using add_mle_list()
-                    // XXX is this true? improve API
-                    prod.add_mle_list([Arc::new(sum_Mz)], F::one()).unwrap();
-                } else {
-                    prod.mul_by_mle(Arc::new(sum_Mz), F::one()).unwrap();
-                }
+            let mut Q_k = vec![];
+            for &j in self.S[i].iter() {
+                Q_k.push(dense_vec_to_dense_mle(self.s, &mat_vec_mul(&self.M[j], z)?));
             }
-            // Multiply by the product by the coefficient c_i
-            prod.scalar_mul(&self.c[i]);
-            // Add it to the running sum
-            q = q.add(&prod);
+            q_x.add_mle_list(Q_k.iter().map(|v| Arc::new(v.clone())), self.c[i])?;
         }
-        q
-    }
-
-    pub fn compute_Q_OLD(&self, z: &[F], beta: &[F]) -> VirtualPolynomial<F> {
-        let q = self.compute_q(z);
-        q.build_f_hat(beta).unwrap()
+        Ok(q_x)
     }
 
     /// Computes Q(x) = eq(beta, x) * q(x)
     ///               = eq(beta, x) * \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
     /// polynomial over x
-    pub fn compute_Q(&self, z: &[F], beta: &[F]) -> VirtualPolynomial<F> {
-        let eq_beta = build_eq_x_r_vec(beta).unwrap();
+    pub fn compute_Q(&self, z: &[F], beta: &[F]) -> Result<VirtualPolynomial<F>, Error> {
+        let eq_beta = build_eq_x_r_vec(beta)?;
         let eq_beta_mle = dense_vec_to_dense_mle(self.s, &eq_beta);
 
         let mut Q = VirtualPolynomial::<F>::new(self.s);
         for i in 0..self.q {
             let mut Q_k = vec![];
             for &j in self.S[i].iter() {
-                Q_k.push(dense_vec_to_dense_mle(
-                    self.s,
-                    &mat_vec_mul(&self.M[j], z).unwrap(),
-                ));
+                Q_k.push(dense_vec_to_dense_mle(self.s, &mat_vec_mul(&self.M[j], z)?));
             }
             Q_k.push(eq_beta_mle.clone());
-            Q.add_mle_list(Q_k.iter().map(|v| Arc::new(v.clone())), self.c[i])
-                .unwrap();
+            Q.add_mle_list(Q_k.iter().map(|v| Arc::new(v.clone())), self.c[i])?;
         }
-        Q
+        Ok(Q)
     }
 }
 
@@ -140,9 +110,10 @@ impl<C: CurveGroup> CCCS<C> {
             [vec![C::ScalarField::one()], self.x.clone(), w.w.to_vec()].concat();
 
         // A CCCS relation is satisfied if the q(x) multivariate polynomial evaluates to zero in the hypercube
-        let q_x = ccs.compute_q(&z);
+        let q_x = ccs.compute_q(&z)?;
+
         for x in BooleanHypercube::new(ccs.s) {
-            if !q_x.evaluate(&x).unwrap().is_zero() {
+            if !q_x.evaluate(&x)?.is_zero() {
                 return Err(Error::NotSatisfied);
             }
         }
@@ -169,7 +140,7 @@ pub mod tests {
         let ccs = get_test_ccs::<Fr>();
         let z = get_test_z(3);
 
-        let q = ccs.compute_q(&z);
+        let q = ccs.compute_q(&z).unwrap();
 
         // Evaluate inside the hypercube
         for x in BooleanHypercube::new(ccs.s) {
@@ -193,7 +164,7 @@ pub mod tests {
         let beta: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Compute Q(x) = eq(beta, x) * q(x).
-        let Q = ccs.compute_Q(&z, &beta);
+        let Q = ccs.compute_Q(&z, &beta).unwrap();
 
         // Let's consider the multilinear polynomial G(x) = \sum_{y \in {0, 1}^s} eq(x, y) q(y)
         // which interpolates the multivariate polynomial q(x) inside the hypercube.
@@ -226,9 +197,9 @@ pub mod tests {
 
         // Now test that if we create Q(x) with eq(d,y) where d is inside the hypercube, \sum Q(x) should be G(d) which
         // should be equal to q(d), since G(x) interpolates q(x) inside the hypercube
-        let q = ccs.compute_q(&z);
+        let q = ccs.compute_q(&z).unwrap();
         for d in BooleanHypercube::new(ccs.s) {
-            let Q_at_d = ccs.compute_Q(&z, &d);
+            let Q_at_d = ccs.compute_Q(&z, &d).unwrap();
 
             // Get G(d) by summing over Q_d(x) over the hypercube
             let G_at_d = BooleanHypercube::new(ccs.s)
@@ -239,7 +210,7 @@ pub mod tests {
 
         // Now test that they should disagree outside of the hypercube
         let r: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
-        let Q_at_r = ccs.compute_Q(&z, &r);
+        let Q_at_r = ccs.compute_Q(&z, &r).unwrap();
 
         // Get G(d) by summing over Q_d(x) over the hypercube
         let G_at_r = BooleanHypercube::new(ccs.s)

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -421,7 +421,8 @@ mod tests {
                 .map(|lcccs| lcccs.r_x.clone())
                 .collect(),
             &r_x_prime,
-        );
+        )
+        .unwrap();
 
         let cs = ConstraintSystem::<Fr>::new_ref();
         let mut vec_sigmas = Vec::new();

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -361,7 +361,7 @@ mod tests {
         commitment::{pedersen::Pedersen, CommitmentScheme},
         folding::hypernova::{
             nimfs::NIMFS,
-            utils::{compute_c, compute_sigmas_and_thetas},
+            utils::{compute_c, compute_sigmas_thetas},
         },
         transcript::{
             poseidon::{poseidon_canonical_config, PoseidonTranscript, PoseidonTranscriptVar},
@@ -409,7 +409,7 @@ mod tests {
             cccs_instances.push(inst);
         }
 
-        let sigmas_thetas = compute_sigmas_and_thetas(&ccs, &z_lcccs, &z_cccs, &r_x_prime);
+        let sigmas_thetas = compute_sigmas_thetas(&ccs, &z_lcccs, &z_cccs, &r_x_prime).unwrap();
 
         let expected_c = compute_c(
             &ccs,

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -200,7 +200,7 @@ where
         let beta: Vec<C::ScalarField> = transcript.get_challenges(ccs.s);
 
         // Compute g(x)
-        let g = compute_g(ccs, running_instances, &z_lcccs, &z_cccs, gamma, &beta);
+        let g = compute_g(ccs, running_instances, &z_lcccs, &z_cccs, gamma, &beta)?;
 
         // Step 3: Run the sumcheck prover
         let sumcheck_proof = IOPSumCheck::<C, T>::prove(&g, transcript)

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -336,7 +336,7 @@ where
                 .map(|lcccs| lcccs.r_x.clone())
                 .collect(),
             &r_x_prime,
-        );
+        )?;
 
         // check that the g(r_x') from the sumcheck proof is equal to the computed c from sigmas&thetas
         if c != sumcheck_subclaim.expected_evaluation {
@@ -345,9 +345,10 @@ where
 
         // Sanity check: we can also compute g(r_x') from the proof last evaluation value, and
         // should be equal to the previously obtained values.
-        let g_on_rxprime_from_sumcheck_last_eval =
-            DensePolynomial::from_coefficients_slice(&proof.sc_proof.proofs.last().unwrap().coeffs)
-                .evaluate(r_x_prime.last().unwrap());
+        let g_on_rxprime_from_sumcheck_last_eval = DensePolynomial::from_coefficients_slice(
+            &proof.sc_proof.proofs.last().ok_or(Error::Empty)?.coeffs,
+        )
+        .evaluate(r_x_prime.last().ok_or(Error::Empty)?);
         if g_on_rxprime_from_sumcheck_last_eval != c {
             return Err(Error::NotEqual);
         }

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -7,7 +7,7 @@ use ark_std::{One, Zero};
 
 use super::cccs::{Witness, CCCS};
 use super::lcccs::LCCCS;
-use super::utils::{compute_c, compute_g, compute_sigmas_and_thetas};
+use super::utils::{compute_c, compute_g, compute_sigmas_thetas};
 use crate::ccs::CCS;
 use crate::transcript::Transcript;
 use crate::utils::hypercube::BooleanHypercube;
@@ -244,7 +244,7 @@ where
         let r_x_prime = sumcheck_proof.point.clone();
 
         // Step 4: compute sigmas and thetas
-        let sigmas_thetas = compute_sigmas_and_thetas(ccs, &z_lcccs, &z_cccs, &r_x_prime);
+        let sigmas_thetas = compute_sigmas_thetas(ccs, &z_lcccs, &z_cccs, &r_x_prime)?;
 
         // Step 6: Get the folding challenge
         let rho_scalar = C::ScalarField::from_le_bytes_mod_order(b"rho");
@@ -395,7 +395,7 @@ pub mod tests {
         let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         let sigmas_thetas =
-            compute_sigmas_and_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime);
+            compute_sigmas_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime).unwrap();
 
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -7,7 +7,7 @@ use super::{CommittedInstance, Witness};
 use crate::ccs::r1cs::R1CS;
 use crate::commitment::CommitmentScheme;
 use crate::transcript::Transcript;
-use crate::utils::vec::*;
+use crate::utils::vec::{hadamard, mat_vec_mul, vec_add, vec_scalar_mul, vec_sub};
 use crate::Error;
 
 /// Implements the Non-Interactive Folding Scheme described in section 4 of
@@ -32,12 +32,12 @@ where
         let (A, B, C) = (r1cs.A.clone(), r1cs.B.clone(), r1cs.C.clone());
 
         // this is parallelizable (for the future)
-        let Az1 = mat_vec_mul_sparse(&A, z1)?;
-        let Bz1 = mat_vec_mul_sparse(&B, z1)?;
-        let Cz1 = mat_vec_mul_sparse(&C, z1)?;
-        let Az2 = mat_vec_mul_sparse(&A, z2)?;
-        let Bz2 = mat_vec_mul_sparse(&B, z2)?;
-        let Cz2 = mat_vec_mul_sparse(&C, z2)?;
+        let Az1 = mat_vec_mul(&A, z1)?;
+        let Bz1 = mat_vec_mul(&B, z1)?;
+        let Cz1 = mat_vec_mul(&C, z1)?;
+        let Az2 = mat_vec_mul(&A, z2)?;
+        let Bz2 = mat_vec_mul(&B, z2)?;
+        let Cz2 = mat_vec_mul(&C, z2)?;
 
         let Az1_Bz2 = hadamard(&Az1, &Bz2)?;
         let Az2_Bz1 = hadamard(&Az2, &Bz1)?;

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -370,9 +370,9 @@ fn lagrange_polys<F: PrimeField>(domain_n: GeneralEvaluationDomain<F>) -> Vec<De
 // f(w) in R1CS context. For the moment we use R1CS, in the future we will abstract this with a
 // trait
 fn eval_f<F: PrimeField>(r1cs: &R1CS<F>, w: &[F]) -> Result<Vec<F>, Error> {
-    let Az = mat_vec_mul_sparse(&r1cs.A, w)?;
-    let Bz = mat_vec_mul_sparse(&r1cs.B, w)?;
-    let Cz = mat_vec_mul_sparse(&r1cs.C, w)?;
+    let Az = mat_vec_mul(&r1cs.A, w)?;
+    let Bz = mat_vec_mul(&r1cs.B, w)?;
+    let Cz = mat_vec_mul(&r1cs.C, w)?;
     let AzBz = hadamard(&Az, &Bz)?;
     vec_sub(&AzBz, &Cz)
 }

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -68,6 +68,8 @@ pub enum Error {
     NewDomainFail,
     #[error("The number of folded steps must be greater than 1")]
     NotEnoughSteps,
+    #[error("Evaluation failed")]
+    EvaluationFail,
 
     // Commitment errors
     #[error("Pedersen parameters length is not sufficient (generators.len={0} < vector.len={1} unsatisfied)")]

--- a/folding-schemes/src/utils/espresso/virtual_polynomial.rs
+++ b/folding-schemes/src/utils/espresso/virtual_polynomial.rs
@@ -325,12 +325,15 @@ pub fn eq_eval<F: PrimeField>(x: &[F], y: &[F]) -> Result<F, ArithErrors> {
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<DenseMultilinearExtension<F>>, ArithErrors> {
+pub fn build_eq_x_r<F: PrimeField>(
+    r: &[F],
+) -> Result<Arc<DenseMultilinearExtension<F>>, ArithErrors> {
     let evals = build_eq_x_r_vec(r)?;
     let mle = DenseMultilinearExtension::from_evaluations_vec(r.len(), evals);
 
     Ok(Arc::new(mle))
 }
+
 /// This function build the eq(x, r) polynomial for any given r, and output the
 /// evaluation of eq(x, r) in its vector form.
 ///
@@ -338,7 +341,7 @@ fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<DenseMultilinearExtension<
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, ArithErrors> {
+pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, ArithErrors> {
     // we build eq(x,r) from its evaluations
     // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
     // for example, with num_vars = 4, x is a binary vector of 4, then

--- a/folding-schemes/src/utils/mle.rs
+++ b/folding-schemes/src/utils/mle.rs
@@ -1,6 +1,6 @@
 /// Some basic MLE utilities
 use ark_ff::PrimeField;
-use ark_poly::DenseMultilinearExtension;
+use ark_poly::{DenseMultilinearExtension, SparseMultilinearExtension};
 use ark_std::log2;
 
 use super::vec::SparseMatrix;
@@ -15,7 +15,7 @@ pub fn pad_matrix<F: PrimeField>(m: &SparseMatrix<F>) -> SparseMatrix<F> {
 
 /// Returns the dense multilinear extension from the given matrix, without modifying the original
 /// matrix.
-pub fn matrix_to_mle<F: PrimeField>(matrix: SparseMatrix<F>) -> DenseMultilinearExtension<F> {
+pub fn matrix_to_dense_mle<F: PrimeField>(matrix: SparseMatrix<F>) -> DenseMultilinearExtension<F> {
     let n_vars: usize = (log2(matrix.n_rows) + log2(matrix.n_cols)) as usize; // n_vars = s + s'
 
     // Matrices might need to get padded before turned into an MLE
@@ -30,11 +30,11 @@ pub fn matrix_to_mle<F: PrimeField>(matrix: SparseMatrix<F>) -> DenseMultilinear
     }
 
     // convert the dense vector into a mle
-    vec_to_mle(n_vars, &v)
+    vec_to_dense_mle(n_vars, &v)
 }
 
 /// Takes the n_vars and a dense vector and returns its dense MLE.
-pub fn vec_to_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> DenseMultilinearExtension<F> {
+pub fn vec_to_dense_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> DenseMultilinearExtension<F> {
     let v_padded: Vec<F> = if v.len() != (1 << n_vars) {
         // pad to 2^n_vars
         [
@@ -50,7 +50,35 @@ pub fn vec_to_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> DenseMultilinearExte
     DenseMultilinearExtension::<F>::from_evaluations_vec(n_vars, v_padded)
 }
 
-pub fn dense_vec_to_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> DenseMultilinearExtension<F> {
+/// Returns the sparse multilinear extension from the given matrix, without modifying the original
+/// matrix.
+pub fn matrix_to_mle<F: PrimeField>(m: SparseMatrix<F>) -> SparseMultilinearExtension<F> {
+    let n_rows = m.n_rows.next_power_of_two();
+    let n_cols = m.n_cols.next_power_of_two();
+    let n_vars: usize = (log2(n_rows) + log2(n_cols)) as usize; // n_vars = s + s'
+
+    // build the sparse vec representing the sparse matrix
+    let mut v: Vec<(usize, F)> = Vec::new();
+    for (i, row) in m.coeffs.iter().enumerate() {
+        for (val, j) in row.iter() {
+            v.push((i * n_cols + j, *val));
+        }
+    }
+
+    // convert the dense vector into a mle
+    vec_to_mle(n_vars, &v)
+}
+
+/// Takes the n_vars and a sparse vector and returns its sparse MLE.
+pub fn vec_to_mle<F: PrimeField>(n_vars: usize, v: &[(usize, F)]) -> SparseMultilinearExtension<F> {
+    SparseMultilinearExtension::<F>::from_evaluations(n_vars, v)
+}
+
+/// Takes the n_vars and a dense vector and returns its dense MLE.
+pub fn dense_vec_to_dense_mle<F: PrimeField>(
+    n_vars: usize,
+    v: &[F],
+) -> DenseMultilinearExtension<F> {
     // Pad to 2^n_vars
     let v_padded: Vec<F> = [
         v.to_owned(),
@@ -60,6 +88,16 @@ pub fn dense_vec_to_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> DenseMultiline
     ]
     .concat();
     DenseMultilinearExtension::<F>::from_evaluations_vec(n_vars, v_padded)
+}
+
+/// Takes the n_vars and a dense vector and returns its sparse MLE.
+pub fn dense_vec_to_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> SparseMultilinearExtension<F> {
+    let v_sparse = v
+        .iter()
+        .enumerate()
+        .map(|(i, v_i)| (i, *v_i))
+        .collect::<Vec<(usize, F)>>();
+    SparseMultilinearExtension::<F>::from_evaluations(n_vars, &v_sparse)
 }
 
 #[cfg(test)]
@@ -138,7 +176,7 @@ mod tests {
             vec![420, 4, 2, 0],
         ]);
 
-        let A_mle = matrix_to_mle(A.clone());
+        let A_mle = matrix_to_dense_mle(A.clone());
         let A = A.to_dense();
         let bhc = BooleanHypercube::new(2);
         for (i, y) in bhc.enumerate() {

--- a/folding-schemes/src/utils/mle.rs
+++ b/folding-schemes/src/utils/mle.rs
@@ -124,7 +124,8 @@ mod tests {
         ]);
 
         let A_mle = matrix_to_mle(A);
-        assert_eq!(A_mle.evaluations.len(), 16); // 4x4 matrix, thus 2bit x 2bit, thus 2^4=16 evals
+        assert_eq!(A_mle.evaluations.len(), 15); // 15 non-zero elements
+        assert_eq!(A_mle.num_vars, 4); // 4x4 matrix, thus 2bit x 2bit, thus 2^4=16 evals
 
         let A = to_F_matrix::<Fr>(vec![
             vec![2, 3, 4, 4, 1],
@@ -134,7 +135,8 @@ mod tests {
             vec![420, 4, 2, 0, 5],
         ]);
         let A_mle = matrix_to_mle(A.clone());
-        assert_eq!(A_mle.evaluations.len(), 64); // 5x5 matrix, thus 3bit x 3bit, thus 2^6=64 evals
+        assert_eq!(A_mle.evaluations.len(), 23); // 23 non-zero elements
+        assert_eq!(A_mle.num_vars, 6); // 5x5 matrix, thus 3bit x 3bit, thus 2^6=64 evals
 
         // check that the A_mle evaluated over the boolean hypercube equals the matrix A_i_j values
         let bhc = BooleanHypercube::new(A_mle.num_vars);


### PR DESCRIPTION
When we implemented the HyperNova multifolding (https://github.com/privacy-scaling-explorations/multifolding-poc) the focus was on understanding the protocol and the data structures, but not on making things run fast. When using real-world sized circuits, the hypernova methods implementations were taking too much computation time, since for example iterating over the full Boolean hypercube of size 16 takes too much time (>10min) and RAM.

This PR reimplements most of the HyperNova internal methods changing their approaches and reducing their computation times `>100x` depending on the method and the size.
(And the `>100x` is for matrices of size $2^9 \times 2^9$, where the real-world use case is of $2^{16} \times 2^{16}$, where the difference would be much more higher, but don't have enough RAM to compute the old version with those sizes to have concrete numbers. Thus the estimation is that probably the reduction for the real-world use case is about more than `1000x`).

| method                | matrix size   | old version seconds | new version seconds |
| --------------------- | ------------- | ------------------- | ------------------- |
| compute_g             | 2^8 x 2^8     | 16.48               | 0.16                |
| compute_g             | 2^9 x 2^9     | 122.62              | 0.51                |
| compute_Ls            | 2^8 x 2^8     | 9.73                | 0.11                |
| compute_Ls            | 2^9 x 2^9     | 67.16               | 0.38                |
| to_lcccs              | 2^8 x 2^8     | 4.56                | 0.21                |
| to_lcccs              | 2^9 x 2^9     | 67.65               | 0.84                |
| compute_sigmas_thetas | 2^8 x 2^8     | 12.86               | 0.13                |
| compute_sigmas_thetas | 2^9 x 2^9     | 100.01              | 0.51                |
| compute_Q             | 2^8 x 2^8     | 4.49                | 0.07                |
| compute_Q             | 2^9 x 2^9     | 70.77               | 0.55                |
