### PR TITLE
Enable WASM-compat and monitor it in the CI

### DIFF
--- a/.github/scripts/wasm-target-test-build.sh
+++ b/.github/scripts/wasm-target-test-build.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+GIT_ROOT=$(pwd)
+
+cd /tmp
+
+# create test project
+cargo new foobar
+cd foobar
+
+# set rust-toolchain same as "sonobe"
+cp "${GIT_ROOT}/rust-toolchain" .
+
+# add wasm32-* targets
+rustup target add wasm32-unknown-unknown wasm32-wasi wasm32-unknown-emscripten
+
+# add dependencies
+cargo add --path "${GIT_ROOT}/folding-schemes" --features wasm, parallel
+cargo add getrandom --features js --target wasm32-unknown-unknown
+
+# test build for wasm32-* targets
+cargo build --release --target wasm32-unknown-unknown
+cargo build --release --target wasm32-wasi
+cargo build --release --target wasm32-unknown-emscripten
+
+# delete test project
+cd ../
+rm -rf foobar

--- a/.github/scripts/wasm-target-test-build.sh
+++ b/.github/scripts/wasm-target-test-build.sh
@@ -12,7 +12,7 @@ cd foobar
 cp "${GIT_ROOT}/rust-toolchain" .
 
 # add wasm32-* targets
-rustup target add wasm32-unknown-unknown wasm32-wasi wasm32-unknown-emscripten
+rustup target add wasm32-unknown-unknown wasm32-wasi 
 
 # add dependencies
 cargo add --path "${GIT_ROOT}/folding-schemes" --features wasm, parallel
@@ -21,7 +21,8 @@ cargo add getrandom --features js --target wasm32-unknown-unknown
 # test build for wasm32-* targets
 cargo build --release --target wasm32-unknown-unknown
 cargo build --release --target wasm32-wasi
-cargo build --release --target wasm32-unknown-emscripten
+# Emscripten would require to fetch the `emcc` tooling. Hence we don't build the lib as a dep for it.
+# cargo build --release --target wasm32-unknown-emscripten
 
 # delete test project
 cd ../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,18 +161,20 @@ jobs:
           - feature_set: basic
             features: --features default,light-test
           - feature_set: wasm
-            features: --features wasm,parallel
+            features: --features wasm,parallel --target wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+      - name: Add target
+        run: rustup target add wasm32-unknown-unknown
       - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --no-default-features ${{ matrix.features }} -- -D warnings
+          args: --no-default-features ${{ matrix.features }} -- -D warnings
 
   typos:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         run: ./folding-schemes/src/frontend/circom/test_folder/compile.sh
       - name: Execute compile.sh to generate .json from noir
         run: ./folding-schemes/src/frontend/noir/test_folder/compile.sh
+      - name: Clean tmp
+        run: cargo clean
       - name: Build
         # This build will be reused by nextest,
         # and also checks (--all-targets) that benches don't bit-rot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,8 +160,9 @@ jobs:
         include:
           - feature_set: basic
             features: --features default,light-test
+            # We only want to test `folding-schemes` package with `wasm` feature.
           - feature_set: wasm
-            features: --features wasm,parallel --target wasm32-unknown-unknown
+            features: -p folding-schemes --features wasm,parallel --target wasm32-unknown-unknown
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           cargo test --doc
 
   build:
+    if: github.event.pull_request.draft == false
     name: Build target ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,17 +40,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        feature_set: [basic]
         include:
-          - feature: default
+          - feature_set: basic
+            features: --features default,light-test
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
       - uses: noir-lang/noirup@v0.1.3
         with:
           toolchain: nightly
-      - uses: actions-rs/toolchain@v1
-      # use the more efficient nextest
-      - uses: taiki-e/install-action@nextest
-      - uses: Swatinem/rust-cache@v2
       - name: Download Circom
         run: |
           mkdir -p $HOME/bin
@@ -65,18 +64,16 @@ jobs:
         run: ./folding-schemes/src/frontend/circom/test_folder/compile.sh
       - name: Execute compile.sh to generate .json from noir
         run: ./folding-schemes/src/frontend/noir/test_folder/compile.sh
