### PR TITLE
Generalized CycleFold

### DIFF
--- a/folding-schemes/src/constants.rs
+++ b/folding-schemes/src/constants.rs
@@ -2,4 +2,4 @@
 // From [Srinath Setty](https://microsoft.com/en-us/research/people/srinath/): In Nova, soundness
 // error ≤ 2/|S|, where S is the subset of the field F from which the challenges are drawn. In this
 // case, we keep the size of S close to 2^128.
-pub const N_BITS_RO: usize = 128;
+pub const NOVA_N_BITS_RO: usize = 128;

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -23,7 +23,7 @@ use core::{borrow::Borrow, marker::PhantomData};
 use super::{nonnative::uint::NonNativeUintVar, CF2};
 use crate::arith::r1cs::{extract_w_x, R1CS};
 use crate::commitment::CommitmentScheme;
-use crate::constants::N_BITS_RO;
+use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::nova::{nifs::NIFS, CommittedInstance, Witness};
 use crate::transcript::{AbsorbNonNativeGadget, Transcript, TranscriptVar};
 use crate::Error;
@@ -252,7 +252,7 @@ where
         transcript.absorb_nonnative(&U_i);
         transcript.absorb_nonnative(&u_i);
         transcript.absorb_point(&cmT);
-        transcript.squeeze_bits(N_BITS_RO)
+        transcript.squeeze_bits(NOVA_N_BITS_RO)
     }
 
     // compatible with the native get_challenge_native
@@ -267,7 +267,7 @@ where
         transcript.absorb(&U_i_vec)?;
         transcript.absorb_nonnative(&u_i)?;
         transcript.absorb_point(&cmT)?;
-        transcript.squeeze_bits(N_BITS_RO)
+        transcript.squeeze_bits(NOVA_N_BITS_RO)
     }
 }
 
@@ -505,7 +505,7 @@ pub mod tests {
     }
 
     impl<C: CurveGroup> CycleFoldConfig for TestCycleFoldConfig<C> {
-        const RANDOMNESS_BIT_LENGTH: usize = N_BITS_RO;
+        const RANDOMNESS_BIT_LENGTH: usize = NOVA_N_BITS_RO;
         const N_INPUT_POINTS: usize = 2;
         type C = C;
         type F = C::BaseField;

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -1,7 +1,7 @@
 /// Contains [CycleFold](https://eprint.iacr.org/2023/1192.pdf) related circuits and functions that
 /// are shared across the different folding schemes
 use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge};
-use ark_ec::{CurveGroup, Group};
+use ark_ec::{AffineRepr, CurveGroup, Group};
 use ark_ff::{BigInteger, Field, PrimeField};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
@@ -24,12 +24,18 @@ use super::{nonnative::uint::NonNativeUintVar, CF1, CF2};
 use crate::arith::r1cs::{extract_w_x, R1CS};
 use crate::commitment::CommitmentScheme;
 use crate::constants::NOVA_N_BITS_RO;
-use crate::folding::nova::{nifs::NIFS, CommittedInstance, Witness};
-use crate::transcript::{AbsorbNonNativeGadget, Transcript, TranscriptVar};
+use crate::folding::nova::nifs::NIFS;
+use crate::transcript::{AbsorbNonNative, AbsorbNonNativeGadget, Transcript, TranscriptVar};
 use crate::Error;
 
-/// CycleFoldCommittedInstanceVar is the CycleFold CommittedInstance representation in the Nova
-/// circuit.
+/// Re-export the Nova committed instance as `CycleFoldCommittedInstance` and
+/// witness as `CycleFoldWitness`, for clarity and consistency
+pub use crate::folding::nova::{
+    CommittedInstance as CycleFoldCommittedInstance, Witness as CycleFoldWitness,
+};
+
+/// CycleFoldCommittedInstanceVar is the CycleFold CommittedInstance represented
+/// in folding verifier circuit
 #[derive(Debug, Clone)]
 pub struct CycleFoldCommittedInstanceVar<C: CurveGroup, GC: CurveVar<C, CF2<C>>>
 where
@@ -40,14 +46,14 @@ where
     pub cmW: GC,
     pub x: Vec<NonNativeUintVar<CF2<C>>>,
 }
-impl<C, GC> AllocVar<CommittedInstance<C>, CF2<C>> for CycleFoldCommittedInstanceVar<C, GC>
+impl<C, GC> AllocVar<CycleFoldCommittedInstance<C>, CF2<C>> for CycleFoldCommittedInstanceVar<C, GC>
 where
     C: CurveGroup,
     GC: CurveVar<C, CF2<C>>,
     <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
     for<'a> &'a GC: GroupOpsBounds<'a, C, GC>,
 {
-    fn new_variable<T: Borrow<CommittedInstance<C>>>(
+    fn new_variable<T: Borrow<CycleFoldCommittedInstance<C>>>(
         cs: impl Into<Namespace<CF2<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
         mode: AllocationMode,
@@ -62,6 +68,29 @@ where
 
             Ok(Self { cmE, u, cmW, x })
         })
+    }
+}
+
+impl<C: CurveGroup> AbsorbNonNative<C::BaseField> for CycleFoldCommittedInstance<C>
+where
+    C::BaseField: PrimeField + Absorb,
+{
+    // Compatible with the in-circuit `CycleFoldCommittedInstanceVar::to_native_sponge_field_elements`
+    fn to_native_sponge_field_elements(&self, dest: &mut Vec<C::BaseField>) {
+        [self.u].to_native_sponge_field_elements(dest);
+        self.x.to_native_sponge_field_elements(dest);
+        let (cmE_x, cmE_y) = match self.cmE.into_affine().xy() {
+            Some((&x, &y)) => (x, y),
+            None => (C::BaseField::zero(), C::BaseField::zero()),
+        };
+        let (cmW_x, cmW_y) = match self.cmW.into_affine().xy() {
+            Some((&x, &y)) => (x, y),
+            None => (C::BaseField::zero(), C::BaseField::zero()),
+        };
+        cmE_x.to_sponge_field_elements(dest);
+        cmE_y.to_sponge_field_elements(dest);
+        cmW_x.to_sponge_field_elements(dest);
+        cmW_y.to_sponge_field_elements(dest);
     }
 }
 
@@ -98,6 +127,25 @@ where
     }
 }
 
