### PR TITLE
Add multi-instances folding to AugmentedFCircuit & IVC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Folding schemes implemented:
 
 - [Nova: Recursive Zero-Knowledge Arguments from Folding Schemes](https://eprint.iacr.org/2021/370.pdf), Abhiram Kothapalli, Srinath Setty, Ioanna Tzialla. 2021
 - [CycleFold: Folding-scheme-based recursive arguments over a cycle of elliptic curves](https://eprint.iacr.org/2023/1192.pdf), Abhiram Kothapalli, Srinath Setty. 2023
+- [HyperNova: Recursive arguments for customizable constraint systems](https://eprint.iacr.org/2023/573.pdf), Abhiram Kothapalli, Srinath Setty. 2023
 
 Work in progress:
 
-- [HyperNova: Recursive arguments for customizable constraint systems](https://eprint.iacr.org/2023/573.pdf), Abhiram Kothapalli, Srinath Setty. 2023
 - [ProtoGalaxy: Efficient ProtoStar-style folding of multiple instances](https://eprint.iacr.org/2023/1106.pdf), Liam Eagen, Ariel Gabizon. 2023
 
 ## Available frontends

--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -85,7 +85,7 @@ fn main() {
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
-    let mut nova = N::init(nova_params.clone(), f_circuit.clone(), z_0).unwrap();
+    let mut nova = N::init(&nova_params, f_circuit.clone(), z_0).unwrap();
 
     // prepare the Decider prover & verifier params
     let (decider_pp, decider_vp) = D::preprocess(&mut rng, &nova_params, nova.clone()).unwrap();
@@ -93,7 +93,7 @@ fn main() {
     // run n steps of the folding iteration
     for (i, external_inputs_at_step) in external_inputs.iter().enumerate() {
         let start = Instant::now();
-        nova.prove_step(rng, external_inputs_at_step.clone())
+        nova.prove_step(rng, external_inputs_at_step.clone(), None)
             .unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -190,14 +190,13 @@ fn main() {
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
 
     println!("Initialize FoldingScheme");
-    let mut folding_scheme =
-        N::init(nova_params.clone(), F_circuit, initial_state.clone()).unwrap();
+    let mut folding_scheme = N::init(&nova_params, F_circuit, initial_state.clone()).unwrap();
 
     // compute a step of the IVC
     for (i, external_inputs_at_step) in external_inputs.iter().enumerate() {
         let start = Instant::now();
         folding_scheme
-            .prove_step(rng, external_inputs_at_step.clone())
+            .prove_step(rng, external_inputs_at_step.clone(), None)
             .unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -102,7 +102,7 @@ fn main() {
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
-    let mut nova = N::init(nova_params.clone(), f_circuit, z_0).unwrap();
+    let mut nova = N::init(&nova_params, f_circuit, z_0).unwrap();
 
     // prepare the Decider prover & verifier params
     let (decider_pp, decider_vp) = D::preprocess(&mut rng, &nova_params, nova.clone()).unwrap();
@@ -110,7 +110,7 @@ fn main() {
     // run n steps of the folding iteration
     for i in 0..n_steps {
         let start = Instant::now();
-        nova.prove_step(rng, vec![]).unwrap();
+        nova.prove_step(rng, vec![], None).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -144,13 +144,12 @@ fn main() {
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
 
     println!("Initialize FoldingScheme");
-    let mut folding_scheme =
-        N::init(nova_params.clone(), F_circuit, initial_state.clone()).unwrap();
+    let mut folding_scheme = N::init(&nova_params, F_circuit, initial_state.clone()).unwrap();
 
     // compute a step of the IVC
     for i in 0..num_steps {
         let start = Instant::now();
-        folding_scheme.prove_step(rng, vec![]).unwrap();
+        folding_scheme.prove_step(rng, vec![], None).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/noname_full_flow.rs
+++ b/examples/noname_full_flow.rs
@@ -86,7 +86,7 @@ fn main() {
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
 
     // initialize the folding scheme engine, in our case we use Nova
-    let mut nova = N::init(nova_params.clone(), f_circuit.clone(), z_0).unwrap();
+    let mut nova = N::init(&nova_params, f_circuit.clone(), z_0).unwrap();
 
     // prepare the Decider prover & verifier params
     let (decider_pp, decider_vp) = D::preprocess(&mut rng, &nova_params, nova.clone()).unwrap();
@@ -94,7 +94,7 @@ fn main() {
     // run n steps of the folding iteration
     for (i, external_inputs_at_step) in external_inputs.iter().enumerate() {
         let start = Instant::now();
-        nova.prove_step(rng, external_inputs_at_step.clone())
+        nova.prove_step(rng, external_inputs_at_step.clone(), None)
             .unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -129,12 +129,11 @@ fn main() {
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params).unwrap();
 
     println!("Initialize FoldingScheme");
-    let mut folding_scheme =
-        N::init(nova_params.clone(), F_circuit, initial_state.clone()).unwrap();
+    let mut folding_scheme = N::init(&nova_params, F_circuit, initial_state.clone()).unwrap();
     // compute a step of the IVC
     for i in 0..num_steps {
         let start = Instant::now();
-        folding_scheme.prove_step(rng, vec![]).unwrap();
+        folding_scheme.prove_step(rng, vec![], None).unwrap();
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/folding-schemes/src/arith/ccs.rs
+++ b/folding-schemes/src/arith/ccs.rs
@@ -67,7 +67,7 @@ impl<F: PrimeField> Arith<F> for CCS<F> {
         Ok(())
     }
 
-    fn params_to_bytes(&self) -> Vec<u8> {
+    fn params_to_le_bytes(&self) -> Vec<u8> {
         [
             self.l.to_le_bytes(),
             self.m.to_le_bytes(),

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -11,5 +11,5 @@ pub trait Arith<F: PrimeField> {
 
     /// Returns the bytes that represent the parameters, that is, the matrices sizes, the amount of
     /// public inputs, etc, without the matrices/polynomials values.
-    fn params_to_bytes(&self) -> Vec<u8>;
+    fn params_to_le_bytes(&self) -> Vec<u8>;
 }

--- a/folding-schemes/src/arith/r1cs.rs
+++ b/folding-schemes/src/arith/r1cs.rs
@@ -28,7 +28,7 @@ impl<F: PrimeField> Arith<F> for R1CS<F> {
         Ok(())
     }
 
-    fn params_to_bytes(&self) -> Vec<u8> {
+    fn params_to_le_bytes(&self) -> Vec<u8> {
         [
             self.l.to_le_bytes(),
             self.A.n_rows.to_le_bytes(),

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -21,11 +21,8 @@ use cccs::CCCS;
 use lcccs::LCCCS;
 use nimfs::NIMFS;
 
-use crate::arith::{
-    ccs::CCS,
-    r1cs::{extract_w_x, R1CS},
-};
 use crate::commitment::CommitmentScheme;
+use crate::constants::N_BITS_RO;
 use crate::folding::circuits::{
     cyclefold::{fold_cyclefold_circuit, CycleFoldCircuit},
     CF2,
@@ -37,7 +34,13 @@ use crate::folding::nova::{
 use crate::frontend::FCircuit;
 use crate::utils::{get_cm_coordinates, pp_hash};
 use crate::Error;
-use crate::FoldingScheme;
+use crate::{
+    arith::{
+        ccs::CCS,
+        r1cs::{extract_w_x, R1CS},
+    },
+    FoldingScheme, MultiFolding,
+};
 
 /// Witness for the LCCCS & CCCS, containing the w vector, and the r_w used as randomness in the Pedersen commitment.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -70,6 +73,8 @@ where
     pub cf_cs_params: CS2::ProverParams,
     // if ccs is set, it will be used, if not, it will be computed at runtime
     pub ccs: Option<CCS<C1::ScalarField>>,
+    pub mu: usize,
+    pub nu: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -136,6 +141,8 @@ where
     pub F: FC,
     /// public params hash
     pub pp_hash: C1::ScalarField,
+    pub mu: usize, // number of LCCCS instances to be folded
+    pub nu: usize, // number of CCCS instances to be folded
     pub i: C1::ScalarField,
     /// initial state
     pub z_0: Vec<C1::ScalarField>,
@@ -150,6 +157,180 @@ where
     /// CycleFold running instance
     pub cf_W_i: NovaWitness<C2>,
     pub cf_U_i: CommittedInstance<C2>,
+}
+
+impl<C1, GC1, C2, GC2, FC, CS1, CS2> MultiFolding<C1, C2, FC>
+    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2>
+where
+    C1: CurveGroup,
+    GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
+    C2: CurveGroup,
+    GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
+    FC: FCircuit<C1::ScalarField>,
+    CS1: CommitmentScheme<C1>,
+    CS2: CommitmentScheme<C2>,
+    <C1 as CurveGroup>::BaseField: PrimeField,
+    <C2 as CurveGroup>::BaseField: PrimeField,
+    <C1 as Group>::ScalarField: Absorb,
+    <C2 as Group>::ScalarField: Absorb,
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    for<'a> &'a GC1: GroupOpsBounds<'a, C1, GC1>,
+    for<'a> &'a GC2: GroupOpsBounds<'a, C2, GC2>,
+{
+    type RunningInstance = (LCCCS<C1>, Witness<C1::ScalarField>);
+    type IncomingInstance = (CCCS<C1>, Witness<C1::ScalarField>);
+    type MultiInstance = (Vec<Self::RunningInstance>, Vec<Self::IncomingInstance>);
+
+    /// Creates a new LCCS instance for the given state, which satisfies the HyperNova.CCS. This
+    /// method can be used to generate the 'other' LCCS instances to be folded in the multi-folding
+    /// step.
+    fn new_running_instance(
+        &self,
+        mut rng: impl RngCore,
+        state: Vec<C1::ScalarField>,
+        external_inputs: Vec<C1::ScalarField>,
+    ) -> Result<Self::RunningInstance, Error> {
+        let r1cs_z = self.new_instance_generic(state, external_inputs)?;
+        // compute committed instances, w_{i+1}, u_{i+1}, which will be used as w_i, u_i, so we
+        // assign them directly to w_i, u_i.
+        let (U_i, W_i) = self
+            .ccs
+            .to_lcccs::<_, _, CS1>(&mut rng, &self.cs_params, &r1cs_z)?;
+
+        #[cfg(test)]
+        U_i.check_relation(&self.ccs, &W_i)?;
+
+        Ok((U_i, W_i))
+    }
+
+    /// Creates a new CCCS instance for the given state, which satisfies the HyperNova.CCS. This
+    /// method can be used to generate the 'other' CCCS instances to be folded in the multi-folding
+    /// step.
+    fn new_incoming_instance(
+        &self,
+        mut rng: impl RngCore,
+        state: Vec<C1::ScalarField>,
+        external_inputs: Vec<C1::ScalarField>,
+    ) -> Result<Self::IncomingInstance, Error> {
+        let r1cs_z = self.new_instance_generic(state, external_inputs)?;
+        // compute committed instances, w_{i+1}, u_{i+1}, which will be used as w_i, u_i, so we
+        // assign them directly to w_i, u_i.
+        let (u_i, w_i) = self
+            .ccs
+            .to_cccs::<_, _, CS1>(&mut rng, &self.cs_params, &r1cs_z)?;
+
+        #[cfg(test)]
+        u_i.check_relation(&self.ccs, &w_i)?;
+
+        Ok((u_i, w_i))
+    }
+}
+
+impl<C1, GC1, C2, GC2, FC, CS1, CS2> HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2>
+where
+    C1: CurveGroup,
+    GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
+    C2: CurveGroup,
+    GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
+    FC: FCircuit<C1::ScalarField>,
+    CS1: CommitmentScheme<C1>,
+    CS2: CommitmentScheme<C2>,
+    <C1 as CurveGroup>::BaseField: PrimeField,
+    <C2 as CurveGroup>::BaseField: PrimeField,
+    <C1 as Group>::ScalarField: Absorb,
+    <C2 as Group>::ScalarField: Absorb,
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    for<'a> &'a GC1: GroupOpsBounds<'a, C1, GC1>,
+    for<'a> &'a GC2: GroupOpsBounds<'a, C2, GC2>,
+{
+    /// internal helper for new_running_instance & new_incoming_instance methods, returns the R1CS
+    /// z=[u,x,w] vector to be used to create the LCCCS & CCCS fresh instances.
+    fn new_instance_generic(
+        &self,
+        state: Vec<C1::ScalarField>,
+        external_inputs: Vec<C1::ScalarField>,
+    ) -> Result<Vec<C1::ScalarField>, Error> {
+        // prepare the initial dummy instances
+        let U_i = LCCCS::<C1>::dummy(self.ccs.l, self.ccs.t, self.ccs.s);
+        let mut u_i = CCCS::<C1>::dummy(self.ccs.l);
+        let (_, cf_U_i): (NovaWitness<C2>, CommittedInstance<C2>) = self.cf_r1cs.dummy_instance();
+
+        let sponge = PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
+
+        u_i.x = vec![
+            U_i.hash(
+                &sponge,
+                self.pp_hash,
+                C1::ScalarField::zero(), // i
+                self.z_0.clone(),
+                state.clone(),
+            ),
+            cf_U_i.hash_cyclefold(&sponge, self.pp_hash),
+        ];
+        let us = vec![u_i.clone(); self.nu - 1];
+
+        let z_i1 = self
+            .F
+            .step_native(0, state.clone(), external_inputs.clone())?;
+
+        // compute u_{i+1}.x
+        let U_i1 = LCCCS::dummy(self.ccs.l, self.ccs.t, self.ccs.s);
+        let u_i1_x = U_i1.hash(
+            &sponge,
+            self.pp_hash,
+            C1::ScalarField::one(), // i+1, where i=0
+            self.z_0.clone(),
+            z_i1.clone(),
+        );
+
+        let cf_u_i1_x = cf_U_i.hash_cyclefold(&sponge, self.pp_hash);
+        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC> {
+            _c2: PhantomData,
+            _gc2: PhantomData,
+            poseidon_config: self.poseidon_config.clone(),
+            ccs: self.ccs.clone(),
+            pp_hash: Some(self.pp_hash),
+            mu: self.mu,
+            nu: self.nu,
+            i: Some(C1::ScalarField::zero()),
+            i_usize: Some(0),
+            z_0: Some(self.z_0.clone()),
+            z_i: Some(state.clone()),
+            external_inputs: Some(external_inputs),
+            U_i: Some(U_i.clone()),
+            Us: None,
+            u_i_C: Some(u_i.C),
+            us: Some(us),
+            U_i1_C: Some(U_i1.C),
+            F: self.F.clone(),
+            x: Some(u_i1_x),
+            nimfs_proof: None,
+
+            // cyclefold values
+            cf_u_i_cmW: None,
+            cf_U_i: None,
+            cf_x: Some(cf_u_i1_x),
+            cf_cmT: None,
+        };
+
+        let (cs, _) = augmented_f_circuit.compute_cs_ccs()?;
+
+        #[cfg(test)]
+        assert!(cs.is_satisfied()?);
+
+        let (r1cs_w_i1, r1cs_x_i1) = extract_w_x::<C1::ScalarField>(&cs); // includes 1 and public inputs
+
+        #[cfg(test)]
+        assert_eq!(r1cs_x_i1[0], augmented_f_circuit.x.unwrap());
+
+        let r1cs_z = [
+            vec![C1::ScalarField::one()],
+            r1cs_x_i1.clone(),
+            r1cs_w_i1.clone(),
+        ]
+        .concat();
+        Ok(r1cs_z)
+    }
 }
 
 impl<C1, GC1, C2, GC2, FC, CS1, CS2> FoldingScheme<C1, C2, FC>
@@ -170,25 +351,37 @@ where
     for<'a> &'a GC1: GroupOpsBounds<'a, C1, GC1>,
     for<'a> &'a GC2: GroupOpsBounds<'a, C2, GC2>,
 {
-    type PreprocessorParam = PreprocessorParam<C1, C2, FC, CS1, CS2>;
+    /// Reuse Nova's PreprocessorParam, together with two usize values, which are mu & nu
+    /// respectively, which indicate the amount of LCCCS & CCCS instances to be folded at each
+    /// folding step.
+    type PreprocessorParam = (PreprocessorParam<C1, C2, FC, CS1, CS2>, usize, usize);
     type ProverParam = ProverParams<C1, C2, CS1, CS2>;
     type VerifierParam = VerifierParams<C1, C2, CS1, CS2>;
     type RunningInstance = (LCCCS<C1>, Witness<C1::ScalarField>);
     type IncomingInstance = (CCCS<C1>, Witness<C1::ScalarField>);
+    type MultiCommittedInstanceWithWitness =
+        (Vec<Self::RunningInstance>, Vec<Self::IncomingInstance>);
     type CFInstance = (CommittedInstance<C2>, NovaWitness<C2>);
 
     fn preprocess(
         mut rng: impl RngCore,
         prep_param: &Self::PreprocessorParam,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
+        let (prep_param, mu, nu) = prep_param;
+        if *mu < 1 || *nu < 1 {
+            return Err(Error::CantBeZero("mu,nu".to_string()));
+        }
+
         let augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC>::empty(
             &prep_param.poseidon_config,
             prep_param.F.clone(),
             None,
+            *mu,
+            *nu,
         )?;
         let ccs = augmented_f_circuit.ccs.clone();
 
-        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty();
+        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty(mu + nu);
         let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
 
         // if cs params exist, use them, if not, generate new ones
@@ -215,6 +408,8 @@ where
             cs_params: cs_pp.clone(),
             cf_cs_params: cf_cs_pp.clone(),
             ccs: Some(ccs.clone()),
+            mu: *mu,
+            nu: *nu,
         };
         let vp = VerifierParams::<C1, C2, CS1, CS2> {
             poseidon_config: prep_param.poseidon_config.clone(),
@@ -228,11 +423,15 @@ where
 
     /// Initializes the HyperNova+CycleFold's IVC for the given parameters and initial state `z_0`.
     fn init(
-        params: (Self::ProverParam, Self::VerifierParam),
+        params: &(Self::ProverParam, Self::VerifierParam),
         F: FC,
         z_0: Vec<C1::ScalarField>,
     ) -> Result<Self, Error> {
         let (pp, vp) = params;
+        if pp.mu < 1 || pp.nu < 1 {
+            return Err(Error::CantBeZero("mu,nu".to_string()));
+        }
+
         // `sponge` is for digest computation.
         let sponge = PoseidonSponge::<C1::ScalarField>::new(&pp.poseidon_config);
 
@@ -242,10 +441,12 @@ where
             &pp.poseidon_config,
             F.clone(),
             pp.ccs.clone(),
+            pp.mu,
+            pp.nu,
         )?;
         let ccs = augmented_f_circuit.ccs.clone();
 
-        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty();
+        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty(pp.mu + pp.nu);
         let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
 
         // compute the public params hash
@@ -282,6 +483,8 @@ where
             cf_cs_params: pp.cf_cs_params.clone(),
             F,
             pp_hash,
+            mu: pp.mu,
+            nu: pp.nu,
             i: C1::ScalarField::zero(),
             z_0: z_0.clone(),
             z_i: z_0,
@@ -300,9 +503,41 @@ where
         &mut self,
         mut rng: impl RngCore,
         external_inputs: Vec<C1::ScalarField>,
+        other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error> {
         // `sponge` is for digest computation.
         let sponge = PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
+
+        let other_instances = other_instances.ok_or(Error::MissingOtherInstances)?;
+
+        #[allow(clippy::type_complexity)]
+        let (lcccs, cccs): (
+            Vec<(LCCCS<C1>, Witness<C1::ScalarField>)>,
+            Vec<(CCCS<C1>, Witness<C1::ScalarField>)>,
+        ) = other_instances;
+
+        // recall, mu & nu is the number of all the LCCCS & CCCS respectively, including the
+        // running and incoming instances that are not part of the 'other_instances', hence the +1
+        // in the couple of following checks.
+        if lcccs.len() + 1 != self.mu {
+            return Err(Error::NotSameLength(
+                "other_instances.lcccs.len()".to_string(),
+                lcccs.len(),
+                "hypernova.mu".to_string(),
+                self.mu,
+            ));
+        }
+        if cccs.len() + 1 != self.nu {
+            return Err(Error::NotSameLength(
+                "other_instances.cccs.len()".to_string(),
+                cccs.len(),
+                "hypernova.nu".to_string(),
+                self.nu,
+            ));
+        }
+
+        let (Us, Ws): (Vec<LCCCS<C1>>, Vec<Witness<C1::ScalarField>>) = lcccs.into_iter().unzip();
+        let (us, ws): (Vec<CCCS<C1>>, Vec<Witness<C1::ScalarField>>) = cccs.into_iter().unzip();
 
         let augmented_f_circuit: AugmentedFCircuit<C1, C2, GC2, FC>;
 
@@ -361,13 +596,17 @@ where
                 poseidon_config: self.poseidon_config.clone(),
                 ccs: self.ccs.clone(),
                 pp_hash: Some(self.pp_hash),
+                mu: self.mu,
+                nu: self.nu,
                 i: Some(C1::ScalarField::zero()),
                 i_usize: Some(0),
                 z_0: Some(self.z_0.clone()),
                 z_i: Some(self.z_i.clone()),
                 external_inputs: Some(external_inputs.clone()),
-                u_i_C: Some(self.u_i.C),
                 U_i: Some(self.U_i.clone()),
+                Us: Some(Us.clone()),
+                u_i_C: Some(self.u_i.C),
+                us: Some(us.clone()),
                 U_i1_C: Some(U_i1.C),
                 F: self.F.clone(),
                 x: Some(u_i1_x),
@@ -383,15 +622,15 @@ where
             let mut transcript_p: PoseidonSponge<C1::ScalarField> =
                 PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
             transcript_p.absorb(&self.pp_hash);
-            let (rho_bits, nimfs_proof);
-            (nimfs_proof, U_i1, W_i1, rho_bits) =
+            let (rho_powers, nimfs_proof);
+            (nimfs_proof, U_i1, W_i1, rho_powers) =
                 NIMFS::<C1, PoseidonSponge<C1::ScalarField>>::prove(
                     &mut transcript_p,
                     &self.ccs,
-                    &[self.U_i.clone()],
-                    &[self.u_i.clone()],
-                    &[self.W_i.clone()],
-                    &[self.w_i.clone()],
+                    &[vec![self.U_i.clone()], Us.clone()].concat(),
+                    &[vec![self.u_i.clone()], us.clone()].concat(),
+                    &[vec![self.W_i.clone()], Ws].concat(),
+                    &[vec![self.w_i.clone()], ws].concat(),
                 )?;
 
             // sanity check: check the folded instance relation
@@ -406,29 +645,60 @@ where
                 z_i1.clone(),
             );
 
-            let rho_Fq = C2::ScalarField::from_bigint(BigInteger::from_bits_le(&rho_bits))
-                .ok_or(Error::OutOfBounds)?;
+            let rho_powers_Fq: Vec<C1::BaseField> = rho_powers
+                .iter()
+                .map(|rho_i| {
+                    C1::BaseField::from_bigint(BigInteger::from_bits_le(
+                        &rho_i.into_bigint().to_bits_le(),
+                    ))
+                    .unwrap()
+                })
+                .collect();
+            let rho_powers_bits: Vec<Vec<bool>> = rho_powers
+                .iter()
+                .map(|rho_i| rho_i.into_bigint().to_bits_le()[..N_BITS_RO].to_vec())
+                .collect();
+
             // CycleFold part:
-            // get the vector used as public inputs 'x' in the CycleFold circuit
-            // cyclefold circuit for cmW
+            // get the vector used as public inputs 'x' in the CycleFold circuit.
+            // Place the random values and the points coordinates as the public input x:
+            // In Nova, this is: x == [r, p1, p2, p3].
+            // In multifolding schemes such as HyperNova, this is:
+            // computed_x = [r_0, r_1, r_2, ...,  r_n, p_0, p_1, p_2, ..., p_n],
+            // where each p_i is in fact p_i.to_constraint_field()
             let cf_u_i_x = [
-                vec![rho_Fq],
+                rho_powers_Fq,
                 get_cm_coordinates(&self.U_i.C),
+                Us.iter()
+                    .flat_map(|Us_i| get_cm_coordinates(&Us_i.C))
+                    .collect(),
                 get_cm_coordinates(&self.u_i.C),
+                us.iter()
+                    .flat_map(|us_i| get_cm_coordinates(&us_i.C))
+                    .collect(),
                 get_cm_coordinates(&U_i1.C),
             ]
             .concat();
 
             let cf_circuit = CycleFoldCircuit::<C1, GC1> {
                 _gc: PhantomData,
-                r_bits: Some(rho_bits.clone()),
-                p1: Some(self.U_i.clone().C),
-                p2: Some(self.u_i.clone().C),
+                n_points: self.mu + self.nu,
+                r_bits: Some(rho_powers_bits.clone()),
+                points: Some(
+                    [
+                        vec![self.U_i.clone().C],
+                        Us.iter().map(|Us_i| Us_i.C).collect(),
+                        vec![self.u_i.clone().C],
+                        us.iter().map(|us_i| us_i.C).collect(),
+                    ]
+                    .concat(),
+                ),
                 x: Some(cf_u_i_x.clone()),
             };
 
             let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
                 fold_cyclefold_circuit::<C1, GC1, C2, GC2, FC, CS1, CS2>(
+                    self.mu + self.nu,
                     &mut transcript_p,
                     self.cf_r1cs.clone(),
                     self.cf_cs_params.clone(),
@@ -447,13 +717,17 @@ where
                 poseidon_config: self.poseidon_config.clone(),
                 ccs: self.ccs.clone(),
                 pp_hash: Some(self.pp_hash),
+                mu: self.mu,
+                nu: self.nu,
                 i: Some(self.i),
                 i_usize: Some(i_usize),
                 z_0: Some(self.z_0.clone()),
                 z_i: Some(self.z_i.clone()),
                 external_inputs: Some(external_inputs),
-                u_i_C: Some(self.u_i.C),
                 U_i: Some(self.U_i.clone()),
+                Us: Some(Us.clone()),
+                u_i_C: Some(self.u_i.C),
+                us: Some(us.clone()),
                 U_i1_C: Some(U_i1.C),
                 F: self.F.clone(),
                 x: Some(u_i1_x),
@@ -618,31 +892,48 @@ mod tests {
 
         type HN<CS1, CS2> =
             HyperNova<Projective, GVar, Projective2, GVar2, CubicFCircuit<Fr>, CS1, CS2>;
+        let (mu, nu) = (2, 3);
 
         let prep_param =
             PreprocessorParam::<Projective, Projective2, CubicFCircuit<Fr>, CS1, CS2>::new(
                 poseidon_config.clone(),
                 F_circuit,
             );
-        let (prover_params, verifier_params) = HN::preprocess(&mut rng, &prep_param).unwrap();
+        let hypernova_params = HN::preprocess(&mut rng, &(prep_param, mu, nu)).unwrap();
 
         let z_0 = vec![Fr::from(3_u32)];
-        let mut hypernova = HN::init(
-            (prover_params, verifier_params.clone()),
-            F_circuit,
-            z_0.clone(),
-        )
-        .unwrap();
+        let mut hypernova = HN::init(&hypernova_params, F_circuit, z_0.clone()).unwrap();
 
         let num_steps: usize = 3;
         for _ in 0..num_steps {
-            hypernova.prove_step(&mut rng, vec![]).unwrap();
+            // prepare some new instances to fold in the multifolding step
+            let mut lcccs = vec![];
+            for j in 0..mu - 1 {
+                let instance_state = vec![Fr::from(j as u32 + 85_u32)];
+                let (U, W) = hypernova
+                    .new_running_instance(&mut rng, instance_state, vec![])
+                    .unwrap();
+                lcccs.push((U, W));
+            }
+            let mut cccs = vec![];
+            for j in 0..nu - 1 {
+                let instance_state = vec![Fr::from(j as u32 + 15_u32)];
+                let (u, w) = hypernova
+                    .new_incoming_instance(&mut rng, instance_state, vec![])
+                    .unwrap();
+                cccs.push((u, w));
+            }
+
+            dbg!(&hypernova.i);
+            hypernova
+                .prove_step(&mut rng, vec![], Some((lcccs, cccs)))
+                .unwrap();
         }
         assert_eq!(Fr::from(num_steps as u32), hypernova.i);
 
         let (running_instance, incoming_instance, cyclefold_instance) = hypernova.instances();
         HN::verify(
-            verifier_params,
+            hypernova_params.1, // verifier_params
             z_0,
             hypernova.z_i,
             hypernova.i,

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -20,11 +20,11 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, Namespace,
 use ark_std::{fmt::Debug, One, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
-use super::CommittedInstance;
+use super::{CommittedInstance, NOVA_CF_N_POINTS};
 use crate::constants::N_BITS_RO;
 use crate::folding::circuits::{
     cyclefold::{
-        CycleFoldChallengeGadget, CycleFoldCommittedInstanceVar, NIFSFullGadget, CF_IO_LEN,
+        cf_io_len, CycleFoldChallengeGadget, CycleFoldCommittedInstanceVar, NIFSFullGadget,
     },
     nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
     CF1, CF2,
@@ -337,7 +337,7 @@ where
         let cmT =
             NonNativeAffineVar::new_witness(cs.clone(), || Ok(self.cmT.unwrap_or_else(C1::zero)))?;
 
-        let cf_u_dummy = CommittedInstance::dummy(CF_IO_LEN);
+        let cf_u_dummy = CommittedInstance::dummy(cf_io_len(NOVA_CF_N_POINTS));
         let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
             Ok(self.cf_U_i.unwrap_or(cf_u_dummy.clone()))
         })?;

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -361,12 +361,12 @@ pub mod tests {
         let nova_params = N::preprocess(&mut rng, &prep_param).unwrap();
 
         let start = Instant::now();
-        let mut nova = N::init(nova_params.clone(), F_circuit, z_0.clone()).unwrap();
+        let mut nova = N::init(&nova_params, F_circuit, z_0.clone()).unwrap();
         println!("Nova initialized, {:?}", start.elapsed());
         let start = Instant::now();
-        nova.prove_step(&mut rng, vec![]).unwrap();
+        nova.prove_step(&mut rng, vec![], None).unwrap();
         println!("prove_step, {:?}", start.elapsed());
-        nova.prove_step(&mut rng, vec![]).unwrap(); // do a 2nd step
+        nova.prove_step(&mut rng, vec![], None).unwrap(); // do a 2nd step
 
         let mut rng = rand::rngs::OsRng;
 

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -37,6 +37,10 @@ use circuits::{AugmentedFCircuit, ChallengeGadget};
 use nifs::NIFS;
 use traits::NovaR1CS;
 
+/// Number of points to be folded in the CycleFold circuit, in Nova's case, this is a fixed amount:
+/// 2 points to be folded.
+const NOVA_CF_N_POINTS: usize = 2_usize;
+
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct CommittedInstance<C: CurveGroup> {
     pub cmE: C,
@@ -344,6 +348,7 @@ where
     type VerifierParam = VerifierParams<C1, C2, CS1, CS2>;
     type RunningInstance = (CommittedInstance<C1>, Witness<C1>);
     type IncomingInstance = (CommittedInstance<C1>, Witness<C1>);
+    type MultiCommittedInstanceWithWitness = ();
     type CFInstance = (CommittedInstance<C2>, Witness<C2>);
 
     fn preprocess(
@@ -390,7 +395,7 @@ where
 
     /// Initializes the Nova+CycleFold's IVC for the given parameters and initial state `z_0`.
     fn init(
-        params: (Self::ProverParam, Self::VerifierParam),
+        params: &(Self::ProverParam, Self::VerifierParam),
         F: FC,
         z_0: Vec<C1::ScalarField>,
     ) -> Result<Self, Error> {
@@ -402,7 +407,7 @@ where
 
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, GC2, FC>::empty(&pp.poseidon_config, F.clone());
-        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty();
+        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty(NOVA_CF_N_POINTS);
 
         augmented_F_circuit.generate_constraints(cs.clone())?;
         cs.finalize();
@@ -452,6 +457,8 @@ where
         &mut self,
         _rng: impl RngCore,
         external_inputs: Vec<C1::ScalarField>,
+        // Nova does not support multi-instances folding
+        _other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error> {
         // `sponge` is for digest computation.
         let sponge = PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
@@ -459,6 +466,11 @@ where
         let mut transcript = sponge.clone();
 
         let augmented_F_circuit: AugmentedFCircuit<C1, C2, GC2, FC>;
+
+        // Nova does not support (by design) multi-instances folding
+        if _other_instances.is_some() {
+            return Err(Error::NoMultiInstances);
+        }
 
         if self.z_i.len() != self.F.state_len() {
             return Err(Error::NotSameLength(
@@ -572,16 +584,16 @@ where
 
             let cfW_circuit = CycleFoldCircuit::<C1, GC1> {
                 _gc: PhantomData,
-                r_bits: Some(r_bits.clone()),
-                p1: Some(self.U_i.clone().cmW),
-                p2: Some(self.u_i.clone().cmW),
+                n_points: NOVA_CF_N_POINTS,
+                r_bits: Some(vec![r_bits.clone()]),
+                points: Some(vec![self.U_i.clone().cmW, self.u_i.clone().cmW]),
                 x: Some(cfW_u_i_x.clone()),
             };
             let cfE_circuit = CycleFoldCircuit::<C1, GC1> {
                 _gc: PhantomData,
-                r_bits: Some(r_bits.clone()),
-                p1: Some(self.U_i.clone().cmE),
-                p2: Some(cmT),
+                n_points: NOVA_CF_N_POINTS,
+                r_bits: Some(vec![r_bits.clone()]),
+                points: Some(vec![self.U_i.clone().cmE, cmT]),
                 x: Some(cfE_u_i_x.clone()),
             };
 
@@ -820,6 +832,7 @@ where
         Error,
     > {
         fold_cyclefold_circuit::<C1, GC1, C2, GC2, FC, CS1, CS2>(
+            NOVA_CF_N_POINTS,
             transcript,
             self.cf_r1cs.clone(),
             self.cf_cs_pp.clone(),
@@ -866,7 +879,7 @@ where
 {
     let augmented_F_circuit =
         AugmentedFCircuit::<C1, C2, GC2, FC>::empty(poseidon_config, F_circuit);
-    let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty();
+    let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty(NOVA_CF_N_POINTS);
     let r1cs = get_r1cs_from_cs::<C1::ScalarField>(augmented_F_circuit)?;
     let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
     Ok((r1cs, cf_r1cs))
@@ -944,11 +957,11 @@ pub mod tests {
         let nova_params = N::preprocess(&mut rng, &prep_param).unwrap();
 
         let z_0 = vec![Fr::from(3_u32)];
-        let mut nova = N::init(nova_params.clone(), F_circuit, z_0.clone()).unwrap();
+        let mut nova = N::init(&nova_params, F_circuit, z_0.clone()).unwrap();
 
         let num_steps: usize = 3;
         for _ in 0..num_steps {
-            nova.prove_step(&mut rng, vec![]).unwrap();
+            nova.prove_step(&mut rng, vec![], None).unwrap();
         }
         assert_eq!(Fr::from(num_steps as u32), nova.i);
 

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -69,6 +69,8 @@ pub enum Error {
     NotEnoughSteps,
     #[error("Evaluation failed")]
     EvaluationFail,
+    #[error("{0} can not be zero")]
+    CantBeZero(String),
 
     // Commitment errors
     #[error("Pedersen parameters length is not sufficient (generators.len={0} < vector.len={1} unsatisfied)")]
@@ -97,6 +99,10 @@ pub enum Error {
     BigIntConversionError(String),
     #[error("Failed to serde: {0}")]
     JSONSerdeError(String),
+    #[error("Multi instances folding not supported in this scheme")]
+    NoMultiInstances,
+    #[error("Missing 'other' instances, since this is a multi-instances folding scheme")]
+    MissingOtherInstances,
 }
 
 /// FoldingScheme defines trait that is implemented by the diverse folding schemes. It is defined
@@ -116,6 +122,7 @@ where
     type VerifierParam: Debug + Clone;
     type RunningInstance: Debug; // contains the CommittedInstance + Witness
     type IncomingInstance: Debug; // contains the CommittedInstance + Witness
+    type MultiCommittedInstanceWithWitness: Debug; // type used for the extra instances in the multi-instance folding setting
     type CFInstance: Debug; // CycleFold CommittedInstance & Witness
 
     fn preprocess(
@@ -124,7 +131,7 @@ where
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error>;
 
     fn init(
-        params: (Self::ProverParam, Self::VerifierParam),
+        params: &(Self::ProverParam, Self::VerifierParam),
         step_circuit: FC,
         z_0: Vec<C1::ScalarField>, // initial state
     ) -> Result<Self, Error>;
@@ -133,6 +140,7 @@ where
         &mut self,
         rng: impl RngCore,
         external_inputs: Vec<C1::ScalarField>,
+        other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error>;
 
     // returns the state at the current step
@@ -158,6 +166,35 @@ where
         incoming_instance: Self::IncomingInstance,
         cyclefold_instance: Self::CFInstance,
     ) -> Result<(), Error>;
+}
+
+/// Trait with auxiliary methods for multi-folding schemes (ie. HyperNova, ProtoGalaxy, etc),
+/// allowing to create new instances for the multifold.
+pub trait MultiFolding<C1: CurveGroup, C2: CurveGroup, FC>: Clone + Debug
+where
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2::BaseField: PrimeField,
+    FC: FCircuit<C1::ScalarField>,
+{
+    type RunningInstance: Debug;
+    type IncomingInstance: Debug;
+    type MultiInstance: Debug;
+
+    /// Creates a new RunningInstance for the given state, to be folded in the multi-folding step.
+    fn new_running_instance(
+        &self,
+        rng: impl RngCore,
+        state: Vec<C1::ScalarField>,
+        external_inputs: Vec<C1::ScalarField>,
+    ) -> Result<Self::RunningInstance, Error>;
+
+    /// Creates a new IncomingInstance for the given state, to be folded in the multi-folding step.
+    fn new_incoming_instance(
+        &self,
+        rng: impl RngCore,
+        state: Vec<C1::ScalarField>,
+        external_inputs: Vec<C1::ScalarField>,
+    ) -> Result<Self::IncomingInstance, Error>;
 }
 
 pub trait Decider<

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -60,9 +60,9 @@ where
     hasher.update(C1::ScalarField::MODULUS_BIT_SIZE.to_le_bytes());
     hasher.update(C2::ScalarField::MODULUS_BIT_SIZE.to_le_bytes());
     // AugmentedFCircuit Arith params
-    hasher.update(arith.params_to_bytes());
+    hasher.update(arith.params_to_le_bytes());
     // CycleFold Circuit Arith params
-    hasher.update(cf_arith.params_to_bytes());
+    hasher.update(cf_arith.params_to_le_bytes());
     // cs_vp & cf_cs_vp (commitments setup)
     let mut cs_vp_bytes = Vec::new();
     cs_vp.serialize_uncompressed(&mut cs_vp_bytes)?;

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -324,7 +324,7 @@ mod tests {
         );
         let nova_params = NOVA::preprocess(&mut rng, &prep_param).unwrap();
         let nova = NOVA::init(
-            nova_params.clone(),
+            &nova_params,
             f_circuit.clone(),
             vec![Fr::zero(); f_circuit.state_len()].clone(),
         )
@@ -358,9 +358,9 @@ mod tests {
 
         let mut rng = rand::rngs::OsRng;
 
-        let mut nova = NOVA::<FC>::init(fs_params, f_circuit, z_0).unwrap();
+        let mut nova = NOVA::<FC>::init(&fs_params, f_circuit, z_0).unwrap();
         for _ in 0..n_steps {
-            nova.prove_step(&mut rng, vec![]).unwrap();
+            nova.prove_step(&mut rng, vec![], None).unwrap();
         }
 
         let start = Instant::now();


### PR DESCRIPTION
- Adds the logic to support multi-instances folding in HyperNova's AugmentedFCircuit & IVC.
- Adds also methods to generate new LCCCS & CCCS instances that don't depend on the main folding chain, to be folded in in the next step
- Updates CycleFold circuit & methods to work other folding schemes than Nova adapting it to fold multiple points per circuit (instead of 2-to-1 as till now)