### PR TITLE
Nova decider serialization

### DIFF
--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -16,7 +16,7 @@ ark-relations = { version = "^0.4.0", default-features = false }
 ark-r1cs-std = { version = "0.4.0", default-features = false, features = ["parallel"] }
 ark-snark = { version = "^0.4.0", default-features = false }
 ark-serialize = { version = "^0.4.0", default-features = false }
-ark-circom = { git = "https://github.com/arnaucube/circom-compat", default-features = false }
+ark-circom = { git = "https://github.com/arnaucube/circom-compat", rev = "18ca7f2", default-features = false }
 ark-groth16 = { version = "^0.4.0", default-features = false, features = ["parallel"]}
 ark-bn254 = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -16,7 +16,7 @@ ark-relations = { version = "^0.4.0", default-features = false }
 ark-r1cs-std = { version = "0.4.0", default-features = false, features = ["parallel"] }
 ark-snark = { version = "^0.4.0", default-features = false }
 ark-serialize = { version = "^0.4.0", default-features = false }
-ark-circom = { git = "https://github.com/arnaucube/circom-compat", rev = "18ca7f2", default-features = false }
+ark-circom = { git = "https://github.com/arnaucube/circom-compat", default-features = false }
 ark-groth16 = { version = "^0.4.0", default-features = false, features = ["parallel"]}
 ark-bn254 = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"
@@ -25,12 +25,12 @@ num-bigint = "0.4"
 num-integer = "0.1"
 color-eyre = "=0.6.2"
 sha3 = "0.10"
-ark-noname = { git = "https://github.com/dmpierre/ark-noname", branch="feat/sonobe-integration" }
+ark-noname = { git = "https://github.com/dmpierre/ark-noname", branch = "feat/sonobe-integration" }
 noname = { git = "https://github.com/dmpierre/noname" }
 serde_json = "1.0.85"                                                                # to (de)serialize JSON
 serde = "1.0.203"
 acvm = { git = "https://github.com/noir-lang/noir", rev="2b4853e", default-features = false }
-arkworks_backend = { git = "https://github.com/dmpierre/arkworks_backend", rev = "4ec77d7" }
+arkworks_backend = { git = "https://github.com/dmpierre/arkworks_backend", branch = "feat/sonobe-integration" }
 log = "0.4"
 
 # tmp import for espresso's sumcheck

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -30,7 +30,7 @@ noname = { git = "https://github.com/dmpierre/noname" }
 serde_json = "1.0.85"                                                                # to (de)serialize JSON
 serde = "1.0.203"
 acvm = { git = "https://github.com/noir-lang/noir", rev="2b4853e", default-features = false }
