### PR TITLE
Optimize CycleFold circuit MSM approach

### DIFF
--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -608,13 +608,13 @@ where
 
             let cfW_circuit = NovaCycleFoldCircuit::<C1, GC1> {
                 _gc: PhantomData,
-                r_bits: Some(vec![r_bits.clone()]),
+                r_bits: Some(r_bits.clone()),
                 points: Some(vec![self.U_i.clone().cmW, self.u_i.clone().cmW]),
                 x: Some(cfW_u_i_x.clone()),
             };
             let cfE_circuit = NovaCycleFoldCircuit::<C1, GC1> {
                 _gc: PhantomData,
-                r_bits: Some(vec![r_bits.clone()]),
+                r_bits: Some(r_bits.clone()),
                 points: Some(vec![self.U_i.clone().cmE, cmT]),
                 x: Some(cfE_u_i_x.clone()),
             };


### PR DESCRIPTION
In CycleFold we want to compute
$P_{folded} = P_0 + r \cdot P_1 + r^2 \cdot P_2 + r^3 \cdot P_3 + ... + r^{n-2} \cdot P_{n-2} + r^{n-1} \cdot P_{n-1}$, since the scalars follow the pattern r^i Youssef El Housni ( @yelhousni ) proposed to update the approach of the CycleFold circuit to reduce the number of constraints needed, by computing
$P_{folded} = (((P_{n-1} \cdot r + P_{n-2}) \cdot r + P_{n-3})... ) \cdot r + P_0$.

By itself, this update reduces the number of constraints as the number of points being folded in the CycleFold circuit grows. But it also has impact at the HyperNova circuit, where it removes the need of using the bit representations of the powers of the random value, substancially reducing the amount of constraints used by the HyperNova AugmentedFCircuit.

The number of constraints difference in the CycleFold circuit and in the HyperNova's AugmentedFCircuit:

- CycleFold circuit:

| num points* | old       | new       | diff     |
|-------------|-----------|-----------|----------|
| 2           | 1_354     | 1_354     | 0        |
| 3           | 2_683     | 2_554     | -129     |
| 4           | 4_012     | 3_754     | -258     |
| 8           | 9_328     | 8_554     | -744     |
| 16          | 19_960    | 18_154    | -1_806   |
| 32          | 41_224    | 37_354    | -3_870   |
| 64          | 83_752    | 75_754    | -7_998   |
| 128         | 168_808   | 152_554   | -16_254  |
| 1024        | 1_359_592 | 1_227_754 | -131_838 |

*num points: number of points being folded by the CycleFold circuit.

- HyperNova AugmentedFCircuit circuit

| folded instances* | old     | new     | diff     |
|-------------------|---------|---------|----------|
| 5                 | 90_285  | 80_150  | -10_135  |
| 10                | 144_894 | 117_655 | -27_239  |
| 20                | 249_839 | 192_949 | -56_890  |
| 40                | 463_078 | 344_448 | -118_630 |

*folded instances: folded instances per step, half of them being LCCCS and the other half CCCS.