-      - name: Clean tmp
-        run: cargo clean
-      - name: Build
-        # This build will be reused by nextest,
-        # and also checks (--all-targets) that benches don't bit-rot
-        run: cargo build --release --all-targets --no-default-features --features "light-test,${{ matrix.feature }}"
-      - name: Test
-        run: |
-          cargo nextest run --profile ci --release --workspace --no-default-features --features "light-test,${{ matrix.feature }}"
-      - name: Doctests # nextest does not support doc tests
-        run: |
-          cargo test --doc
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --workspace --no-default-features ${{ matrix.features }}
+      - name: Run Doc-tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc
 
   build:
     if: github.event.pull_request.draft == false
@@ -87,7 +84,8 @@ jobs:
         target:
           - wasm32-unknown-unknown
           - wasm32-wasi
-          - wasm32-unknown-emscripten
+          # Ignoring until clear usage is required
+          # - wasm32-unknown-emscripten
 
     steps:
       - uses: actions/checkout@v3
@@ -104,7 +102,9 @@ jobs:
           args: -p folding-schemes --no-default-features --target ${{ matrix.target }} --features "wasm, parallel"
       - name: Run wasm-compat script
         run: |
+          chmod +x .github/scripts/wasm-target-test-build.sh
           .github/scripts/wasm-target-test-build.sh
+        shell: bash
 
   examples:
     if: github.event.pull_request.draft == false
@@ -131,7 +131,9 @@ jobs:
       - name: Execute compile.sh to generate .json from noir
         run: ./folding-schemes/src/frontend/noir/test_folder/compile.sh
       - name: Run examples tests
-        run: cargo test --examples
+        run: |
+          cargo update
+          cargo test --examples
       - name: Run examples
         run: cargo run --release --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --release --example
 
@@ -148,12 +150,20 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --all --check
 
   clippy:
     if: github.event.pull_request.draft == false
     name: Clippy lint checks
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature_set: [basic, wasm]
+        include:
+          - feature_set: basic
+            features: --features default,light-test
+          - feature_set: wasm
+            features: --features wasm,parallel
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -164,7 +174,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets --no-default-features ${{ matrix.features }} -- -D warnings
 
   typos:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,9 +131,7 @@ jobs:
       - name: Execute compile.sh to generate .json from noir
         run: ./folding-schemes/src/frontend/noir/test_folder/compile.sh
       - name: Run examples tests
-        run: |
-          cargo update
-          cargo test --examples
+        run: cargo test --examples
       - name: Run examples
         run: cargo run --release --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --release --example
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ env:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-  
 
 jobs:
   test:
@@ -47,7 +46,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: nightly 
+          toolchain: nightly
       - uses: actions-rs/toolchain@v1
       # use the more efficient nextest
       - uses: taiki-e/install-action@nextest
@@ -77,6 +76,33 @@ jobs:
         run: |
           cargo test --doc
 
+  build:
+    name: Build target ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - wasm32-unknown-unknown
+          - wasm32-wasi
+          - wasm32-unknown-emscripten
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          override: false
+          default: true
+      - name: Add target
+        run: rustup target add ${{ matrix.target }}
+      - name: Wasm-compat build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -p folding-schemes --no-default-features --target ${{ matrix.target }} --features "wasm, parallel"
+      - name: Run wasm-compat script
+        run: |
+          .github/scripts/wasm-target-test-build.sh
+
   examples:
     if: github.event.pull_request.draft == false
     name: Run examples & examples tests
@@ -86,7 +112,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
       - uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: nightly 
+          toolchain: nightly
       - name: Download Circom
         run: |
           mkdir -p $HOME/bin
@@ -98,9 +124,9 @@ jobs:
           curl -sSfL https://github.com/ethereum/solidity/releases/download/v0.8.4/solc-static-linux -o /usr/local/bin/solc
           chmod +x /usr/local/bin/solc
       - name: Execute compile.sh to generate .r1cs and .wasm from .circom
-        run: ./folding-schemes/src/frontend/circom/test_folder/compile.sh 
+        run: ./folding-schemes/src/frontend/circom/test_folder/compile.sh
       - name: Execute compile.sh to generate .json from noir