-arkworks_backend = { git = "https://github.com/dmpierre/arkworks_backend", branch="feat/sonobe-integration" }
+arkworks_backend = { git = "https://github.com/dmpierre/arkworks_backend", rev = "4ec77d7" }
 log = "0.4"
 
 # tmp import for espresso's sumcheck

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -18,6 +18,7 @@ use ark_r1cs_std::{
     ToBitsGadget,
 };
 use ark_relations::r1cs::{Namespace, SynthesisError};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{cfg_iter, rand::RngCore, UniformRand, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
@@ -30,7 +31,7 @@ use crate::utils::{
 };
 use crate::Error;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C: CurveGroup> {
     a: C::ScalarField,
     l: Vec<C::ScalarField>,

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -70,7 +70,7 @@ impl<'a, C: CurveGroup> Valid for ProverKey<'a, C> {
     }
 }
 
-#[derive(Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Default, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C: CurveGroup> {
     pub eval: C::ScalarField,
     pub proof: C,

--- a/folding-schemes/src/commitment/mod.rs
+++ b/folding-schemes/src/commitment/mod.rs
@@ -15,7 +15,7 @@ pub mod pedersen;
 pub trait CommitmentScheme<C: CurveGroup, const H: bool = false>: Clone + Debug {
     type ProverParams: Clone + Debug;
     type VerifierParams: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
-    type Proof: Clone + Debug;
+    type Proof: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
     type ProverChallenge: Clone + Debug;
     type Challenge: Clone + Debug;
 

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -12,7 +12,7 @@ use crate::transcript::Transcript;
 use crate::utils::vec::{vec_add, vec_scalar_mul};
 use crate::Error;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C: CurveGroup> {
     pub R: C,
     pub u: Vec<C::ScalarField>,

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -1,5 +1,6 @@
 use crate::frontend::FCircuit;
 use crate::frontend::FpVar::Var;
+use crate::utils::PathOrBin;
 use crate::Error;
 use ark_circom::circom::{CircomCircuit, R1CS as CircomR1CS};
 use ark_ff::PrimeField;
@@ -9,7 +10,6 @@ use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_std::fmt::Debug;
 use num_bigint::BigInt;
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::{fmt, usize};
 
@@ -93,11 +93,11 @@ impl<F: PrimeField> CircomFCircuit<F> {
 
 impl<F: PrimeField> FCircuit<F> for CircomFCircuit<F> {
     /// (r1cs_path, wasm_path, state_len, external_inputs_len)
-    type Params = (PathBuf, PathBuf, usize, usize);
+    type Params = (PathOrBin, PathOrBin, usize, usize);
 
     fn new(params: Self::Params) -> Result<Self, Error> {
         let (r1cs_path, wasm_path, state_len, external_inputs_len) = params;
-        let circom_wrapper = CircomWrapper::new(r1cs_path, wasm_path);
+        let circom_wrapper = CircomWrapper::new(r1cs_path, wasm_path)?;
 
         let r1cs = circom_wrapper.extract_r1cs()?;
         Ok(Self {
@@ -208,6 +208,7 @@ pub mod tests {
     use super::*;
     use ark_bn254::Fr;
     use ark_relations::r1cs::ConstraintSystem;
+    use std::path::PathBuf;
 
     // Tests the step_native function of CircomFCircuit.
     #[test]
@@ -216,7 +217,8 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
+        let circom_fcircuit =
+            CircomFCircuit::<Fr>::new((r1cs_path.into(), wasm_path.into(), 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
 
         let z_i = vec![Fr::from(3u32)];
         let z_i1 = circom_fcircuit.step_native(1, z_i, vec![]).unwrap();
@@ -230,7 +232,8 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
+        let circom_fcircuit =
+            CircomFCircuit::<Fr>::new((r1cs_path.into(), wasm_path.into(), 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 
@@ -250,7 +253,8 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
+        let circom_fcircuit =
+            CircomFCircuit::<Fr>::new((r1cs_path.into(), wasm_path.into(), 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
 
         // Allocates z_i1 by using step_native function.
         let z_i = vec![Fr::from(3_u32)];
@@ -276,7 +280,8 @@ pub mod tests {
         let wasm_path = PathBuf::from(
             "./src/frontend/circom/test_folder/with_external_inputs_js/with_external_inputs.wasm",
         );
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 2)).unwrap(); // state_len:1, external_inputs_len:2
+        let circom_fcircuit =
+            CircomFCircuit::<Fr>::new((r1cs_path.into(), wasm_path.into(), 1, 2)).unwrap(); // state_len:1, external_inputs_len:2
         let cs = ConstraintSystem::<Fr>::new_ref();
         let z_i = vec![Fr::from(3u32)];
         let external_inputs = vec![Fr::from(6u32), Fr::from(7u32)];
@@ -319,7 +324,8 @@ pub mod tests {
         let wasm_path = PathBuf::from(
             "./src/frontend/circom/test_folder/no_external_inputs_js/no_external_inputs.wasm",
         );
-        let circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 3, 0)).unwrap();
+        let circom_fcircuit =
+            CircomFCircuit::<Fr>::new((r1cs_path.into(), wasm_path.into(), 3, 0)).unwrap();
         let cs = ConstraintSystem::<Fr>::new_ref();
         let z_i = vec![Fr::from(3u32), Fr::from(4u32), Fr::from(5u32)];
         let z_i_var = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i.clone())).unwrap();
@@ -351,7 +357,8 @@ pub mod tests {
         let wasm_path =
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
-        let mut circom_fcircuit = CircomFCircuit::<Fr>::new((r1cs_path, wasm_path, 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
+        let mut circom_fcircuit =
+            CircomFCircuit::<Fr>::new((r1cs_path.into(), wasm_path.into(), 1, 0)).unwrap(); // state_len:1, external_inputs_len:0
 
         circom_fcircuit.set_custom_step_native(Rc::new(|_i, z_i, _external| {
             let z = z_i[0];

--- a/folding-schemes/src/frontend/circom/utils.rs
+++ b/folding-schemes/src/frontend/circom/utils.rs
@@ -3,16 +3,12 @@ use ark_circom::{
     WitnessCalculator,
 };
 use ark_ff::{BigInteger, PrimeField};
+use ark_serialize::Read;
 use color_eyre::Result;
 use num_bigint::{BigInt, Sign};
-use std::{
-    fs::File,
-    io::{BufReader, Cursor},
-    marker::PhantomData,
-    path::PathBuf,
-};
+use std::{fs::File, io::Cursor, marker::PhantomData, path::PathBuf};
 
-use crate::Error;
+use crate::{utils::PathOrBin, Error};
 
 // A struct that wraps Circom functionalities, allowing for extraction of R1CS and witnesses
 // based on file paths to Circom's .r1cs and .wasm.
@@ -25,12 +21,35 @@ pub struct CircomWrapper<F: PrimeField> {
 
 impl<F: PrimeField> CircomWrapper<F> {
     // Creates a new instance of the CircomWrapper with the file paths.
-    pub fn new(r1csfile_bytes: Vec<u8>, wasmfile_bytes: Vec<u8>) -> Self {
-        CircomWrapper {
+    pub fn new(r1cs: PathOrBin, wasm: PathOrBin) -> Result<Self, Error> {
+        match (r1cs, wasm) {
+            (PathOrBin::Path(r1cs_path), PathOrBin::Path(wasm_path)) => {
+                Self::new_from_path(r1cs_path, wasm_path)
+            }
+            (PathOrBin::Bin(r1cs_bin), PathOrBin::Bin(wasm_bin)) => Ok(Self {
+                r1csfile_bytes: r1cs_bin,
+                wasmfile_bytes: wasm_bin,
+                _marker: PhantomData,
+            }),
+            _ => unreachable!("You should pass the same enum branch for both inputs"),
+        }
+    }
+
+    // Creates a new instance of the CircomWrapper with the file paths.
+    fn new_from_path(r1cs_file_path: PathBuf, wasm_file_path: PathBuf) -> Result<Self, Error> {
+        let mut r1csfile_bytes = vec![];
+        let mut file = File::open(r1cs_file_path)?;
+        file.read_exact(&mut r1csfile_bytes)?;
+
+        let mut wasmfile_bytes = vec![];
+        let mut file = File::open(wasm_file_path)?;
+        file.read_exact(&mut wasmfile_bytes)?;
+
+        Ok(CircomWrapper {
             r1csfile_bytes,
             wasmfile_bytes,
             _marker: PhantomData,
-        }
+        })
     }
 
     // Aggregated function to obtain R1CS and witness from Circom.
@@ -39,7 +58,7 @@ impl<F: PrimeField> CircomWrapper<F> {
         inputs: &[(String, Vec<BigInt>)],
     ) -> Result<(R1CS<F>, Option<Vec<F>>), Error> {
         // Extracts the R1CS
-        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(Cursor::new(self.r1csfile_bytes))?;
+        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(Cursor::new(&self.r1csfile_bytes))?;
         let r1cs = r1cs_reader::R1CS::<F>::from(r1cs_file);
 
         // Extracts the witness vector
@@ -49,7 +68,7 @@ impl<F: PrimeField> CircomWrapper<F> {
     }
 
     pub fn extract_r1cs(&self) -> Result<R1CS<F>, Error> {
-        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(Cursor::new(self.r1csfile_bytes))?;
+        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(Cursor::new(&self.r1csfile_bytes))?;
         let mut r1cs = r1cs_reader::R1CS::<F>::from(r1cs_file);
         r1cs.wire_mapping = None;
         Ok(r1cs)
@@ -76,7 +95,7 @@ impl<F: PrimeField> CircomWrapper<F> {
         &self,
         inputs: &[(String, Vec<BigInt>)],
     ) -> Result<Vec<BigInt>, Error> {
-        let mut calculator = WitnessCalculator::new(&self.wasmfile_bytes).map_err(|e| {
+        let mut calculator = WitnessCalculator::from_binary(&self.wasmfile_bytes).map_err(|e| {
             Error::WitnessCalculationError(format!("Failed to create WitnessCalculator: {}", e))
         })?;
         calculator
@@ -140,7 +159,7 @@ mod tests {
             PathBuf::from("./src/frontend/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
         let inputs = vec![("ivc_input".to_string(), vec![BigInt::from(3)])];
-        let wrapper = CircomWrapper::<Fr>::new(r1cs_path, wasm_path);
+        let wrapper = CircomWrapper::<Fr>::new(r1cs_path.into(), wasm_path.into()).unwrap();
 
         let (r1cs, witness) = wrapper.extract_r1cs_and_witness(&inputs).unwrap();
 

--- a/folding-schemes/src/frontend/noir/mod.rs
+++ b/folding-schemes/src/frontend/noir/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::Error;
+use crate::{utils::PathOrBin, Error};
 
 use super::FCircuit;
 use acvm::{
@@ -16,7 +16,9 @@ use ark_ff::PrimeField;
 use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar, R1CSVar};
 use ark_relations::r1cs::ConstraintSynthesizer;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-use arkworks_backend::{read_program_from_file, sonobe_bridge::AcirCircuitSonobe};
+use arkworks_backend::{
+    read_program_from_binary, read_program_from_file, sonobe_bridge::AcirCircuitSonobe,
+};
 
 #[derive(Clone, Debug)]
 pub struct NoirFCircuit<F: PrimeField> {
@@ -26,12 +28,15 @@ pub struct NoirFCircuit<F: PrimeField> {
 }
 
 impl<F: PrimeField> FCircuit<F> for NoirFCircuit<F> {
-    type Params = (String, usize, usize);
+    type Params = (PathOrBin, usize, usize);
 
     fn new(params: Self::Params) -> Result<Self, crate::Error> {
-        let (path, state_len, external_inputs_len) = params;
-        let program =
-            read_program_from_file(path).map_err(|ee| Error::Other(format!("{:?}", ee)))?;
+        let (source, state_len, external_inputs_len) = params;
+        let program = match source {
+            PathOrBin::Path(path) => read_program_from_file(&path),
+            PathOrBin::Bin(bytes) => read_program_from_binary(&bytes),
+        }
+        .map_err(|ee| Error::Other(format!("{:?}", ee)))?;
         let circuit: Circuit<GenericFieldElement<F>> = program.functions[0].clone();
         let ivc_input_length = circuit.public_parameters.0.len();
         let ivc_return_length = circuit.return_values.0.len();

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+use std::path::PathBuf;
+
 use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
 use ark_ec::{AffineRepr, CurveGroup};
 use ark_ff::PrimeField;
@@ -99,4 +102,32 @@ where
     Ok(C1::ScalarField::from_le_bytes_mod_order(
         &public_params_hash,
     ))
+}
+
+/// Tiny utility enum that allows to import circuits and wasm modules from files by passing their path
+/// or passing their content already read.
+///
+/// This enum implements the [`From`] trait for both [`Path`], [`PathBuf`] and [`Vec<u8>`].
+#[derive(Debug, Clone)]
+pub enum PathOrBin {
+    Path(PathBuf),
+    Bin(Vec<u8>),
+}
+
+impl From<&Path> for PathOrBin {
+    fn from(value: &Path) -> Self {
+        PathOrBin::Path(value.into())
+    }
+}
+
+impl From<PathBuf> for PathOrBin {
+    fn from(value: PathBuf) -> Self {
+        PathOrBin::Path(value)
+    }
+}
+
+impl From<Vec<u8>> for PathOrBin {
+    fn from(value: Vec<u8>) -> Self {
+        PathOrBin::Bin(value)
+    }
 }

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -115,6 +115,33 @@ impl
     }
 }
 
+// TODO: document
+// impl
+//     From<(
+//         folding_schemes::folding::nova::decider_eth::VerifierParam<Fr, >,
+//         usize,
+//     )> for NovaCycleFoldVerifierKey
+// {
+//     fn from(
+//         value: (
+//
+//             (Fr, ArkG16VerifierKey<Bn254>, ArkKZG10VerifierKey<Bn254>),
+//             usize,
+//         ),
+//     ) -> Self {
+//         let decider_vp = value.0;
+//         let g16_vk = Groth16VerifierKey::from(decider_vp.1);
+//         // pass `Vec::new()` since batchCheck will not be used
+//         let kzg_vk = KZG10VerifierKey::from((decider_vp.2, Vec::new()));
+//         Self {
+//             pp_hash: decider_vp.0,
+//             g16_vk,
+//             kzg_vk,
+//             z_len: value.1,
+//         }
+//     }
+// }
+
 impl NovaCycleFoldVerifierKey {
     pub fn new(
         pp_hash: Fr,
@@ -355,7 +382,8 @@ mod tests {
         let f_circuit = FC::new(()).unwrap();
 
         let nova_cyclefold_vk =
-            NovaCycleFoldVerifierKey::from((decider_vp.clone(), f_circuit.state_len()));
+            // NovaCycleFoldVerifierKey::from((decider_vp.clone(), f_circuit.state_len()));
+            NovaCycleFoldVerifierKey::from(((decider_vp.pp_hash.clone(), decider_vp.snark_vp.clone(), decider_vp.cs_vp.clone()), f_circuit.state_len()));
 
         let mut rng = rand::rngs::OsRng;
 


### PR DESCRIPTION
[Do not merge yet]

This PR is based on top of https://github.com/privacy-scaling-explorations/sonobe/pull/149 so that this PR contains already the wasm updates. Once #149 is merged to main I'll rebase this PR to latest main branch.

An example of serializing and deserializing & verifying the proof (from the deserialized data) can be found at https://github.com/privacy-scaling-explorations/sonobe/blob/ee4739791634e56e85e1135fa9f989381e9f9c01/folding-schemes/src/folding/nova/decider_eth.rs#L421 .

This PR is a first draft that I'll polish a bit over the next days as I find time (among other things, simplifying code, removing commented code and adding documentation), but it already works.