+impl<C: CurveGroup> CycleFoldCommittedInstance<C>
+where
+    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField + Absorb,
+{
+    /// hash_cyclefold implements the committed instance hash compatible with the
+    /// in-circuit implementation `CycleFoldCommittedInstanceVar::hash`.
+    /// Returns `H(U_i)`, where `U_i` is a `CycleFoldCommittedInstance`.
+    pub fn hash_cyclefold<T: Transcript<C::BaseField>>(
+        &self,
+        sponge: &T,
+        pp_hash: C::BaseField, // public params hash
+    ) -> C::BaseField {
+        let mut sponge = sponge.clone();
+        sponge.absorb(&pp_hash);
+        sponge.absorb_nonnative(self);
+        sponge.squeeze_field_elements(1)[0]
+    }
+}
+
 impl<C, GC> CycleFoldCommittedInstanceVar<C, GC>
 where
     C: CurveGroup,
@@ -105,11 +153,13 @@ where
     <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField + Absorb,
     for<'a> &'a GC: GroupOpsBounds<'a, C, GC>,
 {
-    /// hash implements the committed instance hash compatible with the native implementation from
-    /// CommittedInstance.hash_cyclefold. Returns `H(U_i)`, where `U` is the `CommittedInstance`
-    /// for CycleFold. Additionally it returns the vector of the field elements from the self
-    /// parameters, so they can be reused in other gadgets avoiding recalculating (reconstraining)
-    /// them.
+    /// hash implements the committed instance hash compatible with the native
+    /// implementation `CycleFoldCommittedInstance::hash_cyclefold`.
+    /// Returns `H(U_i)`, where `U` is a `CycleFoldCommittedInstanceVar`.
+    /// 
+    /// Additionally it returns the vector of the field elements from the self
+    /// parameters, so they can be reused in other gadgets without recalculating
+    /// (reconstraining) them.
     #[allow(clippy::type_complexity)]
     pub fn hash<S: CryptographicSponge, T: TranscriptVar<CF2<C>, S>>(
         self,
@@ -138,13 +188,14 @@ where
     pub cmW: GC,
 }
 
-impl<C, GC> AllocVar<CommittedInstance<C>, CF2<C>> for CommittedInstanceInCycleFoldVar<C, GC>
+impl<C, GC> AllocVar<CycleFoldCommittedInstance<C>, CF2<C>>
+    for CommittedInstanceInCycleFoldVar<C, GC>
 where
     C: CurveGroup,
     GC: CurveVar<C, CF2<C>>,
     for<'a> &'a GC: GroupOpsBounds<'a, C, GC>,
 {
-    fn new_variable<T: Borrow<CommittedInstance<C>>>(
+    fn new_variable<T: Borrow<CycleFoldCommittedInstance<C>>>(
         cs: impl Into<Namespace<CF2<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
         mode: AllocationMode,
@@ -247,8 +298,8 @@ where
     pub fn get_challenge_native<T: Transcript<C::BaseField>>(
         transcript: &mut T,
         pp_hash: C::BaseField, // public params hash
-        U_i: CommittedInstance<C>,
-        u_i: CommittedInstance<C>,
+        U_i: CycleFoldCommittedInstance<C>,
+        u_i: CycleFoldCommittedInstance<C>,
         cmT: C,
     ) -> Vec<bool> {
         transcript.absorb(&pp_hash);
@@ -414,20 +465,20 @@ pub fn fold_cyclefold_circuit<CFG, C1, GC1, C2, GC2, CS2, const H: bool>(
     transcript: &mut impl Transcript<C1::ScalarField>,
     cf_r1cs: R1CS<C2::ScalarField>,
     cf_cs_params: CS2::ProverParams,
-    pp_hash: C1::ScalarField,      // public params hash
-    cf_W_i: Witness<C2>,           // witness of the running instance
-    cf_U_i: CommittedInstance<C2>, // running instance
+    pp_hash: C1::ScalarField,               // public params hash
+    cf_W_i: CycleFoldWitness<C2>,           // witness of the running instance
+    cf_U_i: CycleFoldCommittedInstance<C2>, // running instance
     cf_u_i_x: Vec<C2::ScalarField>,
     cf_circuit: CycleFoldCircuit<CFG, GC1>,
     mut rng: impl RngCore,
 ) -> Result<
     (
-        Witness<C2>,
-        CommittedInstance<C2>, // u_i
-        Witness<C2>,           // W_i1
-        CommittedInstance<C2>, // U_i1
-        C2,                    // cmT
-        C2::ScalarField,       // r_Fq
+        CycleFoldWitness<C2>,
+        CycleFoldCommittedInstance<C2>, // u_i
+        CycleFoldWitness<C2>,           // W_i1
+        CycleFoldCommittedInstance<C2>, // U_i1
+        C2,                             // cmT
+        C2::ScalarField,                // r_Fq
     ),
     Error,
 >
@@ -459,8 +510,9 @@ where
     assert_eq!(cf_x_i.len(), CFG::IO_LEN);
 
     // fold cyclefold instances
-    let cf_w_i = Witness::<C2>::new::<H>(cf_w_i.clone(), cf_r1cs.A.n_rows, &mut rng);
-    let cf_u_i: CommittedInstance<C2> = cf_w_i.commit::<CS2, H>(&cf_cs_params, cf_x_i.clone())?;
+    let cf_w_i = CycleFoldWitness::<C2>::new::<H>(cf_w_i.clone(), cf_r1cs.A.n_rows, &mut rng);
+    let cf_u_i: CycleFoldCommittedInstance<C2> =
+        cf_w_i.commit::<CS2, H>(&cf_cs_params, cf_x_i.clone())?;
 
     // compute T* and cmT* for CycleFoldCircuit
     let (cf_T, cf_cmT) = NIFS::<C2, CS2, H>::compute_cyclefold_cmT(
@@ -518,7 +570,7 @@ pub mod tests {
     fn test_committed_instance_cyclefold_var() {
         let mut rng = ark_std::test_rng();
 
-        let ci = CommittedInstance::<Projective> {
+        let ci = CycleFoldCommittedInstance::<Projective> {
             cmE: Projective::rand(&mut rng),
             u: Fr::rand(&mut rng),
             cmW: Projective::rand(&mut rng),
@@ -616,7 +668,7 @@ pub mod tests {
         let poseidon_config = poseidon_canonical_config::<Fq>();
         let mut transcript = PoseidonSponge::<Fq>::new(&poseidon_config);
 
-        let u_i = CommittedInstance::<Projective> {
+        let u_i = CycleFoldCommittedInstance::<Projective> {
             cmE: Projective::zero(), // zero on purpose, so we test also the zero point case
             u: Fr::zero(),
             cmW: Projective::rand(&mut rng),
@@ -624,7 +676,7 @@ pub mod tests {
                 .take(TestCycleFoldConfig::<Projective>::IO_LEN)
                 .collect(),
         };
-        let U_i = CommittedInstance::<Projective> {
+        let U_i = CycleFoldCommittedInstance::<Projective> {
             cmE: Projective::rand(&mut rng),
             u: Fr::rand(&mut rng),
             cmW: Projective::rand(&mut rng),
@@ -683,7 +735,7 @@ pub mod tests {
         let poseidon_config = poseidon_canonical_config::<Fq>();
         let sponge = PoseidonSponge::<Fq>::new(&poseidon_config);
 
-        let U_i = CommittedInstance::<Projective> {
+        let U_i = CycleFoldCommittedInstance::<Projective> {
             cmE: Projective::rand(&mut rng),
             u: Fr::rand(&mut rng),
             cmW: Projective::rand(&mut rng),

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -326,20 +326,25 @@ where
 }
 
 pub trait CycleFoldConfig {
+    /// `N_INPUT_POINTS` specifies the number of input points that are folded in
+    /// [`CycleFoldCircuit`] via random linear combinations.
     const N_INPUT_POINTS: usize;
+    /// `RANDOMNESS_BIT_LENGTH` is the (maximum) bit length of randomness `r`.
     const RANDOMNESS_BIT_LENGTH: usize;
+    /// `FIELD_CAPACITY` is the maximum number of bits that can be stored in a
+    /// field element.
+    ///
+    /// E.g., given a randomness `r` with `RANDOMNESS_BIT_LENGTH` bits, we need
+    /// `RANDOMNESS_BIT_LENGTH / FIELD_CAPACITY` field elements to represent `r`
+    /// compactly in-circuit.
     const FIELD_CAPACITY: usize = CF2::<Self::C>::MODULUS_BIT_SIZE as usize - 1;
 
-    /// Public inputs length for the CycleFoldCircuit:
+    /// Public inputs length for the CycleFoldCircuit.
+    /// * For Nova this is: `|[r, p1.x,y, p2.x,y, p3.x,y]|`
+    /// * In general, `|[r * (n_points-1), (p_i.x,y)*n_points, p_folded.x,y]|`.
     ///
-    /// * For Nova this is: |[r, p1.x,y, p2.x,y, p3.x,y]|
-    /// * In general, |[r * (n_points-1), (p_i.x,y)*n_points, p_folded.x,y]|.
-    ///
-    /// Here, the randomness r has |r| bits, storing which in the circuit
-    /// requires |r| / field_capacity field elements.
-    ///
-    /// Thus, io len is:
-    /// |r| / field_capacity * (n_points - 1) + 2 * n_points + 2
+    /// Thus, `IO_LEN` is:
+    /// `RANDOMNESS_BIT_LENGTH / FIELD_CAPACITY * (N_INPUT_POINTS - 1) + 2 * N_INPUT_POINTS + 2`
     const IO_LEN: usize = {
         Self::RANDOMNESS_BIT_LENGTH.div_ceil(Self::FIELD_CAPACITY) * (Self::N_INPUT_POINTS - 1)
             + 2 * Self::N_INPUT_POINTS
@@ -362,7 +367,8 @@ pub struct CycleFoldCircuit<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CFG::F>> 
     pub r_bits: Option<Vec<Vec<bool>>>,
     /// points to be folded in the CycleFoldCircuit
     pub points: Option<Vec<CFG::C>>,
-    pub x: Option<Vec<CFG::F>>, // public inputs (cf_u_{i+1}.x)
+    /// public inputs (cf_u_{i+1}.x)
+    pub x: Option<Vec<CFG::F>>,
 }
 
 impl<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CFG::F>> CycleFoldCircuit<CFG, GC> {

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -156,7 +156,7 @@ where
     /// hash implements the committed instance hash compatible with the native
     /// implementation `CycleFoldCommittedInstance::hash_cyclefold`.
     /// Returns `H(U_i)`, where `U` is a `CycleFoldCommittedInstanceVar`.
-    /// 
+    ///
     /// Additionally it returns the vector of the field elements from the self
     /// parameters, so they can be reused in other gadgets without recalculating
     /// (reconstraining) them.

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -26,7 +26,7 @@ pub struct CCCS<C: CurveGroup> {
 }
 
 impl<F: PrimeField> CCS<F> {
-    pub fn to_cccs<R: Rng, C: CurveGroup, CS: CommitmentScheme<C, H>, const H: bool>(
+    pub fn to_cccs<R: Rng, C, CS: CommitmentScheme<C, H>, const H: bool>(
         &self,
         rng: &mut R,
         cs_params: &CS::ProverParams,

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -28,7 +28,7 @@ use super::{
     nimfs::{NIMFSProof, NIMFS},
     HyperNovaCycleFoldConfig, Witness,
 };
-use crate::constants::N_BITS_RO;
+use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::{
     circuits::{
         cyclefold::{
@@ -314,7 +314,7 @@ where
         let rho_scalar_raw = C::ScalarField::from_le_bytes_mod_order(b"rho");
         let rho_scalar: FpVar<CF1<C>> = FpVar::<CF1<C>>::new_constant(cs.clone(), rho_scalar_raw)?;
         transcript.absorb(&rho_scalar)?;
-        let rho_bits: Vec<Boolean<CF1<C>>> = transcript.get_challenge_nbits(N_BITS_RO)?;
+        let rho_bits: Vec<Boolean<CF1<C>>> = transcript.get_challenge_nbits(NOVA_N_BITS_RO)?;
         let rho = Boolean::le_bits_to_fp_var(&rho_bits)?;
 
         // Self::fold will return the folded instance, together with the rho's powers vector so
@@ -343,7 +343,7 @@ where
         let mut v_folded: Vec<FpVar<CF1<C>>> = vec![FpVar::zero(); sigmas[0].len()];
 
         let mut rho_vec: Vec<Vec<Boolean<CF1<C>>>> =
-            vec![vec![Boolean::FALSE; N_BITS_RO]; lcccs.len() + cccs.len() - 1];
+            vec![vec![Boolean::FALSE; NOVA_N_BITS_RO]; lcccs.len() + cccs.len() - 1];
         let mut rho_i = FpVar::one();
         for i in 0..(lcccs.len() + cccs.len()) {
             let u: FpVar<CF1<C>>;
@@ -382,12 +382,12 @@ where
 
             // compute the next power of rho
             rho_i *= rho.clone();
-            // crop the size of rho_i to N_BITS_RO
+            // crop the size of rho_i to NOVA_N_BITS_RO
             let rho_i_bits = rho_i.to_bits_le()?;
-            rho_i = Boolean::le_bits_to_fp_var(&rho_i_bits[..N_BITS_RO])?;
+            rho_i = Boolean::le_bits_to_fp_var(&rho_i_bits[..NOVA_N_BITS_RO])?;
             if i < lcccs.len() + cccs.len() - 1 {
                 // store the cropped rho_i into the rho_vec
-                rho_vec[i] = rho_i_bits[..N_BITS_RO].to_vec();
+                rho_vec[i] = rho_i_bits[..NOVA_N_BITS_RO].to_vec();
             }
         }
 
@@ -1329,7 +1329,7 @@ mod tests {
                     .collect();
                 let rho_powers_bits: Vec<Vec<bool>> = rho_powers
                     .iter()
-                    .map(|rho_i| rho_i.into_bigint().to_bits_le()[..N_BITS_RO].to_vec())
+                    .map(|rho_i| rho_i.into_bigint().to_bits_le()[..NOVA_N_BITS_RO].to_vec())
                     .collect();
 
                 // CycleFold part:

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -855,20 +855,9 @@ where
             cf_u_i.clone(),
             cf_cmT.clone(),
         )?;
-        // Convert cf_r_bits to a `NonNativeFieldVar`
-        let cf_r_nonnat = {
-            let mut bits = cf_r_bits.clone();
-            bits.resize(C1::BaseField::MODULUS_BIT_SIZE as usize, Boolean::FALSE);
-            NonNativeUintVar::from(&bits)
-        };
         // Fold cf1_u_i & cf_U_i into cf1_U_{i+1}
-        let cf_U_i1 = NIFSFullGadget::<C2, GC2>::fold_committed_instance(
-            cf_r_bits,
-            cf_r_nonnat,
-            cf_cmT,
-            cf_U_i,
-            cf_u_i,
-        )?;
+        let cf_U_i1 =
+            NIFSFullGadget::<C2, GC2>::fold_committed_instance(cf_r_bits, cf_cmT, cf_U_i, cf_u_i)?;
 
         // Back to Primary Part
         // P.4.b compute and check the second output of F'

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -457,6 +457,24 @@ fn compute_c_gadget<F: PrimeField>(
     Ok(c)
 }
 
+/// `AugmentedFCircuit` enhances the original step function `F`, so that it can
+/// be used in recursive arguments such as IVC.
+///
+/// The method for converting `F` to `AugmentedFCircuit` (`F'`) is defined in
+/// [Nova](https://eprint.iacr.org/2021/370.pdf), where `AugmentedFCircuit` not
+/// only invokes `F`, but also adds additional constraints for verifying the
+/// correct folding of primary instances (i.e., the instances over `C1`).
+/// In the paper, the primary instances are Nova's `CommittedInstance`, but we
+/// extend this method to support using HyperNova's `LCCCS` and `CCCS` instances
+/// as primary instances.
+///
+/// Furthermore, to reduce circuit size over `C2`, we implement the constraints
+/// defined in [CycleFold](https://eprint.iacr.org/2023/1192.pdf). These extra
+/// constraints verify the correct folding of CycleFold instances.
+///
+/// For multi-instance folding, one needs to specify the const generics below:
+/// * `MU` - the number of LCCCS instances to be folded
+/// * `NU` - the number of CCCS instances to be folded
 #[derive(Debug, Clone)]
 pub struct AugmentedFCircuit<
     C1: CurveGroup,

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -30,7 +30,7 @@ pub struct LCCCS<C: CurveGroup> {
 }
 
 impl<F: PrimeField> CCS<F> {
-    pub fn to_lcccs<R: Rng, C: CurveGroup, CS: CommitmentScheme<C, H>, const H: bool>(
+    pub fn to_lcccs<R: Rng, C, CS: CommitmentScheme<C, H>, const H: bool>(
         &self,
         rng: &mut R,
         cs_params: &CS::ProverParams,

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -20,7 +20,7 @@ use lcccs::LCCCS;
 use nimfs::NIMFS;
 
 use crate::commitment::CommitmentScheme;
-use crate::constants::N_BITS_RO;
+use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::circuits::{
     cyclefold::{fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldConfig},
     CF2,
@@ -47,7 +47,7 @@ struct HyperNovaCycleFoldConfig<C: CurveGroup, const MU: usize, const NU: usize>
 impl<C: CurveGroup, const MU: usize, const NU: usize> CycleFoldConfig
     for HyperNovaCycleFoldConfig<C, MU, NU>
 {
-    const RANDOMNESS_BIT_LENGTH: usize = N_BITS_RO;
+    const RANDOMNESS_BIT_LENGTH: usize = NOVA_N_BITS_RO;
     const N_INPUT_POINTS: usize = MU + NU;
     type C = C;
     type F = C::BaseField;
@@ -673,7 +673,7 @@ where
                 .collect();
             let rho_powers_bits: Vec<Vec<bool>> = rho_powers
                 .iter()
-                .map(|rho_i| rho_i.into_bigint().to_bits_le()[..N_BITS_RO].to_vec())
+                .map(|rho_i| rho_i.into_bigint().to_bits_le()[..NOVA_N_BITS_RO].to_vec())
                 .collect();
 
             // CycleFold part:

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -127,6 +127,7 @@ where
 /// [HyperNova](https://eprint.iacr.org/2023/573.pdf) and
 /// [CycleFold](https://eprint.iacr.org/2023/1192.pdf), following the FoldingScheme trait
 ///
+/// For multi-instance folding, one needs to specify the const generics below:
 /// * `MU` - the number of LCCCS instances to be folded
 /// * `NU` - the number of CCCS instances to be folded
 #[derive(Clone, Debug)]

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -130,8 +130,18 @@ where
 /// * `MU` - the number of LCCCS instances to be folded
 /// * `NU` - the number of CCCS instances to be folded
 #[derive(Clone, Debug)]
-pub struct HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
-where
+pub struct HyperNova<
+    C1,
+    GC1,
+    C2,
+    GC2,
+    FC,
+    CS1,
+    CS2,
+    const MU: usize,
+    const NU: usize,
+    const H: bool,
+> where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
     C2: CurveGroup,
@@ -173,8 +183,8 @@ where
     pub cf_U_i: CycleFoldCommittedInstance<C2>,
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool> MultiFolding<C1, C2, FC>
-    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
+impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
+    MultiFolding<C1, C2, FC> for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
@@ -268,7 +278,8 @@ where
         // prepare the initial dummy instances
         let U_i = LCCCS::<C1>::dummy(self.ccs.l, self.ccs.t, self.ccs.s);
         let mut u_i = CCCS::<C1>::dummy(self.ccs.l);
-        let (_, cf_U_i): (CycleFoldWitness<C2>, CycleFoldCommittedInstance<C2>) = self.cf_r1cs.dummy_instance();
+        let (_, cf_U_i): (CycleFoldWitness<C2>, CycleFoldCommittedInstance<C2>) =
+            self.cf_r1cs.dummy_instance();
 
         let sponge = PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
 
@@ -346,8 +357,8 @@ where
     }
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool> FoldingScheme<C1, C2, FC>
-    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
+impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
+    FoldingScheme<C1, C2, FC> for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
@@ -936,8 +947,7 @@ mod tests {
         let hypernova_params = HN::preprocess(&mut rng, &prep_param).unwrap();
 
         let z_0 = vec![Fr::from(3_u32)];
-        let mut hypernova = HN::init(&hypernova_params, F_circuit, z_0.clone())
-        .unwrap();
+        let mut hypernova = HN::init(&hypernova_params, F_circuit, z_0.clone()).unwrap();
 
         let (w_i_blinding, W_i_blinding) = if H {
             (Fr::rand(&mut rng), Fr::rand(&mut rng))

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -12,7 +12,7 @@ use super::{
     Witness,
 };
 use crate::arith::ccs::CCS;
-use crate::constants::N_BITS_RO;
+use crate::constants::NOVA_N_BITS_RO;
 use crate::transcript::Transcript;
 use crate::utils::sum_check::structs::{IOPProof as SumCheckProof, IOPProverMessage};
 use crate::utils::sum_check::{IOPSumCheck, SumCheck};
@@ -123,10 +123,12 @@ where
 
             // compute the next power of rho
             rho_i *= rho;
-            // crop the size of rho_i to N_BITS_RO
+            // crop the size of rho_i to NOVA_N_BITS_RO
             let rho_i_bits = rho_i.into_bigint().to_bits_le();
-            rho_i = C::ScalarField::from_bigint(BigInteger::from_bits_le(&rho_i_bits[..N_BITS_RO]))
-                .unwrap();
+            rho_i = C::ScalarField::from_bigint(BigInteger::from_bits_le(
+                &rho_i_bits[..NOVA_N_BITS_RO],
+            ))
+            .unwrap();
             if i < lcccs.len() + cccs.len() - 1 {
                 // store the cropped rho_i into the rho_powers vector
                 rho_powers[i] = rho_i;
@@ -181,10 +183,12 @@ where
 
             // compute the next power of rho
             rho_i *= rho;
-            // crop the size of rho_i to N_BITS_RO
+            // crop the size of rho_i to NOVA_N_BITS_RO
             let rho_i_bits = rho_i.into_bigint().to_bits_le();
-            rho_i = C::ScalarField::from_bigint(BigInteger::from_bits_le(&rho_i_bits[..N_BITS_RO]))
-                .unwrap();
+            rho_i = C::ScalarField::from_bigint(BigInteger::from_bits_le(
+                &rho_i_bits[..NOVA_N_BITS_RO],
+            ))
+            .unwrap();
         }
         Witness {
             w: w_folded,
@@ -272,7 +276,7 @@ where
         // Step 6: Get the folding challenge
         let rho_scalar = C::ScalarField::from_le_bytes_mod_order(b"rho");
         transcript.absorb(&rho_scalar);
-        let rho_bits: Vec<bool> = transcript.get_challenge_nbits(N_BITS_RO);
+        let rho_bits: Vec<bool> = transcript.get_challenge_nbits(NOVA_N_BITS_RO);
         let rho: C::ScalarField =
             C::ScalarField::from_bigint(BigInteger::from_bits_le(&rho_bits)).unwrap();
 
@@ -391,7 +395,7 @@ where
         // Step 6: Get the folding challenge
         let rho_scalar = C::ScalarField::from_le_bytes_mod_order(b"rho");
         transcript.absorb(&rho_scalar);
-        let rho_bits: Vec<bool> = transcript.get_challenge_nbits(N_BITS_RO);
+        let rho_bits: Vec<bool> = transcript.get_challenge_nbits(NOVA_N_BITS_RO);
         let rho: C::ScalarField =
             C::ScalarField::from_bigint(BigInteger::from_bits_le(&rho_bits)).unwrap();
 

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -24,7 +24,8 @@ use super::{CommittedInstance, NovaCycleFoldConfig};
 use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::circuits::{
     cyclefold::{
-        CycleFoldChallengeGadget, CycleFoldCommittedInstanceVar, CycleFoldConfig, NIFSFullGadget,
+        CycleFoldChallengeGadget, CycleFoldCommittedInstance, CycleFoldCommittedInstanceVar,
+        CycleFoldConfig, NIFSFullGadget,
     },
     nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
     CF1, CF2,
@@ -246,9 +247,9 @@ pub struct AugmentedFCircuit<
     // cyclefold verifier on C1
     // Here 'cf1, cf2' are for each of the CycleFold circuits, corresponding to the fold of cmW and
     // cmE respectively
-    pub cf1_u_i_cmW: Option<C2>,               // input
-    pub cf2_u_i_cmW: Option<C2>,               // input
-    pub cf_U_i: Option<CommittedInstance<C2>>, // input
+    pub cf1_u_i_cmW: Option<C2>,                        // input
+    pub cf2_u_i_cmW: Option<C2>,                        // input
+    pub cf_U_i: Option<CycleFoldCommittedInstance<C2>>, // input
     pub cf1_cmT: Option<C2>,
     pub cf2_cmT: Option<C2>,
     pub cf_x: Option<CF1<C1>>, // public input (u_{i+1}.x[1])
@@ -337,7 +338,7 @@ where
         let cmT =
             NonNativeAffineVar::new_witness(cs.clone(), || Ok(self.cmT.unwrap_or_else(C1::zero)))?;
 
-        let cf_u_dummy = CommittedInstance::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
+        let cf_u_dummy = CycleFoldCommittedInstance::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
         let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
             Ok(self.cf_U_i.unwrap_or(cf_u_dummy.clone()))
         })?;
@@ -548,7 +549,7 @@ pub mod tests {
         assert_eq!(ciVar.x.value().unwrap(), ci.x);
         // the values cmE and cmW are checked in the CycleFold's circuit
         // CommittedInstanceInCycleFoldVar in
-        // nova::cyclefold::tests::test_committed_instance_cyclefold_var
+        // cyclefold::tests::test_committed_instance_cyclefold_var
     }
 
     #[test]

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -216,9 +216,18 @@ where
     }
 }
 
-/// AugmentedFCircuit implements the F' circuit (augmented F) defined in
-/// [Nova](https://eprint.iacr.org/2021/370.pdf) together with the extra constraints defined in
-/// [CycleFold](https://eprint.iacr.org/2023/1192.pdf).
+/// `AugmentedFCircuit` enhances the original step function `F`, so that it can
+/// be used in recursive arguments such as IVC.
+///
+/// The method for converting `F` to `AugmentedFCircuit` (`F'`) is defined in
+/// [Nova](https://eprint.iacr.org/2021/370.pdf), where `AugmentedFCircuit` not
+/// only invokes `F`, but also adds additional constraints for verifying the
+/// correct folding of primary instances (i.e., Nova's `CommittedInstance`s over
+/// `C1`).
+///
+/// Furthermore, to reduce circuit size over `C2`, we implement the constraints
+/// defined in [CycleFold](https://eprint.iacr.org/2023/1192.pdf). These extra
+/// constraints verify the correct folding of CycleFold instances.
 #[derive(Debug, Clone)]
 pub struct AugmentedFCircuit<
     C1: CurveGroup,

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -481,19 +481,9 @@ where
             cf1_u_i.clone(),
             cf1_cmT.clone(),
         )?;
-        // Convert cf1_r_bits to a `NonNativeFieldVar`
-        let cf1_r_nonnat = {
-            let mut bits = cf1_r_bits.clone();
-            bits.resize(C1::BaseField::MODULUS_BIT_SIZE as usize, Boolean::FALSE);
-            NonNativeUintVar::from(&bits)
-        };
         // Fold cf1_u_i & cf_U_i into cf1_U_{i+1}
         let cf1_U_i1 = NIFSFullGadget::<C2, GC2>::fold_committed_instance(
-            cf1_r_bits,
-            cf1_r_nonnat,
-            cf1_cmT,
-            cf_U_i,
-            cf1_u_i,
+            cf1_r_bits, cf1_cmT, cf_U_i, cf1_u_i,
         )?;
 
         // same for cf2_r:
@@ -504,16 +494,8 @@ where
             cf2_u_i.clone(),
             cf2_cmT.clone(),
         )?;
-        let cf2_r_nonnat = {
-            let mut bits = cf2_r_bits.clone();
-            bits.resize(C1::BaseField::MODULUS_BIT_SIZE as usize, Boolean::FALSE);
-            NonNativeUintVar::from(&bits)
-        };
         let cf_U_i1 = NIFSFullGadget::<C2, GC2>::fold_committed_instance(
-            cf2_r_bits,
-            cf2_r_nonnat,
-            cf2_cmT,
-            cf1_U_i1, // the output from NIFS.V(cf1_r, cf_U, cfE_u)
+            cf2_r_bits, cf2_cmT, cf1_U_i1, // the output from NIFS.V(cf1_r, cf_U, cfE_u)
             cf2_u_i,
         )?;
 

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -21,7 +21,7 @@ use ark_std::{fmt::Debug, One, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
 use super::{CommittedInstance, NovaCycleFoldConfig};
-use crate::constants::N_BITS_RO;
+use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::circuits::{
     cyclefold::{
         CycleFoldChallengeGadget, CycleFoldCommittedInstanceVar, CycleFoldConfig, NIFSFullGadget,
@@ -196,7 +196,7 @@ where
         transcript.absorb(&U_i);
         transcript.absorb(&u_i);
         transcript.absorb_nonnative(&cmT);
-        transcript.squeeze_bits(N_BITS_RO)
+        transcript.squeeze_bits(NOVA_N_BITS_RO)
     }
 
     // compatible with the native get_challenge_native
@@ -211,7 +211,7 @@ where
         transcript.absorb(&U_i_vec)?;
         transcript.absorb(&u_i)?;
         transcript.absorb_nonnative(&cmT)?;
-        transcript.squeeze_bits(N_BITS_RO)
+        transcript.squeeze_bits(NOVA_N_BITS_RO)
     }
 }
 

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -20,11 +20,11 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, Namespace,
 use ark_std::{fmt::Debug, One, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
-use super::{CommittedInstance, NOVA_CF_N_POINTS};
+use super::{CommittedInstance, NovaCycleFoldConfig};
 use crate::constants::N_BITS_RO;
 use crate::folding::circuits::{
     cyclefold::{
-        cf_io_len, CycleFoldChallengeGadget, CycleFoldCommittedInstanceVar, NIFSFullGadget,
+        CycleFoldChallengeGadget, CycleFoldCommittedInstanceVar, CycleFoldConfig, NIFSFullGadget,
     },
     nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
     CF1, CF2,
@@ -337,7 +337,7 @@ where
         let cmT =
             NonNativeAffineVar::new_witness(cs.clone(), || Ok(self.cmT.unwrap_or_else(C1::zero)))?;
 
-        let cf_u_dummy = CommittedInstance::dummy(cf_io_len(NOVA_CF_N_POINTS));
+        let cf_u_dummy = CommittedInstance::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
         let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
             Ok(self.cf_U_i.unwrap_or(cf_u_dummy.clone()))
         })?;

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -22,14 +22,17 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, Namespace,
 use ark_std::{log2, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
-use super::{circuits::ChallengeGadget, nifs::NIFS};
+use super::{
+    circuits::{ChallengeGadget, CommittedInstanceVar},
+    nifs::NIFS,
+    CommittedInstance, Nova, Witness,
+};
 use crate::arith::r1cs::R1CS;
 use crate::commitment::{pedersen::Params as PedersenParams, CommitmentScheme};
 use crate::folding::circuits::{
     nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
     CF1, CF2,
 };
-use crate::folding::nova::{circuits::CommittedInstanceVar, CommittedInstance, Nova, Witness};
 use crate::frontend::FCircuit;
 use crate::transcript::{Transcript, TranscriptVar};
 use crate::utils::{

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -30,6 +30,7 @@ use super::{
 use crate::arith::r1cs::R1CS;
 use crate::commitment::{pedersen::Params as PedersenParams, CommitmentScheme};
 use crate::folding::circuits::{
+    cyclefold::{CycleFoldCommittedInstance, CycleFoldWitness},
     nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
     CF1, CF2,
 };
@@ -159,7 +160,7 @@ where
     }
 }
 
-/// In-circuit representation of the Witness associated to the CommittedInstance, but with
+/// In-circuit representation of the Witness associated to the CycleFoldCommittedInstance, but with
 /// non-native representation, since it is used to represent the CycleFold witness.
 #[derive(Debug, Clone)]
 pub struct CycleFoldWitnessVar<C: CurveGroup> {
@@ -169,12 +170,12 @@ pub struct CycleFoldWitnessVar<C: CurveGroup> {
     pub rW: NonNativeUintVar<CF2<C>>,
 }
 
-impl<C> AllocVar<Witness<C>, CF2<C>> for CycleFoldWitnessVar<C>
+impl<C> AllocVar<CycleFoldWitness<C>, CF2<C>> for CycleFoldWitnessVar<C>
 where
     C: CurveGroup,
     <C as ark_ec::CurveGroup>::BaseField: PrimeField,
 {
-    fn new_variable<T: Borrow<Witness<C>>>(
+    fn new_variable<T: Borrow<CycleFoldWitness<C>>>(
         cs: impl Into<Namespace<CF2<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
         mode: AllocationMode,
@@ -240,8 +241,8 @@ where
     pub cmT: Option<C1>,
     pub r: Option<C1::ScalarField>,
     /// CycleFold running instance
-    pub cf_U_i: Option<CommittedInstance<C2>>,
-    pub cf_W_i: Option<Witness<C2>>,
+    pub cf_U_i: Option<CycleFoldCommittedInstance<C2>>,
+    pub cf_W_i: Option<CycleFoldWitness<C2>>,
 
     /// KZG challenges
     pub kzg_c_W: Option<C1::ScalarField>,
@@ -458,9 +459,11 @@ where
             use ark_r1cs_std::ToBitsGadget;
 
             let cf_u_dummy_native =
-                CommittedInstance::<C2>::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
-            let w_dummy_native =
-                Witness::<C2>::dummy(self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l, self.cf_E_len);
+                CycleFoldCommittedInstance::<C2>::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
+            let w_dummy_native = CycleFoldWitness::<C2>::dummy(
+                vec![C2::ScalarField::zero(); self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l],
+                self.cf_E_len,
+            );
             let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
                 Ok(self.cf_U_i.unwrap_or_else(|| cf_u_dummy_native.clone()))
             })?;

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -447,12 +447,15 @@ where
         {
             // imports here instead of at the top of the file, so we avoid having multiple
             // `#[cfg(not(test))]`
-            use super::NOVA_CF_N_POINTS;
             use crate::commitment::pedersen::PedersenGadget;
-            use crate::folding::circuits::cyclefold::{cf_io_len, CycleFoldCommittedInstanceVar};
+            use crate::folding::{
+                circuits::cyclefold::{CycleFoldCommittedInstanceVar, CycleFoldConfig},
+                nova::NovaCycleFoldConfig,
+            };
             use ark_r1cs_std::ToBitsGadget;
 
-            let cf_u_dummy_native = CommittedInstance::<C2>::dummy(cf_io_len(NOVA_CF_N_POINTS));
+            let cf_u_dummy_native =
+                CommittedInstance::<C2>::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
             let w_dummy_native =
                 Witness::<C2>::dummy(self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l, self.cf_E_len);
             let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -461,7 +461,7 @@ where
             let cf_u_dummy_native =
                 CycleFoldCommittedInstance::<C2>::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
             let w_dummy_native = CycleFoldWitness::<C2>::dummy(
-                vec![C2::ScalarField::zero(); self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l],
+                self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l,
                 self.cf_E_len,
             );
             let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -26,7 +26,7 @@ use crate::Error;
 use crate::FoldingScheme;
 use crate::{
     arith::r1cs::{extract_r1cs, extract_w_x, R1CS},
-    constants::N_BITS_RO,
+    constants::NOVA_N_BITS_RO,
     utils::{get_cm_coordinates, pp_hash},
 };
 
@@ -46,7 +46,7 @@ struct NovaCycleFoldConfig<C: CurveGroup> {
 }
 
 impl<C: CurveGroup> CycleFoldConfig for NovaCycleFoldConfig<C> {
-    const RANDOMNESS_BIT_LENGTH: usize = N_BITS_RO;
+    const RANDOMNESS_BIT_LENGTH: usize = NOVA_N_BITS_RO;
     const N_INPUT_POINTS: usize = 2;
     type C = C;
     type F = C::BaseField;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -16,7 +16,8 @@ use core::marker::PhantomData;
 
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::cyclefold::{
-    fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldConfig,
+    fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldCommittedInstance, CycleFoldConfig,
+    CycleFoldWitness,
 };
 use crate::folding::circuits::CF2;
 use crate::frontend::FCircuit;
@@ -97,30 +98,6 @@ where
     }
 }
 
-impl<C: CurveGroup> AbsorbNonNative<C::BaseField> for CommittedInstance<C>
-where
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField + Absorb,
-{
-    // Compatible with the in-circuit `CycleFoldCommittedInstanceVar::to_native_sponge_field_elements`
-    // in `cyclefold.rs`.
-    fn to_native_sponge_field_elements(&self, dest: &mut Vec<C::BaseField>) {
-        [self.u].to_native_sponge_field_elements(dest);
-        self.x.to_native_sponge_field_elements(dest);
-        let (cmE_x, cmE_y) = match self.cmE.into_affine().xy() {
-            Some((&x, &y)) => (x, y),
-            None => (C::BaseField::zero(), C::BaseField::zero()),
-        };
-        let (cmW_x, cmW_y) = match self.cmW.into_affine().xy() {
-            Some((&x, &y)) => (x, y),
-            None => (C::BaseField::zero(), C::BaseField::zero()),
-        };
-        cmE_x.to_sponge_field_elements(dest);
-        cmE_y.to_sponge_field_elements(dest);
-        cmW_x.to_sponge_field_elements(dest);
-        cmW_y.to_sponge_field_elements(dest);
-    }
-}
-
 impl<C: CurveGroup> CommittedInstance<C>
 where
     <C as Group>::ScalarField: Absorb,
@@ -144,25 +121,6 @@ where
         sponge.absorb(&z_0);
         sponge.absorb(&z_i);
         sponge.absorb(&self);
-        sponge.squeeze_field_elements(1)[0]
-    }
-}
-
-impl<C: CurveGroup> CommittedInstance<C>
-where
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField + Absorb,
-{
-    /// hash_cyclefold implements the committed instance hash compatible with the gadget implemented in
-    /// nova/cyclefold.rs::CycleFoldCommittedInstanceVar.hash.
-    /// Returns `H(U_i)`, where `U_i` is the `CommittedInstance` for CycleFold.
-    pub fn hash_cyclefold<T: Transcript<C::BaseField>>(
-        &self,
-        sponge: &T,
-        pp_hash: C::BaseField, // public params hash
-    ) -> C::BaseField {
-        let mut sponge = sponge.clone();
-        sponge.absorb(&pp_hash);
-        sponge.absorb_nonnative(self);
         sponge.squeeze_field_elements(1)[0]
     }
 }
@@ -355,8 +313,8 @@ where
     pub U_i: CommittedInstance<C1>,
 
     /// CycleFold running instance
-    pub cf_W_i: Witness<C2>,
-    pub cf_U_i: CommittedInstance<C2>,
+    pub cf_W_i: CycleFoldWitness<C2>,
+    pub cf_U_i: CycleFoldCommittedInstance<C2>,
 }
 
 impl<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool> FoldingScheme<C1, C2, FC>
@@ -383,7 +341,7 @@ where
     type RunningInstance = (CommittedInstance<C1>, Witness<C1>);
     type IncomingInstance = (CommittedInstance<C1>, Witness<C1>);
     type MultiCommittedInstanceWithWitness = ();
-    type CFInstance = (CommittedInstance<C2>, Witness<C2>);
+    type CFInstance = (CycleFoldCommittedInstance<C2>, CycleFoldWitness<C2>);
 
     fn preprocess(
         mut rng: impl RngCore,
@@ -866,19 +824,19 @@ where
     fn fold_cyclefold_circuit<T: Transcript<C1::ScalarField>>(
         &self,
         transcript: &mut T,
-        cf_W_i: Witness<C2>,           // witness of the running instance
-        cf_U_i: CommittedInstance<C2>, // running instance
+        cf_W_i: CycleFoldWitness<C2>, // witness of the running instance
+        cf_U_i: CycleFoldCommittedInstance<C2>, // running instance
         cf_u_i_x: Vec<C2::ScalarField>,
         cf_circuit: NovaCycleFoldCircuit<C1, GC1>,
         rng: &mut impl RngCore,
     ) -> Result<
         (
-            Witness<C2>,
-            CommittedInstance<C2>, // u_i
-            Witness<C2>,           // W_i1
-            CommittedInstance<C2>, // U_i1
-            C2,                    // cmT
-            C2::ScalarField,       // r_Fq
+            CycleFoldWitness<C2>,
+            CycleFoldCommittedInstance<C2>, // u_i
+            CycleFoldWitness<C2>,           // W_i1
+            CycleFoldCommittedInstance<C2>, // U_i1
+            C2,                             // cmT
+            C2::ScalarField,                // r_Fq
         ),
         Error,
     > {

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -4,7 +4,7 @@ use ark_crypto_primitives::sponge::{
     poseidon::{PoseidonConfig, PoseidonSponge},
     Absorb, CryptographicSponge,
 };
-use ark_ec::{AffineRepr, CurveGroup, Group};
+use ark_ec::{CurveGroup, Group};
 use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::{groups::GroupOpsBounds, prelude::CurveVar, ToConstraintFieldGadget};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use super::{CommittedInstance, Witness};
 use crate::arith::r1cs::R1CS;
 use crate::commitment::CommitmentScheme;
+use crate::folding::circuits::cyclefold::{CycleFoldCommittedInstance, CycleFoldWitness};
 use crate::transcript::Transcript;
 use crate::utils::vec::{hadamard, mat_vec_mul, vec_add, vec_scalar_mul, vec_sub};
 use crate::Error;
@@ -110,10 +111,10 @@ where
     pub fn compute_cyclefold_cmT(
         cs_prover_params: &CS::ProverParams,
         r1cs: &R1CS<C::ScalarField>, // R1CS over C2.Fr=C1.Fq (here C=C2)
-        w1: &Witness<C>,
-        ci1: &CommittedInstance<C>,
-        w2: &Witness<C>,
-        ci2: &CommittedInstance<C>,
+        w1: &CycleFoldWitness<C>,
+        ci1: &CycleFoldCommittedInstance<C>,
+        w2: &CycleFoldWitness<C>,
+        ci2: &CycleFoldCommittedInstance<C>,
     ) -> Result<(Vec<C::ScalarField>, C), Error>
     where
         <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,

--- a/folding-schemes/src/folding/nova/serialize.rs
+++ b/folding-schemes/src/folding/nova/serialize.rs
@@ -10,14 +10,14 @@ use ark_relations::r1cs::ConstraintSystem;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, SerializationError, Write};
 use std::marker::PhantomData;
 
-use super::{circuits::AugmentedFCircuit, Nova, ProverParams};
-use super::{CommittedInstance, Witness};
-use crate::folding::{
-    circuits::{cyclefold::CycleFoldCircuit, CF2},
-    nova::NOVA_CF_N_POINTS,
+use super::{
+    circuits::AugmentedFCircuit, CommittedInstance, Nova, NovaCycleFoldCircuit, ProverParams,
+    Witness,
 };
 use crate::{
-    arith::r1cs::extract_r1cs, commitment::CommitmentScheme, folding::circuits::CF1,
+    arith::r1cs::extract_r1cs,
+    commitment::CommitmentScheme,
+    folding::circuits::{CF1, CF2},
     frontend::FCircuit,
 };
 
@@ -138,7 +138,7 @@ where
         let cs2 = ConstraintSystem::<C1::BaseField>::new_ref();
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, GC2, FC>::empty(&poseidon_config, f_circuit.clone());
-        let cf_circuit = CycleFoldCircuit::<C1, GC1>::empty(NOVA_CF_N_POINTS);
+        let cf_circuit = NovaCycleFoldCircuit::<C1, GC1>::empty();
 
         augmented_F_circuit
             .generate_constraints(cs.clone())

--- a/folding-schemes/src/transcript/poseidon.rs
+++ b/folding-schemes/src/transcript/poseidon.rs
@@ -226,7 +226,7 @@ pub mod tests {
 
     #[test]
     fn test_transcript_and_transcriptvar_nbits() {
-        let nbits = crate::constants::N_BITS_RO;
+        let nbits = crate::constants::NOVA_N_BITS_RO;
 
         // use 'native' transcript
         let config = poseidon_canonical_config::<Fq>();


### PR DESCRIPTION
This PR depends on #95.

In Nova and HyperNova, the challenge `r` has 128 bits. On the other hand, `r` is sampled from the prime field in Protogalaxy and therefore may be longer than 128 bits.

This PR refactors CycleFold to support both cases. Now, in Nova and HyperNova, we create impls (e.g., `NovaCycleFoldConfig`) for `CycleFoldConfig` and set `CycleFoldConfig::RANDOMNESS_BIT_LENGTH = NOVA_N_BITS_RO`. While in (the incoming implementation of) Protogalaxy, we can set `CycleFoldConfig::RANDOMNESS_BIT_LENGTH = F::MODULUS_BIT_SIZE`.

In addition, now `CommittedInstance` and `Witness` from Nova are re-exported as `CycleFoldCommittedInstance` and `CycleFoldWitness` in `cyclefold.rs`, so the CycleFold instances and witnesses in HyperNova and ProtoGalaxy would have more clear type names.