### PR TITLE
add frontend features to reduce the amount of dependencies and compil…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         feature_set: [basic]
         include:
           - feature_set: basic
-            features: --features default,light-test
+            features: --features default,light-test,circom,noname,noir
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -159,7 +159,7 @@ jobs:
         feature_set: [basic, wasm]
         include:
           - feature_set: basic
-            features: --features default,light-test
+            features: --features default,light-test,circom,noname,noir
             # We only want to test `folding-schemes` package with `wasm` feature.
           - feature_set: wasm
             features: -p folding-schemes --features wasm,parallel --target wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Available frontends to define the folded circuit:
 - [arkworks](https://github.com/arkworks-rs), arkworks contributors
 - [Circom](https://github.com/iden3/circom), iden3, 0Kims Association
 - [Noname](https://github.com/zksecurity/noname), zkSecurity
+- [Noir](https://github.com/noir-lang/noir), Aztec
 
 ## Usage
 

--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -2,6 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 ///
+/// To run:
+/// > cargo run --release --example noir_full_flow -- --nocapture
+///
 /// This example performs the full flow:
 /// - define the circuit to be folded
 /// - fold the circuit with Nova+CycleFold's IVC

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -3,6 +3,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
+///
+/// To run:
+/// > cargo run --release --example external_inputs -- --nocapture
 use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
 use ark_crypto_primitives::{
     crh::{

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -2,6 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 ///
+/// To run:
+/// > cargo run --release --example full_flow -- --nocapture
+///
 /// This example performs the full flow:
 /// - define the circuit to be folded
 /// - fold the circuit with Nova+CycleFold's IVC

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -3,6 +3,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
+///
+/// To run:
+/// > cargo run --release --example multi_inputs -- --nocapture
 use ark_ff::PrimeField;
 use ark_r1cs_std::alloc::AllocVar;
 use ark_r1cs_std::fields::fp::FpVar;

--- a/examples/noir_full_flow.rs
+++ b/examples/noir_full_flow.rs
@@ -2,6 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 ///
+/// To run:
+/// > cargo run --release --example noir_full_flow -- --nocapture
+///
 /// This example performs the full flow:
 /// - define the circuit to be folded
 /// - fold the circuit with Nova+CycleFold's IVC

--- a/examples/noname_full_flow.rs
+++ b/examples/noname_full_flow.rs
@@ -2,6 +2,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 ///
+/// To run:
+/// > cargo run --release --example noname_full_flow -- --nocapture
+///
 /// This example performs the full flow:
 /// - define the circuit to be folded
 /// - fold the circuit with Nova+CycleFold's IVC

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -3,6 +3,9 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
+///
+/// To run:
+/// > cargo run --release --example sha256 -- --nocapture
 use ark_crypto_primitives::crh::{
     sha256::{
         constraints::{Sha256Gadget, UnitVar},

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -12,11 +12,10 @@ ark-crypto-primitives = { version = "^0.4.0", default-features = false, features
 ark-grumpkin = { version = "0.4.0", default-features = false }
 ark-poly-commit = { version = "^0.4.0", default-features = false, features = ["parallel"] }
 ark-relations = { version = "^0.4.0", default-features = false }
-# this is patched at the workspace level
+# ark-r1cs-std is patched at the workspace level
 ark-r1cs-std = { version = "0.4.0", default-features = false, features = ["parallel"] }
 ark-snark = { version = "^0.4.0", default-features = false }
 ark-serialize = { version = "^0.4.0", default-features = false }
-ark-circom = { git = "https://github.com/arnaucube/circom-compat", default-features = false }
 ark-groth16 = { version = "^0.4.0", default-features = false, features = ["parallel"]}
 ark-bn254 = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"
@@ -25,16 +24,19 @@ num-bigint = "0.4"
 num-integer = "0.1"
 color-eyre = "=0.6.2"
 sha3 = "0.10"
-ark-noname = { git = "https://github.com/dmpierre/ark-noname", branch = "feat/sonobe-integration" }
-noname = { git = "https://github.com/dmpierre/noname" }
-serde_json = "1.0.85"                                                                # to (de)serialize JSON
+serde_json = "1.0.85" # to (de)serialize JSON
 serde = "1.0.203"
-acvm = { git = "https://github.com/noir-lang/noir", rev="2b4853e", default-features = false }
-noir_arkworks_backend = { package="arkworks_backend", git = "https://github.com/dmpierre/arkworks_backend", branch = "feat/sonobe-integration" }
 log = "0.4"
 
 # tmp import for espresso's sumcheck
 espresso_subroutines = {git="https://github.com/EspressoSystems/hyperplonk", package="subroutines"}
+
+# frontend dependencies:
+ark-circom = { git = "https://github.com/arnaucube/circom-compat", default-features = false, optional=true }
+noir_arkworks_backend = { package="arkworks_backend", git = "https://github.com/dmpierre/arkworks_backend", branch = "feat/sonobe-integration", optional=true }
+acvm = { git = "https://github.com/noir-lang/noir", rev="2b4853e", default-features = false, optional=true }
+noname = { git = "https://github.com/dmpierre/noname", optional=true }
+ark-noname = { git = "https://github.com/dmpierre/ark-noname", branch="feat/sonobe-integration", optional=true }
 
 [dev-dependencies]
 ark-pallas = {version="0.4.0", features=["r1cs"]}
@@ -54,7 +56,14 @@ getrandom = { version = "0.2", features = ["js"] }
 default = ["ark-circom/default", "parallel"]
 parallel = []
 wasm = ["ark-circom/wasm"]
+# 'light-test' is a feature disabled by default, that when enabled will affect
+# the DeciderEthCircuit implementations, skipping the heavy-weight parts of the
+# circuit, allowing to run light tests of it taking less time.
 light-test = []
+# frontend features:
+circom = ["dep:ark-circom"]
+noname = ["dep:noname", "dep:ark-noname"]
+noir = ["dep:acvm", "dep:noir_arkworks_backend"]
 
 
 [[example]]

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -4,8 +4,13 @@ use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use ark_std::fmt::Debug;
 
+// we use features to activate specific frontends, to reduce the amount of dependencies and compile
+// time
+#[cfg(feature = "circom")]
 pub mod circom;
+#[cfg(feature = "noir")]
 pub mod noir;
+#[cfg(feature = "noname")]
 pub mod noname;
 
 /// FCircuit defines the trait of the circuit of the F function, which is the one being folded (ie.

--- a/solidity-verifiers/Cargo.toml
+++ b/solidity-verifiers/Cargo.toml
@@ -28,7 +28,8 @@ tracing-subscriber = { version = "0.2" }
 ark-bn254 = {version="0.4.0", features=["r1cs"]}
 ark-grumpkin = {version="0.4.0", features=["r1cs"]}
 rand = "0.8.5"
-folding-schemes = { path = "../folding-schemes/", features=["light-test"]}
+# use the diverse frontend features for the examples
+folding-schemes = { path = "../folding-schemes/", features=["light-test", "circom", "noname", "noir"]}
 noname = { git = "https://github.com/dmpierre/noname" }
 
 [features]
@@ -56,4 +57,3 @@ path = "../examples/noname_full_flow.rs"
 [[example]]
 name = "noir_full_flow"
 path = "../examples/noir_full_flow.rs"
-


### PR DESCRIPTION
…ation time

The reasoning behind this is that compilation time now is too long, in part because dependencies on specific frontends, so if the compilation don't use some frontend it can be turned off by default. Also in a normal usage of the lib the dev would choose one of the available frontends, but probably not all of them simultaneously.

resolves #138 