-        run: ./folding-schemes/src/frontend/noir/test_folder/compile.sh 
+        run: ./folding-schemes/src/frontend/noir/test_folder/compile.sh
       - name: Run examples tests
         run: cargo test --examples
       - name: Run examples
@@ -142,8 +168,8 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Use typos with config file
-      uses: crate-ci/typos@master
-      with: 
-        config: .github/workflows/typos.toml
+      - uses: actions/checkout@v4
+      - name: Use typos with config file
+        uses: crate-ci/typos@master
+        with:
+          config: .github/workflows/typos.toml

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Also, notice that:
 - `wasm` feature **IS MANDATORY** if compilation to WASM targets is desired.
 - `parallel` feature enables some parallelization optimizations available in the crate.
 - `light-test` feature runs the computationally-intensive parts of the testing such as the full proof generation for the Eth-decider circuit
-of Nova which is aproximately 4-5M constraints. **This feature only matters when it comes to running Sonobe's tests.**
+of Nova which is approximately 4-5M constraints. **This feature only matters when it comes to running Sonobe's tests.**
 
 ### Folding Schemes introduction
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Available frontends to define the folded circuit:
 
 Detailed usage and design documentation can be found at [Sonobe docs](https://privacy-scaling-explorations.github.io/sonobe-docs/).
 
+### WASM-compatibility & features
+
+The `sonobe/folding-schemes` crate is the only workspace member that supports WASM-target compilation. But, to have it working, `getrandom/js` needs
+to be imported in the `Cargo.toml` of the crate that uses it as dependency.
+```toml
+[dependencies]
+folding-schemes = { version = "0.1.0", default-features = false, features = ["parallel", "wasm"] }
+getrandom = { version = "0.2", features = ["js"] }
+```
+See more details about `getrandom` here: https://docs.rs/getrandom/latest/getrandom/#webassembly-support.
+
+Also, notice that:
+- `wasm` feature **IS MANDATORY** if compilation to WASM targets is desired.
+- `parallel` feature enables some parallelization optimizations available in the crate.
+- `light-test` feature runs the computationally-intensive parts of the testing such as the full proof generation for the Eth-decider circuit
+of Nova which is aproximately 4-5M constraints. **This feature only matters when it comes to running Sonobe's tests.**
+
 ### Folding Schemes introduction
 
 Folding schemes efficiently achieve incrementally verifiable computation (IVC), where the prover recursively proves the correct execution of the incremental computations.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ Available frontends to define the folded circuit:
 
 ## Usage
 
+### Build & test
+You can test the library for both, WASM-targets and regular ones.
+#### Regular targets
+Tier-S targets allow the user to simply run `cargo test` or `cargo build` without needing to worry about anything.
+**We strongly recommend to test using the `light-test` feature.** Which will omit the computationally intensive parts of the tests such as
+generating a SNARK of 4~5M constraints to then verify it.
+
+#### WASM targets
+In order to build the lib for WASM-targets, use the following command:
+`cargo build -p folding-schemes --no-default-features --target wasm32-unknown-unknown --features "wasm, parallel"`.
+Where the target can be any WASM one and the `parallel` feature is optional.
+
+**Trying to build for a WASM-target without the `wasm` feature or viceversa will end up in a compilation error.**
+
 ### Docs
 
 Detailed usage and design documentation can be found at [Sonobe docs](https://privacy-scaling-explorations.github.io/sonobe-docs/).

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -4,25 +4,27 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ark-ec = "^0.4.0"
-ark-ff = "^0.4.0"
-ark-poly = "^0.4.0"
-ark-std = "^0.4.0"
-ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge", "crh"] }
-ark-grumpkin = {version="0.4.0"}
-ark-poly-commit = "^0.4.0"
+ark-ec = { version = "^0.4.0", default-features = false, features = ["parallel"] }
+ark-ff = { version = "^0.4.0", default-features = false, features = ["parallel", "asm"] }
+ark-poly = { version = "^0.4.0", default-features = false, features = ["parallel"] }
+ark-std = { version = "^0.4.0", default-features = false, features = ["parallel"] }
+ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge", "crh", "parallel"] }
+ark-grumpkin = { version = "0.5.0-alpha.0", default-features = false }
+ark-poly-commit = { version = "^0.4.0", default-features = false, features = ["parallel"] }
 ark-relations = { version = "^0.4.0", default-features = false }
-ark-r1cs-std = { version = "0.4.0", default-features = false } # this is patched at the workspace level
-ark-snark = { version = "^0.4.0"}
-ark-serialize = "^0.4.0"
-ark-circom = { git = "https://github.com/arnaucube/circom-compat" }
+# this is patched at the workspace level
+ark-r1cs-std = { version = "0.4.0", default-features = false, features = ["parallel"] }
+ark-snark = { version = "^0.4.0", default-features = false }
+ark-serialize = { version = "^0.4.0", default-features = false }
+# ark-circom = { git = "https://github.com/arnaucube/circom-compat" }
+ark-circom = { path = "../../../dev/circom-compat", default-features = false }
+ark-groth16 = { version = "^0.4.0", default-features = false, features = ["parallel"]}
+ark-bn254 = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"
-rayon = "1.7.0"
+rayon = "1"
 num-bigint = "0.4"
 num-integer = "0.1"
 color-eyre = "=0.6.2"
-ark-bn254 = {version="0.4.0"}
-ark-groth16 = { version = "^0.4.0" }
 sha3 = "0.10"
 ark-noname = { git = "https://github.com/dmpierre/ark-noname", branch="feat/sonobe-integration" }
 noname = { git = "https://github.com/dmpierre/noname" }
@@ -44,18 +46,16 @@ rand = "0.8.5"
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 tracing-subscriber = { version = "0.2" }
 
-[features]
-default = ["parallel"]
-light-test = []
+# This allows the crate to be built when targeting WASM.
+# See more at: https://docs.rs/getrandom/#webassembly-support 
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
-parallel = [ 
-    "ark-std/parallel", 
-    "ark-ff/parallel",  
-    "ark-ec/parallel",  
-    "ark-poly/parallel", 
-    "ark-crypto-primitives/parallel",  
-    "ark-r1cs-std/parallel",  
-    ]
+[features]
+default = ["ark-circom/default", "parallel"]
+parallel = []
+wasm = ["ark-circom/wasm"]
+light-test = []
 
 
 [[example]]

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -16,8 +16,7 @@ ark-relations = { version = "^0.4.0", default-features = false }
 ark-r1cs-std = { version = "0.4.0", default-features = false, features = ["parallel"] }
 ark-snark = { version = "^0.4.0", default-features = false }
 ark-serialize = { version = "^0.4.0", default-features = false }
-# ark-circom = { git = "https://github.com/arnaucube/circom-compat" }
-ark-circom = { path = "../../../dev/circom-compat", default-features = false }
+ark-circom = { git = "https://github.com/arnaucube/circom-compat", default-features = false }
 ark-groth16 = { version = "^0.4.0", default-features = false, features = ["parallel"]}
 ark-bn254 = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -40,7 +40,7 @@ espresso_subroutines = {git="https://github.com/EspressoSystems/hyperplonk", pac
 ark-pallas = {version="0.4.0", features=["r1cs"]}
 ark-vesta = {version="0.4.0", features=["r1cs"]}
 ark-bn254 = {version="0.4.0", features=["r1cs"]}
-ark-grumpkin = {version="0.4.0", features=["r1cs"]}
+ark-grumpkin = {version="0.5.0-alpha.0", features=["r1cs"]}
 rand = "0.8.5"
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 tracing-subscriber = { version = "0.2" }

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -9,7 +9,7 @@ ark-ff = { version = "^0.4.0", default-features = false, features = ["parallel",
 ark-poly = { version = "^0.4.0", default-features = false, features = ["parallel"] }
 ark-std = { version = "^0.4.0", default-features = false, features = ["parallel"] }
 ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge", "crh", "parallel"] }
-ark-grumpkin = { version = "0.5.0-alpha.0", default-features = false }
+ark-grumpkin = { version = "0.4.0", default-features = false }
 ark-poly-commit = { version = "^0.4.0", default-features = false, features = ["parallel"] }
 ark-relations = { version = "^0.4.0", default-features = false }
 # this is patched at the workspace level
@@ -40,7 +40,7 @@ espresso_subroutines = {git="https://github.com/EspressoSystems/hyperplonk", pac
 ark-pallas = {version="0.4.0", features=["r1cs"]}
 ark-vesta = {version="0.4.0", features=["r1cs"]}
 ark-bn254 = {version="0.4.0", features=["r1cs"]}
-ark-grumpkin = {version="0.5.0-alpha.0", features=["r1cs"]}
+ark-grumpkin = {version="0.4.0", features=["r1cs"]}
 rand = "0.8.5"
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 tracing-subscriber = { version = "0.2" }

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -593,9 +593,21 @@ where
             return Err(Error::MaxStep);
         }
 
-        let mut i_bytes: [u8; 8] = [0; 8];
-        i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..8]);
-        let i_usize: usize = usize::from_le_bytes(i_bytes);
+        let i_usize;
+
+        #[cfg(target_pointer_width = "64")]
+        {
+            let mut i_bytes: [u8; 8] = [0; 8];
+            i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..8]);
+            i_usize = usize::from_le_bytes(i_bytes);
+        }
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            let mut i_bytes: [u8; 4] = [0; 4];
+            i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..4]);
+            i_usize = usize::from_le_bytes(i_bytes);
+        }
 
         let z_i1 = self
             .F

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -201,7 +201,7 @@ where
         let (cmW_x, cmW_y) = NonNativeAffineVar::inputize(U.cmW)?;
         let (cmT_x, cmT_y) = NonNativeAffineVar::inputize(proof.cmT)?;
 
