### PR TITLE
fix sumcheck verifier for when poly=0

### DIFF
--- a/folding-schemes/src/utils/espresso/sum_check/verifier.rs
+++ b/folding-schemes/src/utils/espresso/sum_check/verifier.rs
@@ -137,7 +137,11 @@ impl<F: PrimeField + Absorb> SumCheckVerifier<F> for IOPVerifierState<F> {
         {
             let poly = DensePolynomial::from_coefficients_slice(coeffs);
             let eval_at_one: F = poly.iter().sum();
-            let eval_at_zero: F = poly.coeffs[0];
+            let eval_at_zero: F = if poly.coeffs.is_empty() {
+                F::zero()
+            } else {
+                poly.coeffs[0]
+            };
             let eval = eval_at_one + eval_at_zero;
 
             // the deferred check during the interactive phase:


### PR DESCRIPTION
@NiDimi reported (https://github.com/privacy-scaling-explorations/sonobe/issues/122) the sumcheck verification panicking when the poly is zero. This was due the verifier modified code was trying to access to `poly.coeffs[0]` and when the poly is zero this vec is empty.

This PR fixes it, and adds a test (which fails without this PR fix).

fixes #122 