### PR TITLE
Enable hiding commitments in nova and hypernova

### DIFF
--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -64,7 +64,8 @@ fn main() {
     let f_circuit_params = (r1cs_path, wasm_path, 1, 2);
     let f_circuit = CircomFCircuit::<Fr>::new(f_circuit_params).unwrap();
 
-    pub type N = Nova<G1, GVar, G2, GVar2, CircomFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
+    pub type N =
+        Nova<G1, GVar, G2, GVar2, CircomFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
     pub type D = DeciderEth<
         G1,
         GVar,

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -181,6 +181,7 @@ fn main() {
         ExternalInputsCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<Projective2>,
+        false,
     >;
 
     let mut rng = rand::rngs::OsRng;

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -81,7 +81,8 @@ fn main() {
 
     let f_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
 
-    pub type N = Nova<G1, GVar, G2, GVar2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
+    pub type N =
+        Nova<G1, GVar, G2, GVar2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
     pub type D = DeciderEth<
         G1,
         GVar,

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -137,6 +137,7 @@ fn main() {
         MultiInputsFCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<Projective2>,
+        false,
     >;
 
     println!("Prepare Nova ProverParams & VerifierParams");

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -119,6 +119,7 @@ fn main() {
         Sha256FCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<Projective2>,
+        false,
     >;
 
     let poseidon_config = poseidon_canonical_config::<Fr>();

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -382,7 +382,7 @@ where
 /// scheme struct because it is used both by Nova & HyperNova's CycleFold.
 #[allow(clippy::type_complexity)]
 #[allow(clippy::too_many_arguments)]
-pub fn fold_cyclefold_circuit<C1, GC1, C2, GC2, FC, CS1, CS2>(
+pub fn fold_cyclefold_circuit<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool>(
     _n_points: usize,
     transcript: &mut impl Transcript<C1::ScalarField>,
     cf_r1cs: R1CS<C2::ScalarField>,
@@ -409,8 +409,8 @@ where
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
     FC: FCircuit<C1::ScalarField>,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
     <C1 as CurveGroup>::BaseField: PrimeField,
     <C2 as CurveGroup>::BaseField: PrimeField,
     <C1 as Group>::ScalarField: Absorb,
@@ -433,10 +433,10 @@ where
 
     // fold cyclefold instances
     let cf_w_i = Witness::<C2>::new(cf_w_i.clone(), cf_r1cs.A.n_rows);
-    let cf_u_i: CommittedInstance<C2> = cf_w_i.commit::<CS2>(&cf_cs_params, cf_x_i.clone())?;
+    let cf_u_i: CommittedInstance<C2> = cf_w_i.commit::<CS2, H>(&cf_cs_params, cf_x_i.clone())?;
 
     // compute T* and cmT* for CycleFoldCircuit
-    let (cf_T, cf_cmT) = NIFS::<C2, CS2>::compute_cyclefold_cmT(
+    let (cf_T, cf_cmT) = NIFS::<C2, CS2, H>::compute_cyclefold_cmT(
         &cf_cs_params,
         &cf_r1cs,
         &cf_w_i,
@@ -455,7 +455,7 @@ where
     let cf_r_Fq = C1::BaseField::from_bigint(BigInteger::from_bits_le(&cf_r_bits))
         .expect("cf_r_bits out of bounds");
 
-    let (cf_W_i1, cf_U_i1) = NIFS::<C2, CS2>::fold_instances(
+    let (cf_W_i1, cf_U_i1) = NIFS::<C2, CS2, H>::fold_instances(
         cf_r_Fq, &cf_W_i, &cf_U_i, &cf_w_i, &cf_u_i, &cf_T, cf_cmT,
     )?;
     Ok((cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, cf_r_Fq))

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -432,7 +432,7 @@ where
     assert_eq!(cf_x_i.len(), cf_io_len(_n_points));
 
     // fold cyclefold instances
-    let cf_w_i = Witness::<C2>::new(cf_w_i.clone(), cf_r1cs.A.n_rows);
+    let cf_w_i = Witness::<C2>::new(cf_w_i.clone(), cf_W_i.rW, cf_r1cs.A.n_rows, cf_W_i.rE);
     let cf_u_i: CommittedInstance<C2> = cf_w_i.commit::<CS2, H>(&cf_cs_params, cf_x_i.clone())?;
 
     // compute T* and cmT* for CycleFoldCircuit

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -16,6 +16,7 @@ use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError,
 };
 use ark_std::fmt::Debug;
+use ark_std::rand::RngCore;
 use ark_std::Zero;
 use core::{borrow::Borrow, marker::PhantomData};
 
@@ -392,6 +393,7 @@ pub fn fold_cyclefold_circuit<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool>(
     cf_U_i: CommittedInstance<C2>, // running instance
     cf_u_i_x: Vec<C2::ScalarField>,
     cf_circuit: CycleFoldCircuit<C1, GC1>,
+    mut rng: impl RngCore,
 ) -> Result<
     (
         Witness<C2>,
@@ -432,7 +434,7 @@ where
     assert_eq!(cf_x_i.len(), cf_io_len(_n_points));
 
     // fold cyclefold instances
-    let cf_w_i = Witness::<C2>::new(cf_w_i.clone(), cf_W_i.rW, cf_r1cs.A.n_rows, cf_W_i.rE);
+    let cf_w_i = Witness::<C2>::new::<H>(cf_w_i.clone(), cf_r1cs.A.n_rows, &mut rng);
     let cf_u_i: CommittedInstance<C2> = cf_w_i.commit::<CS2, H>(&cf_cs_params, cf_x_i.clone())?;
 
     // compute T* and cmT* for CycleFoldCircuit

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -26,7 +26,7 @@ pub struct CCCS<C: CurveGroup> {
 }
 
 impl<F: PrimeField> CCS<F> {
-    pub fn to_cccs<R: Rng, C: CurveGroup, CS: CommitmentScheme<C>>(
+    pub fn to_cccs<R: Rng, C: CurveGroup, CS: CommitmentScheme<C, H>, const H: bool>(
         &self,
         rng: &mut R,
         cs_params: &CS::ProverParams,

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -1393,6 +1393,7 @@ mod tests {
                     cf_U_i.clone(), // CycleFold running instance
                     cf_u_i_x,       // CycleFold incoming instance
                     cf_circuit,
+                    &mut rng,
                 )
                 .unwrap();
 

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -949,7 +949,7 @@ mod tests {
         let mut lcccs_instances = Vec::new();
         for z_i in z_lcccs.iter() {
             let (inst, _) = ccs
-                .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                .to_lcccs::<_, _, Pedersen<Projective, true>, true>(&mut rng, &pedersen_params, z_i)
                 .unwrap();
             lcccs_instances.push(inst);
         }
@@ -957,7 +957,7 @@ mod tests {
         let mut cccs_instances = Vec::new();
         for z_i in z_cccs.iter() {
             let (inst, _) = ccs
-                .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, z_i)
                 .unwrap();
             cccs_instances.push(inst);
         }
@@ -1045,7 +1045,11 @@ mod tests {
         let mut w_lcccs = Vec::new();
         for z_i in z_lcccs.iter() {
             let (running_instance, w) = ccs
-                .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                .to_lcccs::<_, _, Pedersen<Projective, false>, false>(
+                    &mut rng,
+                    &pedersen_params,
+                    z_i,
+                )
                 .unwrap();
             lcccs_instances.push(running_instance);
             w_lcccs.push(w);
@@ -1055,7 +1059,7 @@ mod tests {
         let mut w_cccs = Vec::new();
         for z_i in z_cccs.iter() {
             let (new_instance, w) = ccs
-                .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, z_i)
                 .unwrap();
             cccs_instances.push(new_instance);
             w_cccs.push(w);
@@ -1139,7 +1143,7 @@ mod tests {
         let z_0 = vec![Fr::from(3_u32)];
         let z_i = vec![Fr::from(3_u32)];
         let (lcccs, _) = ccs
-            .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z1)
+            .to_lcccs::<_, _, Pedersen<Projective, true>, true>(&mut rng, &pedersen_params, &z1)
             .unwrap();
         let h = lcccs
             .clone()
@@ -1378,6 +1382,7 @@ mod tests {
                     CubicFCircuit<Fr>,
                     Pedersen<Projective>,
                     Pedersen<Projective2>,
+                    false,
                 >(
                     mu + nu,
                     &mut transcript_p,
@@ -1439,7 +1444,7 @@ mod tests {
             // compute committed instances, w_{i+1}, u_{i+1}, which will be used as w_i, u_i, so we
             // assign them directly to w_i, u_i.
             (u_i, w_i) = ccs
-                .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &r1cs_z)
+                .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &r1cs_z)
                 .unwrap();
             u_i.check_relation(&ccs, &w_i).unwrap();
 

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -30,7 +30,7 @@ pub struct LCCCS<C: CurveGroup> {
 }
 
 impl<F: PrimeField> CCS<F> {
-    pub fn to_lcccs<R: Rng, C: CurveGroup, CS: CommitmentScheme<C>>(
+    pub fn to_lcccs<R: Rng, C: CurveGroup, CS: CommitmentScheme<C, H>, const H: bool>(
         &self,
         rng: &mut R,
         cs_params: &CS::ProverParams,
@@ -221,7 +221,11 @@ pub mod tests {
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
 
         let (lcccs, _) = ccs
-            .to_lcccs::<_, Projective, Pedersen<Projective>>(&mut rng, &pedersen_params, &z)
+            .to_lcccs::<_, Projective, Pedersen<Projective, false>, false>(
+                &mut rng,
+                &pedersen_params,
+                &z,
+            )
             .unwrap();
         // with our test vector coming from R1CS, v should have length 3
         assert_eq!(lcccs.v.len(), 3);
@@ -255,7 +259,7 @@ pub mod tests {
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
         // Compute v_j with the right z
         let (lcccs, _) = ccs
-            .to_lcccs::<_, Projective, Pedersen<Projective>>(&mut rng, &pedersen_params, &z)
+            .to_lcccs::<_, Projective, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z)
             .unwrap();
         // with our test vector coming from R1CS, v should have length 3
         assert_eq!(lcccs.v.len(), 3);

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -61,12 +61,12 @@ impl<F: PrimeField> Witness<F> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ProverParams<C1, C2, CS1, CS2>
+pub struct ProverParams<C1, C2, CS1, CS2, const H: bool>
 where
     C1: CurveGroup,
     C2: CurveGroup,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
 {
     pub poseidon_config: PoseidonConfig<C1::ScalarField>,
     pub cs_params: CS1::ProverParams,
@@ -81,8 +81,9 @@ where
 pub struct VerifierParams<
     C1: CurveGroup,
     C2: CurveGroup,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
+    const H: bool,
 > {
     pub poseidon_config: PoseidonConfig<C1::ScalarField>,
     pub ccs: CCS<C1::ScalarField>,
@@ -91,16 +92,16 @@ pub struct VerifierParams<
     pub cf_cs_vp: CS2::VerifierParams,
 }
 
-impl<C1, C2, CS1, CS2> VerifierParams<C1, C2, CS1, CS2>
+impl<C1, C2, CS1, CS2, const H: bool> VerifierParams<C1, C2, CS1, CS2, H>
 where
     C1: CurveGroup,
     C2: CurveGroup,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
 {
     /// returns the hash of the public parameters of HyperNova
     pub fn pp_hash(&self) -> Result<C1::ScalarField, Error> {
-        pp_hash::<C1, C2, CS1, CS2>(
+        pp_hash::<C1, C2, CS1, CS2, H>(
             &self.ccs,
             &self.cf_r1cs,
             &self.cs_vp,
@@ -114,15 +115,15 @@ where
 /// [HyperNova](https://eprint.iacr.org/2023/573.pdf) and
 /// [CycleFold](https://eprint.iacr.org/2023/1192.pdf), following the FoldingScheme trait
 #[derive(Clone, Debug)]
-pub struct HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2>
+pub struct HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>>,
     FC: FCircuit<C1::ScalarField>,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
 {
     _gc1: PhantomData<GC1>,
     _c2: PhantomData<C2>,
@@ -159,16 +160,16 @@ where
     pub cf_U_i: CommittedInstance<C2>,
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2> MultiFolding<C1, C2, FC>
-    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2>
+impl<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool> MultiFolding<C1, C2, FC>
+    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, H>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
     FC: FCircuit<C1::ScalarField>,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
     <C1 as CurveGroup>::BaseField: PrimeField,
     <C2 as CurveGroup>::BaseField: PrimeField,
     <C1 as Group>::ScalarField: Absorb,
@@ -195,7 +196,7 @@ where
         // assign them directly to w_i, u_i.
         let (U_i, W_i) = self
             .ccs
-            .to_lcccs::<_, _, CS1>(&mut rng, &self.cs_params, &r1cs_z)?;
+            .to_lcccs::<_, _, CS1, H>(&mut rng, &self.cs_params, &r1cs_z)?;
 
         #[cfg(test)]
         U_i.check_relation(&self.ccs, &W_i)?;
@@ -217,7 +218,7 @@ where
         // assign them directly to w_i, u_i.
         let (u_i, w_i) = self
             .ccs
-            .to_cccs::<_, _, CS1>(&mut rng, &self.cs_params, &r1cs_z)?;
+            .to_cccs::<_, _, CS1, H>(&mut rng, &self.cs_params, &r1cs_z)?;
 
         #[cfg(test)]
         u_i.check_relation(&self.ccs, &w_i)?;
@@ -226,15 +227,15 @@ where
     }
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2> HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2>
+impl<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool> HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, H>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
     FC: FCircuit<C1::ScalarField>,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
     <C1 as CurveGroup>::BaseField: PrimeField,
     <C2 as CurveGroup>::BaseField: PrimeField,
     <C1 as Group>::ScalarField: Absorb,
@@ -333,16 +334,16 @@ where
     }
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2> FoldingScheme<C1, C2, FC>
-    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2>
+impl<C1, GC1, C2, GC2, FC, CS1, CS2, const H: bool> FoldingScheme<C1, C2, FC>
+    for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, H>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
     FC: FCircuit<C1::ScalarField>,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
     <C1 as CurveGroup>::BaseField: PrimeField,
     <C2 as CurveGroup>::BaseField: PrimeField,
     <C1 as Group>::ScalarField: Absorb,
@@ -354,9 +355,9 @@ where
     /// Reuse Nova's PreprocessorParam, together with two usize values, which are mu & nu
     /// respectively, which indicate the amount of LCCCS & CCCS instances to be folded at each
     /// folding step.
-    type PreprocessorParam = (PreprocessorParam<C1, C2, FC, CS1, CS2>, usize, usize);
-    type ProverParam = ProverParams<C1, C2, CS1, CS2>;
-    type VerifierParam = VerifierParams<C1, C2, CS1, CS2>;
+    type PreprocessorParam = (PreprocessorParam<C1, C2, FC, CS1, CS2, H>, usize, usize);
+    type ProverParam = ProverParams<C1, C2, CS1, CS2, H>;
+    type VerifierParam = VerifierParams<C1, C2, CS1, CS2, H>;
     type RunningInstance = (LCCCS<C1>, Witness<C1::ScalarField>);
     type IncomingInstance = (CCCS<C1>, Witness<C1::ScalarField>);
     type MultiCommittedInstanceWithWitness =
@@ -403,7 +404,7 @@ where
             (cf_cs_pp, cf_cs_vp) = CS2::setup(&mut rng, cf_r1cs.A.n_cols - cf_r1cs.l - 1)?;
         }
 
-        let pp = ProverParams::<C1, C2, CS1, CS2> {
+        let pp = ProverParams::<C1, C2, CS1, CS2, H> {
             poseidon_config: prep_param.poseidon_config.clone(),
             cs_params: cs_pp.clone(),
             cf_cs_params: cf_cs_pp.clone(),
@@ -411,7 +412,7 @@ where
             mu: *mu,
             nu: *nu,
         };
-        let vp = VerifierParams::<C1, C2, CS1, CS2> {
+        let vp = VerifierParams::<C1, C2, CS1, CS2, H> {
             poseidon_config: prep_param.poseidon_config.clone(),
             ccs,
             cf_r1cs,
@@ -697,7 +698,7 @@ where
             };
 
             let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
-                fold_cyclefold_circuit::<C1, GC1, C2, GC2, FC, CS1, CS2>(
+                fold_cyclefold_circuit::<C1, GC1, C2, GC2, FC, CS1, CS2, H>(
                     self.mu + self.nu,
                     &mut transcript_p,
                     self.cf_r1cs.clone(),
@@ -762,7 +763,7 @@ where
         // assign them directly to w_i, u_i.
         let (u_i, w_i) = self
             .ccs
-            .to_cccs::<_, C1, CS1>(&mut rng, &self.cs_params, &r1cs_z)?;
+            .to_cccs::<_, C1, CS1, H>(&mut rng, &self.cs_params, &r1cs_z)?;
         self.u_i = u_i.clone();
         self.w_i = w_i.clone();
 
@@ -874,35 +875,63 @@ mod tests {
         let F_circuit = CubicFCircuit::<Fr>::new(()).unwrap();
 
         // run the test using Pedersen commitments on both sides of the curve cycle
-        test_ivc_opt::<Pedersen<Projective>, Pedersen<Projective2>>(
+        test_ivc_opt::<Pedersen<Projective>, Pedersen<Projective2>, false>(
             poseidon_config.clone(),
             F_circuit,
         );
+
+        test_ivc_opt::<Pedersen<Projective, true>, Pedersen<Projective2, true>, true>(
+            poseidon_config.clone(),
+            F_circuit,
+        );
+
         // run the test using KZG for the commitments on the main curve, and Pedersen for the
         // commitments on the secondary curve
-        test_ivc_opt::<KZG<Bn254>, Pedersen<Projective2>>(poseidon_config, F_circuit);
+        test_ivc_opt::<KZG<Bn254>, Pedersen<Projective2>, false>(poseidon_config, F_circuit);
     }
 
     // test_ivc allowing to choose the CommitmentSchemes
-    fn test_ivc_opt<CS1: CommitmentScheme<Projective>, CS2: CommitmentScheme<Projective2>>(
+    fn test_ivc_opt<
+        CS1: CommitmentScheme<Projective, H>,
+        CS2: CommitmentScheme<Projective2, H>,
+        const H: bool,
+    >(
         poseidon_config: PoseidonConfig<Fr>,
         F_circuit: CubicFCircuit<Fr>,
     ) {
         let mut rng = ark_std::test_rng();
 
-        type HN<CS1, CS2> =
-            HyperNova<Projective, GVar, Projective2, GVar2, CubicFCircuit<Fr>, CS1, CS2>;
         let (mu, nu) = (2, 3);
 
         let prep_param =
-            PreprocessorParam::<Projective, Projective2, CubicFCircuit<Fr>, CS1, CS2>::new(
+            PreprocessorParam::<Projective, Projective2, CubicFCircuit<Fr>, CS1, CS2, H>::new(
                 poseidon_config.clone(),
                 F_circuit,
             );
-        let hypernova_params = HN::preprocess(&mut rng, &(prep_param, mu, nu)).unwrap();
+        let hypernova_params = HyperNova::<
+            Projective,
+            GVar,
+            Projective2,
+            GVar2,
+            CubicFCircuit<Fr>,
+            CS1,
+            CS2,
+            H,
+        >::preprocess(&mut rng, &(prep_param, mu, nu))
+        .unwrap();
 
         let z_0 = vec![Fr::from(3_u32)];
-        let mut hypernova = HN::init(&hypernova_params, F_circuit, z_0.clone()).unwrap();
+        let mut hypernova = HyperNova::<
+            Projective,
+            GVar,
+            Projective2,
+            GVar2,
+            CubicFCircuit<Fr>,
+            CS1,
+            CS2,
+            H,
+        >::init(&hypernova_params, F_circuit, z_0.clone())
+        .unwrap();
 
         let num_steps: usize = 3;
         for _ in 0..num_steps {
@@ -932,7 +961,7 @@ mod tests {
         assert_eq!(Fr::from(num_steps as u32), hypernova.i);
 
         let (running_instance, incoming_instance, cyclefold_instance) = hypernova.instances();
-        HN::verify(
+        HyperNova::<Projective, GVar, Projective2, GVar2, CubicFCircuit<Fr>, CS1, CS2, H>::verify(
             hypernova_params.1, // verifier_params
             z_0,
             hypernova.z_i,

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -725,6 +725,7 @@ where
                     self.cf_U_i.clone(), // CycleFold running instance
                     cf_u_i_x,
                     cf_circuit,
+                    &mut rng,
                 )?;
 
             cf_u_i1_x = cf_U_i1.hash_cyclefold(&sponge, self.pp_hash);

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -441,10 +441,10 @@ pub mod tests {
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
 
         let (lcccs, w1) = ccs
-            .to_lcccs::<_, Projective, Pedersen<Projective>>(&mut rng, &pedersen_params, &z1)
+            .to_lcccs::<_, Projective, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z1)
             .unwrap();
         let (cccs, w2) = ccs
-            .to_cccs::<_, Projective, Pedersen<Projective>>(&mut rng, &pedersen_params, &z2)
+            .to_cccs::<_, Projective, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z2)
             .unwrap();
 
         lcccs.check_relation(&ccs, &w1).unwrap();
@@ -484,11 +484,11 @@ pub mod tests {
 
         // Create the LCCCS instance out of z_1
         let (running_instance, w1) = ccs
-            .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z_1)
+            .to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z_1)
             .unwrap();
         // Create the CCCS instance out of z_2
         let (new_instance, w2) = ccs
-            .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z_2)
+            .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z_2)
             .unwrap();
 
         // Prover's transcript
@@ -540,7 +540,7 @@ pub mod tests {
         // LCCCS witness
         let z_1 = get_test_z(2);
         let (mut running_instance, mut w1) = ccs
-            .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z_1)
+            .to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z_1)
             .unwrap();
 
         let poseidon_config = poseidon_canonical_config::<Fr>();
@@ -557,7 +557,7 @@ pub mod tests {
             let z_2 = get_test_z(i);
 
             let (new_instance, w2) = ccs
-                .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z_2)
+                .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z_2)
                 .unwrap();
 
             // run the prover side of the multifolding
@@ -621,7 +621,7 @@ pub mod tests {
         let mut w_lcccs = Vec::new();
         for z_i in z_lcccs.iter() {
             let (running_instance, w) = ccs
-                .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                .to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, z_i)
                 .unwrap();
             lcccs_instances.push(running_instance);
             w_lcccs.push(w);
@@ -631,7 +631,7 @@ pub mod tests {
         let mut w_cccs = Vec::new();
         for z_i in z_cccs.iter() {
             let (new_instance, w) = ccs
-                .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, z_i)
                 .unwrap();
             cccs_instances.push(new_instance);
             w_cccs.push(w);
@@ -717,7 +717,7 @@ pub mod tests {
             let mut w_lcccs = Vec::new();
             for z_i in z_lcccs.iter() {
                 let (running_instance, w) = ccs
-                    .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                    .to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, z_i)
                     .unwrap();
                 lcccs_instances.push(running_instance);
                 w_lcccs.push(w);
@@ -727,7 +727,7 @@ pub mod tests {
             let mut w_cccs = Vec::new();
             for z_i in z_cccs.iter() {
                 let (new_instance, w) = ccs
-                    .to_cccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, z_i)
+                    .to_cccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, z_i)
                     .unwrap();
                 cccs_instances.push(new_instance);
                 w_cccs.push(w);

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -242,7 +242,7 @@ pub mod tests {
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
         let (lcccs_instance, _) = ccs
-            .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z1)
+            .to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z1)
             .unwrap();
 
         let sigmas_thetas =
@@ -292,7 +292,7 @@ pub mod tests {
         let (pedersen_params, _) =
             Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1).unwrap();
         let (lcccs_instance, _) = ccs
-            .to_lcccs::<_, _, Pedersen<Projective>>(&mut rng, &pedersen_params, &z1)
+            .to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z1)
             .unwrap();
 
         // Compute g(x) with that r_x

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -81,10 +81,10 @@ where
     for<'b> &'b GC1: GroupOpsBounds<'b, C1, GC1>,
     for<'b> &'b GC2: GroupOpsBounds<'b, C2, GC2>,
     // constrain FS into Nova, since this is a Decider specifically for Nova
-    Nova<C1, GC1, C2, GC2, FC, CS1, CS2>: From<FS>,
-    crate::folding::nova::ProverParams<C1, C2, CS1, CS2>:
+    Nova<C1, GC1, C2, GC2, FC, CS1, CS2, false>: From<FS>,
+    crate::folding::nova::ProverParams<C1, C2, CS1, CS2, false>:
         From<<FS as FoldingScheme<C1, C2, FC>>::ProverParam>,
-    crate::folding::nova::VerifierParams<C1, C2, CS1, CS2>:
+    crate::folding::nova::VerifierParams<C1, C2, CS1, CS2, false>:
         From<<FS as FoldingScheme<C1, C2, FC>>::VerifierParam>,
 {
     type PreprocessorParam = (FS::ProverParam, FS::VerifierParam);
@@ -108,14 +108,17 @@ where
 
         // get the FoldingScheme prover & verifier params from Nova
         #[allow(clippy::type_complexity)]
-        let nova_pp:
-            <Nova<C1, GC1, C2, GC2, FC, CS1, CS2> as FoldingScheme<C1, C2, FC>>::ProverParam =
-                prep_param.0.clone().into()
-            ;
+        let nova_pp: <Nova<C1, GC1, C2, GC2, FC, CS1, CS2, false> as FoldingScheme<
+            C1,
+            C2,
+            FC,
+        >>::ProverParam = prep_param.0.clone().into();
         #[allow(clippy::type_complexity)]
-        let nova_vp:
-            <Nova<C1, GC1, C2, GC2, FC, CS1, CS2> as FoldingScheme<C1, C2, FC>>::VerifierParam =
-                prep_param.1.clone().into();
+        let nova_vp: <Nova<C1, GC1, C2, GC2, FC, CS1, CS2, false> as FoldingScheme<
+            C1,
+            C2,
+            FC,
+        >>::VerifierParam = prep_param.1.clone().into();
         let pp_hash = nova_vp.pp_hash()?;
 
         let pp = (g16_pk, nova_pp.cs_pp);
@@ -338,6 +341,7 @@ pub mod tests {
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
+            false,
         >;
         type D = Decider<
             Projective,

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -378,7 +378,9 @@ where
         let u_dummy_native = CommittedInstance::<C1>::dummy(2);
         let w_dummy_native = Witness::<C1>::new(
             vec![C1::ScalarField::zero(); self.r1cs.A.n_cols - 3 /* (3=2+1, since u_i.x.len=2) */],
+            C1::ScalarField::zero(),
             self.E_len,
+            C1::ScalarField::zero(),
         );
 
         let u_i = CommittedInstanceVar::<C1>::new_witness(cs.clone(), || {
@@ -455,7 +457,9 @@ where
             let cf_u_dummy_native = CommittedInstance::<C2>::dummy(cf_io_len(NOVA_CF_N_POINTS));
             let w_dummy_native = Witness::<C2>::new(
                 vec![C2::ScalarField::zero(); self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l],
+                C2::ScalarField::zero(),
                 self.cf_E_len,
+                C2::ScalarField::zero(),
             );
             let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
                 Ok(self.cf_U_i.unwrap_or_else(|| cf_u_dummy_native.clone()))

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -193,14 +193,14 @@ where
 /// Circuit that implements the in-circuit checks needed for the onchain (Ethereum's EVM)
 /// verification.
 #[derive(Clone, Debug)]
-pub struct DeciderEthCircuit<C1, GC1, C2, GC2, CS1, CS2>
+pub struct DeciderEthCircuit<C1, GC1, C2, GC2, CS1, CS2, const H: bool = false>
 where
     C1: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>>,
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>>,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
 {
     _c1: PhantomData<C1>,
     _gc1: PhantomData<GC1>,
@@ -246,25 +246,25 @@ where
     pub eval_W: Option<C1::ScalarField>,
     pub eval_E: Option<C1::ScalarField>,
 }
-impl<C1, GC1, C2, GC2, CS1, CS2> DeciderEthCircuit<C1, GC1, C2, GC2, CS1, CS2>
+impl<C1, GC1, C2, GC2, CS1, CS2, const H: bool> DeciderEthCircuit<C1, GC1, C2, GC2, CS1, CS2, H>
 where
     C1: CurveGroup,
     C2: CurveGroup,
     GC1: CurveVar<C1, CF2<C1>> + ToConstraintFieldGadget<CF2<C1>>,
     GC2: CurveVar<C2, CF2<C2>> + ToConstraintFieldGadget<CF2<C2>>,
-    CS1: CommitmentScheme<C1>,
+    CS1: CommitmentScheme<C1, H>,
     // enforce that the CS2 is Pedersen commitment scheme, since we're at Ethereum's EVM decider
-    CS2: CommitmentScheme<C2, ProverParams = PedersenParams<C2>>,
+    CS2: CommitmentScheme<C2, H, ProverParams = PedersenParams<C2>>,
     <C1 as Group>::ScalarField: Absorb,
     <C1 as CurveGroup>::BaseField: PrimeField,
 {
     pub fn from_nova<FC: FCircuit<C1::ScalarField>>(
-        nova: Nova<C1, GC1, C2, GC2, FC, CS1, CS2>,
+        nova: Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>,
     ) -> Result<Self, Error> {
         let mut transcript = PoseidonSponge::<C1::ScalarField>::new(&nova.poseidon_config);
 
         // compute the U_{i+1}, W_{i+1}
-        let (T, cmT) = NIFS::<C1, CS1>::compute_cmT(
+        let (T, cmT) = NIFS::<C1, CS1, H>::compute_cmT(
             &nova.cs_pp,
             &nova.r1cs.clone(),
             &nova.w_i.clone(),
@@ -281,7 +281,7 @@ where
         );
         let r_Fr = C1::ScalarField::from_bigint(BigInteger::from_bits_le(&r_bits))
             .ok_or(Error::OutOfBounds)?;
-        let (W_i1, U_i1) = NIFS::<C1, CS1>::fold_instances(
+        let (W_i1, U_i1) = NIFS::<C1, CS1, H>::fold_instances(
             r_Fr, &nova.W_i, &nova.U_i, &nova.w_i, &nova.u_i, &T, cmT,
         )?;
 
@@ -788,6 +788,7 @@ pub mod tests {
             CubicFCircuit<Fr>,
             Pedersen<Projective>,
             Pedersen<Projective2>,
+            false,
         >;
 
         let prep_param = PreprocessorParam::<
@@ -796,6 +797,7 @@ pub mod tests {
             CubicFCircuit<Fr>,
             Pedersen<Projective>,
             Pedersen<Projective2>,
+            false,
         >::new(poseidon_config, F_circuit);
         let nova_params = N::preprocess(&mut rng, &prep_param).unwrap();
 

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -376,10 +376,9 @@ where
         })?;
 
         let u_dummy_native = CommittedInstance::<C1>::dummy(2);
-        let w_dummy_native = Witness::<C1>::new::<false>(
-            vec![C1::ScalarField::zero(); self.r1cs.A.n_cols - 3 /* (3=2+1, since u_i.x.len=2) */],
+        let w_dummy_native = Witness::<C1>::dummy(
+            self.r1cs.A.n_cols - 3, /* (3=2+1, since u_i.x.len=2) */
             self.E_len,
-            test_rng(),
         );
 
         let u_i = CommittedInstanceVar::<C1>::new_witness(cs.clone(), || {
@@ -454,11 +453,8 @@ where
             use ark_r1cs_std::ToBitsGadget;
 
             let cf_u_dummy_native = CommittedInstance::<C2>::dummy(cf_io_len(NOVA_CF_N_POINTS));
-            let w_dummy_native = Witness::<C2>::new::<false>(
-                vec![C2::ScalarField::zero(); self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l],
-                self.cf_E_len,
-                test_rng(),
-            );
+            let w_dummy_native =
+                Witness::<C2>::dummy(self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l, self.cf_E_len);
             let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
                 Ok(self.cf_U_i.unwrap_or_else(|| cf_u_dummy_native.clone()))
             })?;

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -19,7 +19,7 @@ use ark_r1cs_std::{
     ToConstraintFieldGadget,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, Namespace, SynthesisError};
-use ark_std::{log2, test_rng, Zero};
+use ark_std::{log2, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
 use super::{circuits::ChallengeGadget, nifs::NIFS};

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -19,7 +19,7 @@ use ark_r1cs_std::{
     ToConstraintFieldGadget,
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, Namespace, SynthesisError};
-use ark_std::{log2, Zero};
+use ark_std::{log2, test_rng, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
 use super::{circuits::ChallengeGadget, nifs::NIFS};
@@ -376,11 +376,10 @@ where
         })?;
 
         let u_dummy_native = CommittedInstance::<C1>::dummy(2);
-        let w_dummy_native = Witness::<C1>::new(
+        let w_dummy_native = Witness::<C1>::new::<false>(
             vec![C1::ScalarField::zero(); self.r1cs.A.n_cols - 3 /* (3=2+1, since u_i.x.len=2) */],
-            C1::ScalarField::zero(),
             self.E_len,
-            C1::ScalarField::zero(),
+            test_rng(),
         );
 
         let u_i = CommittedInstanceVar::<C1>::new_witness(cs.clone(), || {
@@ -455,11 +454,10 @@ where
             use ark_r1cs_std::ToBitsGadget;
 
             let cf_u_dummy_native = CommittedInstance::<C2>::dummy(cf_io_len(NOVA_CF_N_POINTS));
-            let w_dummy_native = Witness::<C2>::new(
+            let w_dummy_native = Witness::<C2>::new::<false>(
                 vec![C2::ScalarField::zero(); self.cf_r1cs.A.n_cols - 1 - self.cf_r1cs.l],
-                C2::ScalarField::zero(),
                 self.cf_E_len,
-                C2::ScalarField::zero(),
+                test_rng(),
             );
             let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
                 Ok(self.cf_U_i.unwrap_or_else(|| cf_u_dummy_native.clone()))

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -184,6 +184,18 @@ where
         }
     }
 
+    pub fn dummy(w_len: usize, e_len: usize) -> Self {
+        let (rW, rE) = (C::ScalarField::zero(), C::ScalarField::zero());
+        let w = vec![C::ScalarField::zero(); w_len];
+
+        Self {
+            E: vec![C::ScalarField::zero(); e_len],
+            rE,
+            W: w,
+            rW,
+        }
+    }
+
     pub fn commit<CS: CommitmentScheme<C, HC>, const HC: bool>(
         &self,
         params: &CS::ProverParams,

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -857,7 +857,7 @@ where
             self.cf_r1cs.clone(),
             self.cf_cs_pp.clone(),
             self.pp_hash,
-            cf_W_i.clone(),
+            cf_W_i,
             cf_U_i,
             cf_u_i_x,
             cf_circuit,

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -305,11 +305,7 @@ pub mod tests {
         let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, r1cs.A.n_cols).unwrap();
 
         // dummy instance, witness and public inputs zeroes
-        let w_dummy = Witness::<Projective>::new::<false>(
-            vec![Fr::zero(); w1.len()],
-            r1cs.A.n_rows,
-            test_rng(),
-        );
+        let w_dummy = Witness::<Projective>::dummy(w1.len(), r1cs.A.n_rows);
         let mut u_dummy = w_dummy
             .commit::<Pedersen<Projective>, false>(&pedersen_params, vec![Fr::zero(); x1.len()])
             .unwrap();

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -242,8 +242,18 @@ pub mod tests {
         let (w1, x1) = r1cs.split_z(&z1);
         let (w2, x2) = r1cs.split_z(&z2);
 
-        let w1 = Witness::<C>::new(w1.clone(), r1cs.A.n_rows);
-        let w2 = Witness::<C>::new(w2.clone(), r1cs.A.n_rows);
+        let w1 = Witness::<C>::new(
+            w1.clone(),
+            C::ScalarField::zero(),
+            r1cs.A.n_rows,
+            C::ScalarField::zero(),
+        );
+        let w2 = Witness::<C>::new(
+            w2.clone(),
+            C::ScalarField::zero(),
+            r1cs.A.n_rows,
+            C::ScalarField::zero(),
+        );
 
         let mut rng = ark_std::test_rng();
         let (pedersen_params, _) = Pedersen::<C>::setup(&mut rng, r1cs.A.n_cols).unwrap();
@@ -305,7 +315,12 @@ pub mod tests {
         let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, r1cs.A.n_cols).unwrap();
 
         // dummy instance, witness and public inputs zeroes
-        let w_dummy = Witness::<Projective>::new(vec![Fr::zero(); w1.len()], r1cs.A.n_rows);
+        let w_dummy = Witness::<Projective>::new(
+            vec![Fr::zero(); w1.len()],
+            Fr::zero(),
+            r1cs.A.n_rows,
+            Fr::zero(),
+        );
         let mut u_dummy = w_dummy
             .commit::<Pedersen<Projective>, false>(&pedersen_params, vec![Fr::zero(); x1.len()])
             .unwrap();
@@ -418,7 +433,8 @@ pub mod tests {
         let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, r1cs.A.n_cols).unwrap();
 
         // prepare the running instance
-        let mut running_instance_w = Witness::<Projective>::new(w.clone(), r1cs.A.n_rows);
+        let mut running_instance_w =
+            Witness::<Projective>::new(w.clone(), Fr::zero(), r1cs.A.n_rows, Fr::zero());
         let mut running_committed_instance = running_instance_w
             .commit::<Pedersen<Projective>, false>(&pedersen_params, x)
             .unwrap();
@@ -431,7 +447,8 @@ pub mod tests {
             // prepare the incoming instance
             let incoming_instance_z = get_test_z(i + 4);
             let (w, x) = r1cs.split_z(&incoming_instance_z);
-            let incoming_instance_w = Witness::<Projective>::new(w.clone(), r1cs.A.n_rows);
+            let incoming_instance_w =
+                Witness::<Projective>::new(w.clone(), Fr::zero(), r1cs.A.n_rows, Fr::zero());
             let incoming_committed_instance = incoming_instance_w
                 .commit::<Pedersen<Projective>, false>(&pedersen_params, x)
                 .unwrap();

--- a/folding-schemes/src/folding/nova/nifs.rs
+++ b/folding-schemes/src/folding/nova/nifs.rs
@@ -207,7 +207,7 @@ pub mod tests {
     };
     use ark_ff::{BigInteger, PrimeField};
     use ark_pallas::{Fr, Projective};
-    use ark_std::{ops::Mul, UniformRand};
+    use ark_std::{ops::Mul, test_rng, UniformRand};
 
     use crate::arith::r1cs::tests::{get_test_r1cs, get_test_z};
     use crate::commitment::pedersen::{Params as PedersenParams, Pedersen};
@@ -242,18 +242,8 @@ pub mod tests {
         let (w1, x1) = r1cs.split_z(&z1);
         let (w2, x2) = r1cs.split_z(&z2);
 
-        let w1 = Witness::<C>::new(
-            w1.clone(),
-            C::ScalarField::zero(),
-            r1cs.A.n_rows,
-            C::ScalarField::zero(),
-        );
-        let w2 = Witness::<C>::new(
-            w2.clone(),
-            C::ScalarField::zero(),
-            r1cs.A.n_rows,
-            C::ScalarField::zero(),
-        );
+        let w1 = Witness::<C>::new::<false>(w1.clone(), r1cs.A.n_rows, test_rng());
+        let w2 = Witness::<C>::new::<false>(w2.clone(), r1cs.A.n_rows, test_rng());
 
         let mut rng = ark_std::test_rng();
         let (pedersen_params, _) = Pedersen::<C>::setup(&mut rng, r1cs.A.n_cols).unwrap();
@@ -315,11 +305,10 @@ pub mod tests {
         let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, r1cs.A.n_cols).unwrap();
 
         // dummy instance, witness and public inputs zeroes
-        let w_dummy = Witness::<Projective>::new(
+        let w_dummy = Witness::<Projective>::new::<false>(
             vec![Fr::zero(); w1.len()],
-            Fr::zero(),
             r1cs.A.n_rows,
-            Fr::zero(),
+            test_rng(),
         );
         let mut u_dummy = w_dummy
             .commit::<Pedersen<Projective>, false>(&pedersen_params, vec![Fr::zero(); x1.len()])
@@ -434,7 +423,7 @@ pub mod tests {
 
         // prepare the running instance
         let mut running_instance_w =
-            Witness::<Projective>::new(w.clone(), Fr::zero(), r1cs.A.n_rows, Fr::zero());
+            Witness::<Projective>::new::<false>(w.clone(), r1cs.A.n_rows, test_rng());
         let mut running_committed_instance = running_instance_w
             .commit::<Pedersen<Projective>, false>(&pedersen_params, x)
             .unwrap();
@@ -448,7 +437,7 @@ pub mod tests {
             let incoming_instance_z = get_test_z(i + 4);
             let (w, x) = r1cs.split_z(&incoming_instance_z);
             let incoming_instance_w =
-                Witness::<Projective>::new(w.clone(), Fr::zero(), r1cs.A.n_rows, Fr::zero());
+                Witness::<Projective>::new::<false>(w.clone(), r1cs.A.n_rows, test_rng());
             let incoming_committed_instance = incoming_instance_w
                 .commit::<Pedersen<Projective>, false>(&pedersen_params, x)
                 .unwrap();

--- a/folding-schemes/src/folding/nova/serialize.rs
+++ b/folding-schemes/src/folding/nova/serialize.rs
@@ -54,8 +54,7 @@ where
         self.W_i.serialize_with_mode(&mut writer, compress)?;
         self.U_i.serialize_with_mode(&mut writer, compress)?;
         self.cf_W_i.serialize_with_mode(&mut writer, compress)?;
-        self.cf_U_i.serialize_with_mode(&mut writer, compress)?;
-        self.cs_is_hiding.serialize_with_mode(&mut writer, compress)
+        self.cf_U_i.serialize_with_mode(&mut writer, compress)
     }
 
     fn serialized_size(&self, compress: ark_serialize::Compress) -> usize {
@@ -69,7 +68,6 @@ where
             + self.U_i.serialized_size(compress)
             + self.cf_W_i.serialized_size(compress)
             + self.cf_U_i.serialized_size(compress)
-            + self.cs_is_hiding.serialized_size(compress)
     }
 
     fn serialize_compressed<W: Write>(
@@ -155,7 +153,6 @@ where
         cs2.finalize();
         let cs2 = cs2.into_inner().ok_or(SerializationError::InvalidData)?;
         let cf_r1cs = extract_r1cs::<C1::BaseField>(&cs2);
-        let cs_is_hiding = bool::deserialize_with_mode(&mut reader, compress, validate)?;
         Ok(Nova {
             _gc1: PhantomData,
             _c2: PhantomData,
@@ -176,7 +173,6 @@ where
             U_i,
             cf_W_i,
             cf_U_i,
-            cs_is_hiding,
         })
     }
 }

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -34,7 +34,12 @@ where
 {
     fn dummy_instance(&self) -> (Witness<C>, CommittedInstance<C>) {
         let w_len = self.A.n_cols - 1 - self.l;
-        let w_dummy = Witness::<C>::new(vec![C::ScalarField::zero(); w_len], self.A.n_rows);
+        let w_dummy = Witness::<C>::new(
+            vec![C::ScalarField::zero(); w_len],
+            C::ScalarField::zero(),
+            self.A.n_rows,
+            C::ScalarField::zero(),
+        );
         let u_dummy = CommittedInstance::<C>::dummy(self.l);
         (w_dummy, u_dummy)
     }

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -1,6 +1,6 @@
 use ark_crypto_primitives::sponge::Absorb;
 use ark_ec::{CurveGroup, Group};
-use ark_std::{test_rng, One, Zero};
+use ark_std::One;
 
 use super::{CommittedInstance, Witness};
 use crate::arith::{r1cs::R1CS, Arith};

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -1,6 +1,6 @@
 use ark_crypto_primitives::sponge::Absorb;
 use ark_ec::{CurveGroup, Group};
-use ark_std::{One, Zero};
+use ark_std::{test_rng, One, Zero};
 
 use super::{CommittedInstance, Witness};
 use crate::arith::{r1cs::R1CS, Arith};
@@ -34,11 +34,10 @@ where
 {
     fn dummy_instance(&self) -> (Witness<C>, CommittedInstance<C>) {
         let w_len = self.A.n_cols - 1 - self.l;
-        let w_dummy = Witness::<C>::new(
+        let w_dummy = Witness::<C>::new::<false>(
             vec![C::ScalarField::zero(); w_len],
-            C::ScalarField::zero(),
             self.A.n_rows,
-            C::ScalarField::zero(),
+            test_rng(),
         );
         let u_dummy = CommittedInstance::<C>::dummy(self.l);
         (w_dummy, u_dummy)

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -34,11 +34,7 @@ where
 {
     fn dummy_instance(&self) -> (Witness<C>, CommittedInstance<C>) {
         let w_len = self.A.n_cols - 1 - self.l;
-        let w_dummy = Witness::<C>::new::<false>(
-            vec![C::ScalarField::zero(); w_len],
-            self.A.n_rows,
-            test_rng(),
-        );
+        let w_dummy = Witness::<C>::dummy(w_len, self.A.n_rows);
         let u_dummy = CommittedInstance::<C>::dummy(self.l);
         (w_dummy, u_dummy)
     }

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -77,6 +77,8 @@ pub enum Error {
     PedersenParamsLen(usize, usize),
     #[error("Blinding factor not 0 for Commitment without hiding")]
     BlindingNotZero,
+    #[error("Blinding factors incorrect, blinding is set to {0} but blinding values are {1}")]
+    IncorrectBlinding(bool, String),
     #[error("Commitment verification failed")]
     CommitmentVerificationFail,
 

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -41,7 +41,7 @@ pub fn get_cm_coordinates<C: CurveGroup>(cm: &C) -> Vec<C::BaseField> {
 }
 
 /// returns the hash of the given public parameters of the Folding Scheme
-pub fn pp_hash<C1, C2, CS1, CS2>(
+pub fn pp_hash<C1, C2, CS1, CS2, const H: bool>(
     arith: &impl Arith<C1::ScalarField>,
     cf_arith: &impl Arith<C2::ScalarField>,
     cs_vp: &CS1::VerifierParams,
@@ -51,8 +51,8 @@ pub fn pp_hash<C1, C2, CS1, CS2>(
 where
     C1: CurveGroup,
     C2: CurveGroup,
-    CS1: CommitmentScheme<C1>,
-    CS2: CommitmentScheme<C2>,
+    CS1: CommitmentScheme<C1, H>,
+    CS2: CommitmentScheme<C2, H>,
 {
     let mut hasher = Sha3_256::new();
 

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -166,7 +166,7 @@ mod tests {
         NovaCycleFoldVerifierKey, ProtocolVerifierKey,
     };
 
-    type NOVA<FC> = Nova<G1, GVar, G2, GVar2, FC, KZG<'static, Bn254>, Pedersen<G2>>;
+    type NOVA<FC> = Nova<G1, GVar, G2, GVar2, FC, KZG<'static, Bn254>, Pedersen<G2>, false>;
     type DECIDER<FC> = DeciderEth<
         G1,
         GVar,
@@ -318,10 +318,11 @@ mod tests {
         let poseidon_config = poseidon_canonical_config::<Fr>();
 
         let f_circuit = FC::new(()).unwrap();
-        let prep_param = PreprocessorParam::<G1, G2, FC, KZG<'static, Bn254>, Pedersen<G2>>::new(
-            poseidon_config,
-            f_circuit.clone(),
-        );
+        let prep_param =
+            PreprocessorParam::<G1, G2, FC, KZG<'static, Bn254>, Pedersen<G2>, false>::new(
+                poseidon_config,
+                f_circuit.clone(),
+            );
         let nova_params = NOVA::preprocess(&mut rng, &prep_param).unwrap();
         let nova = NOVA::init(
             &nova_params,


### PR DESCRIPTION
This PR aims to make it possible to specify blinding commitments. It consists in changing how generics are specified for the different structs used with nova and hypernova. We test our changes for [pedersen commitments](https://github.com/privacy-scaling-explorations/sonobe/blob/3099befc6a7c7d9a3a35b083cacfb0fa393b2cd9/folding-schemes/src/folding/nova/mod.rs#L939), since blinding factors have been [removed](https://github.com/privacy-scaling-explorations/sonobe/blob/3099befc6a7c7d9a3a35b083cacfb0fa393b2cd9/folding-schemes/src/commitment/kzg.rs#L130) from the KZG `commit()` method. 

This PR precedes #127, which adds the ability to generate zk IVC proofs for nova.