-        let public_input: Vec<C1::ScalarField> = vec![
+        let public_input: Vec<C1::ScalarField> = [
             vec![pp_hash, i],
             z_0,
             z_i,

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -502,9 +502,22 @@ where
         if self.i > C1::ScalarField::from_le_bytes_mod_order(&usize::MAX.to_le_bytes()) {
             return Err(Error::MaxStep);
         }
-        let mut i_bytes: [u8; 8] = [0; 8];
-        i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..8]);
-        let i_usize: usize = usize::from_le_bytes(i_bytes);
+
+        let i_usize;
+
+        #[cfg(target_pointer_width = "64")]
+        {
+            let mut i_bytes: [u8; 8] = [0; 8];
+            i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..8]);
+            i_usize = usize::from_le_bytes(i_bytes);
+        }
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            let mut i_bytes: [u8; 4] = [0; 4];
+            i_bytes.copy_from_slice(&self.i.into_bigint().to_bytes_le()[..4]);
+            i_usize = usize::from_le_bytes(i_bytes);
+        }
 
         let z_i1 = self
             .F

--- a/solidity-verifiers/Cargo.toml
+++ b/solidity-verifiers/Cargo.toml
@@ -26,7 +26,7 @@ ark-relations = "0.4.0"
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 tracing-subscriber = { version = "0.2" }
 ark-bn254 = {version="0.4.0", features=["r1cs"]}
-ark-grumpkin = {version="0.4.0", features=["r1cs"]}
+ark-grumpkin = {version="0.5.0-alpha.0", features=["r1cs"]}
 rand = "0.8.5"
 folding-schemes = { path = "../folding-schemes/", features=["light-test"]}
 noname = { git = "https://github.com/dmpierre/noname" }

--- a/solidity-verifiers/Cargo.toml
+++ b/solidity-verifiers/Cargo.toml
@@ -26,7 +26,7 @@ ark-relations = "0.4.0"
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 tracing-subscriber = { version = "0.2" }
 ark-bn254 = {version="0.4.0", features=["r1cs"]}
-ark-grumpkin = {version="0.5.0-alpha.0", features=["r1cs"]}
+ark-grumpkin = {version="0.4.0", features=["r1cs"]}
 rand = "0.8.5"
 folding-schemes = { path = "../folding-schemes/", features=["light-test"]}
 noname = { git = "https://github.com/dmpierre/noname" }


### PR DESCRIPTION
This PR resolves: #137 

- Implements `target-pointer-size` cfg to allow for `usize` de/serialization.
- Updates `Cargo.toml` such that all features from deps and `folding-chemes` features allow for WASM compilation.
- Adds docs about features and WASM-compatibility to README.md
- Adds CI jobs to always monitor WASM-compat. 


~Depends on https://github.com/arnaucube/circom-compat/pull/2~