### PR TITLE
Traits for witnesses and committed instances

### DIFF
--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -126,9 +126,8 @@ impl<C: CurveGroup> Absorb for CCCS<C>
 where
     C::ScalarField: Absorb,
 {
-    fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
-        // This is never called
-        unimplemented!()
+    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+        C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
 
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -7,9 +7,11 @@ use std::sync::Arc;
 
 use ark_std::rand::Rng;
 
+use super::circuits::CCCSVar;
 use super::Witness;
 use crate::arith::{ccs::CCS, Arith};
 use crate::commitment::CommitmentScheme;
+use crate::folding::traits::CommittedInstanceExt;
 use crate::transcript::AbsorbNonNative;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
@@ -137,6 +139,18 @@ where
             .to_native_sponge_field_elements_as_vec()
             .to_sponge_field_elements(dest);
         self.x.to_sponge_field_elements(dest);
+    }
+}
+
+impl<C: CurveGroup> CommittedInstanceExt<C> for CCCS<C> {
+    type Var = CCCSVar<C>;
+
+    fn get_commitments(&self) -> Vec<C> {
+        vec![self.C]
+    }
+
+    fn is_incoming(&self) -> bool {
+        true
     }
 }
 

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -11,7 +11,7 @@ use super::circuits::CCCSVar;
 use super::Witness;
 use crate::arith::{ccs::CCS, Arith};
 use crate::commitment::CommitmentScheme;
-use crate::folding::traits::CommittedInstanceExt;
+use crate::folding::traits::CommittedInstanceOps;
 use crate::transcript::AbsorbNonNative;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
@@ -142,7 +142,7 @@ where
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceExt<C> for CCCS<C> {
+impl<C: CurveGroup> CommittedInstanceOps<C> for CCCS<C> {
     type Var = CCCSVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -762,12 +762,6 @@ where
 
         let sponge = PoseidonSpongeVar::<C1::ScalarField>::new(cs.clone(), &self.poseidon_config);
 
-        // get z_{i+1} from the F circuit
-        let i_usize = self.i_usize.unwrap_or(0);
-        let z_i1 =
-            self.F
-                .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), external_inputs)?;
-
         let is_basecase = i.is_zero()?;
         let is_not_basecase = is_basecase.not();
 
@@ -809,6 +803,13 @@ where
         U_i1.C = U_i1_C;
 
         // P.4.a compute and check the first output of F'
+
+        // get z_{i+1} from the F circuit
+        let i_usize = self.i_usize.unwrap_or(0);
+        let z_i1 = self
+            .F
+            .generate_step_constraints(cs.clone(), i_usize, z_i, external_inputs)?;
+
         let (u_i1_x, _) = U_i1.clone().hash(
             &sponge,
             &pp_hash,

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -42,7 +42,7 @@ use crate::folding::{
         CF1, CF2,
     },
     nova::get_r1cs_from_cs,
-    traits::CommittedInstanceVarExt,
+    traits::CommittedInstanceVarOps,
 };
 use crate::frontend::FCircuit;
 use crate::utils::virtual_polynomial::VPAuxInfo;
@@ -82,7 +82,7 @@ where
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVarExt<C> for CCCSVar<C> {
+impl<C: CurveGroup> CommittedInstanceVarOps<C> for CCCSVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -161,7 +161,7 @@ impl<C: CurveGroup> AbsorbGadget<C::ScalarField> for LCCCSVar<C> {
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVarExt<C> for LCCCSVar<C> {
+impl<C: CurveGroup> CommittedInstanceVarOps<C> for LCCCSVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -915,7 +915,7 @@ mod tests {
                 utils::{compute_c, compute_sigmas_thetas},
                 HyperNovaCycleFoldCircuit,
             },
-            traits::CommittedInstanceExt,
+            traits::CommittedInstanceOps,
         },
         frontend::utils::CubicFCircuit,
         transcript::poseidon::poseidon_canonical_config,

--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -38,8 +38,8 @@ use crate::utils::{
     vec::poly_from_vec,
 };
 use crate::Error;
-use crate::{arith::ccs::CCS, folding::traits::CommittedInstanceVarExt};
-use crate::{arith::r1cs::R1CS, folding::traits::WitnessVarExt};
+use crate::{arith::ccs::CCS, folding::traits::CommittedInstanceVarOps};
+use crate::{arith::r1cs::R1CS, folding::traits::WitnessVarOps};
 
 /// In-circuit representation of the Witness associated to the CommittedInstance.
 #[derive(Debug, Clone)]
@@ -66,7 +66,7 @@ impl<F: PrimeField> AllocVar<Witness<F>, F> for WitnessVar<F> {
     }
 }
 
-impl<F: PrimeField> WitnessVarExt<F> for WitnessVar<F> {
+impl<F: PrimeField> WitnessVarOps<F> for WitnessVar<F> {
     fn get_openings(&self) -> Vec<(&[FpVar<F>], FpVar<F>)> {
         vec![(&self.w, self.r_w.clone())]
     }

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -121,9 +121,8 @@ impl<C: CurveGroup> Absorb for LCCCS<C>
 where
     C::ScalarField: Absorb,
 {
-    fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
-        // This is never called
-        unimplemented!()
+    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+        C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
 
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -1,15 +1,17 @@
 use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::{CurveGroup, Group};
+use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_poly::DenseMultilinearExtension;
 use ark_poly::MultilinearExtension;
 use ark_std::rand::Rng;
 use ark_std::Zero;
 
+use super::circuits::LCCCSVar;
 use super::Witness;
 use crate::arith::ccs::CCS;
 use crate::commitment::CommitmentScheme;
-use crate::transcript::{AbsorbNonNative, Transcript};
+use crate::folding::traits::CommittedInstanceExt;
+use crate::transcript::AbsorbNonNative;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
 use crate::Error;
@@ -138,29 +140,15 @@ where
     }
 }
 
-impl<C: CurveGroup> LCCCS<C>
-where
-    <C as Group>::ScalarField: Absorb,
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
-{
-    /// [`LCCCS`].hash implements the committed instance hash compatible with the gadget
-    /// implemented in nova/circuits.rs::CommittedInstanceVar.hash.
-    /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and `U_i` is the LCCCS.
-    pub fn hash<T: Transcript<C::ScalarField>>(
-        &self,
-        sponge: &T,
-        pp_hash: C::ScalarField,
-        i: C::ScalarField,
-        z_0: Vec<C::ScalarField>,
-        z_i: Vec<C::ScalarField>,
-    ) -> C::ScalarField {
-        let mut sponge = sponge.clone();
-        sponge.absorb(&pp_hash);
-        sponge.absorb(&i);
-        sponge.absorb(&z_0);
-        sponge.absorb(&z_i);
-        sponge.absorb(&self);
-        sponge.squeeze_field_elements(1)[0]
+impl<C: CurveGroup> CommittedInstanceExt<C> for LCCCS<C> {
+    type Var = LCCCSVar<C>;
+
+    fn get_commitments(&self) -> Vec<C> {
+        vec![self.C]
+    }
+
+    fn is_incoming(&self) -> bool {
+        false
     }
 }
 

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -10,7 +10,7 @@ use super::circuits::LCCCSVar;
 use super::Witness;
 use crate::arith::ccs::CCS;
 use crate::commitment::CommitmentScheme;
-use crate::folding::traits::CommittedInstanceExt;
+use crate::folding::traits::CommittedInstanceOps;
 use crate::transcript::AbsorbNonNative;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
@@ -140,7 +140,7 @@ where
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceExt<C> for LCCCS<C> {
+impl<C: CurveGroup> CommittedInstanceOps<C> for LCCCS<C> {
     type Var = LCCCSVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -31,7 +31,7 @@ use crate::folding::circuits::{
     CF2,
 };
 use crate::folding::nova::{get_r1cs_from_cs, PreprocessorParam};
-use crate::folding::traits::{CommittedInstanceExt, WitnessExt};
+use crate::folding::traits::{CommittedInstanceOps, WitnessOps};
 use crate::frontend::FCircuit;
 use crate::utils::{get_cm_coordinates, pp_hash};
 use crate::Error;
@@ -81,7 +81,7 @@ impl<F: PrimeField> Witness<F> {
     }
 }
 
-impl<F: PrimeField> WitnessExt<F> for Witness<F> {
+impl<F: PrimeField> WitnessOps<F> for Witness<F> {
     type Var = WitnessVar<F>;
 
     fn get_openings(&self) -> Vec<(&[F], F)> {

--- a/folding-schemes/src/folding/mod.rs
+++ b/folding-schemes/src/folding/mod.rs
@@ -2,3 +2,4 @@ pub mod circuits;
 pub mod hypernova;
 pub mod nova;
 pub mod protogalaxy;
+pub mod traits;

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -31,7 +31,7 @@ use crate::folding::circuits::{
 };
 use crate::frontend::FCircuit;
 use crate::transcript::{AbsorbNonNativeGadget, Transcript, TranscriptVar};
-use crate::{constants::NOVA_N_BITS_RO, folding::traits::CommittedInstanceVarExt};
+use crate::{constants::NOVA_N_BITS_RO, folding::traits::CommittedInstanceVarOps};
 
 /// CommittedInstanceVar contains the u, x, cmE and cmW values which are folded on the main Nova
 /// constraints field (E1::Fr, where E1 is the main curve). The peculiarity is that cmE and cmW are
@@ -90,7 +90,7 @@ where
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVarExt<C> for CommittedInstanceVar<C> {
+impl<C: CurveGroup> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -521,7 +521,7 @@ pub mod tests {
     use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::nifs::tests::prepare_simple_fold_inputs;
     use crate::folding::nova::nifs::NIFS;
-    use crate::folding::traits::CommittedInstanceExt;
+    use crate::folding::traits::CommittedInstanceOps;
     use crate::transcript::poseidon::poseidon_canonical_config;
 
     #[test]

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -347,12 +347,6 @@ where
         // `transcript` is for challenge generation.
         let mut transcript = sponge.clone();
 
-        // get z_{i+1} from the F circuit
-        let i_usize = self.i_usize.unwrap_or(0);
-        let z_i1 =
-            self.F
-                .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), external_inputs)?;
-
         let is_basecase = i.is_zero()?;
 
         // Primary Part
@@ -403,6 +397,13 @@ where
         U_i1.cmW = U_i1_cmW;
 
         // P.4.a compute and check the first output of F'
+
+        // get z_{i+1} from the F circuit
+        let i_usize = self.i_usize.unwrap_or(0);
+        let z_i1 = self
+            .F
+            .generate_step_constraints(cs.clone(), i_usize, z_i, external_inputs)?;
+
         // Base case: u_{i+1}.x[0] == H((i+1, z_0, z_{i+1}, U_{\bot})
         // Non-base case: u_{i+1}.x[0] == H((i+1, z_0, z_{i+1}, U_{i+1})
         let (u_i1_x, _) = U_i1.clone().hash(

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -39,10 +39,10 @@ use crate::utils::{
     vec::poly_from_vec,
 };
 use crate::Error;
-use crate::{arith::r1cs::R1CS, folding::traits::WitnessVarExt};
+use crate::{arith::r1cs::R1CS, folding::traits::WitnessVarOps};
 use crate::{
     commitment::{pedersen::Params as PedersenParams, CommitmentScheme},
-    folding::traits::CommittedInstanceVarExt,
+    folding::traits::CommittedInstanceVarOps,
 };
 
 #[derive(Debug, Clone)]
@@ -162,7 +162,7 @@ where
     }
 }
 
-impl<C: CurveGroup> WitnessVarExt<C::ScalarField> for WitnessVar<C> {
+impl<C: CurveGroup> WitnessVarOps<C::ScalarField> for WitnessVar<C> {
     fn get_openings(&self) -> Vec<(&[FpVar<C::ScalarField>], FpVar<C::ScalarField>)> {
         vec![(&self.E, self.rE.clone()), (&self.W, self.rW.clone())]
     }

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -42,7 +42,7 @@ pub mod zk;
 use circuits::{AugmentedFCircuit, ChallengeGadget, CommittedInstanceVar};
 use nifs::NIFS;
 
-use super::traits::{CommittedInstanceExt, WitnessExt};
+use super::traits::{CommittedInstanceOps, WitnessOps};
 
 /// Configuration for Nova's CycleFold circuit
 pub struct NovaCycleFoldConfig<C: CurveGroup> {
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceExt<C> for CommittedInstance<C> {
+impl<C: CurveGroup> CommittedInstanceOps<C> for CommittedInstance<C> {
     type Var = CommittedInstanceVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {
@@ -176,7 +176,7 @@ impl<C: CurveGroup> Witness<C> {
     }
 }
 
-impl<C: CurveGroup> WitnessExt<C::ScalarField> for Witness<C> {
+impl<C: CurveGroup> WitnessOps<C::ScalarField> for Witness<C> {
     type Var = WitnessVar<C>;
 
     fn get_openings(&self) -> Vec<(&[C::ScalarField], C::ScalarField)> {

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -86,9 +86,8 @@ impl<C: CurveGroup> Absorb for CommittedInstance<C>
 where
     C::ScalarField: Absorb,
 {
-    fn to_sponge_bytes(&self, _dest: &mut Vec<u8>) {
-        // This is never called
-        unimplemented!()
+    fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
+        C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
 
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {

--- a/folding-schemes/src/folding/nova/zk.rs
+++ b/folding-schemes/src/folding/nova/zk.rs
@@ -36,7 +36,7 @@ use ark_std::{One, Zero};
 
 use crate::{
     arith::r1cs::{RelaxedR1CS, R1CS},
-    folding::traits::CommittedInstanceExt,
+    folding::traits::CommittedInstanceOps,
     RngCore,
 };
 use ark_crypto_primitives::sponge::{

--- a/folding-schemes/src/folding/nova/zk.rs
+++ b/folding-schemes/src/folding/nova/zk.rs
@@ -36,6 +36,7 @@ use ark_std::{One, Zero};
 
 use crate::{
     arith::r1cs::{RelaxedR1CS, R1CS},
+    folding::traits::CommittedInstanceExt,
     RngCore,
 };
 use ark_crypto_primitives::sponge::{
@@ -226,7 +227,7 @@ where
 
         // b. Check computed hashes are correct
         let mut sponge = PoseidonSponge::<C1::ScalarField>::new(poseidon_config);
-        let expected_u_i_x = proof.U_i.hash(&sponge, pp_hash, i, z_0, z_i);
+        let expected_u_i_x = proof.U_i.hash(&sponge, pp_hash, i, &z_0, &z_i);
         if expected_u_i_x != proof.u_i.x[0] {
             return Err(Error::zkIVCVerificationFail);
         }

--- a/folding-schemes/src/folding/protogalaxy/circuits.rs
+++ b/folding-schemes/src/folding/protogalaxy/circuits.rs
@@ -349,12 +349,6 @@ where
         // `transcript` is for challenge generation.
         let mut transcript = sponge.clone();
 
-        // get z_{i+1} from the F circuit
-        let i_usize = self.i_usize;
-        let z_i1 =
-            self.F
-                .generate_step_constraints(cs.clone(), i_usize, z_i.clone(), external_inputs)?;
-
         let is_basecase = i.is_zero()?;
 
         // Primary Part
@@ -377,6 +371,12 @@ where
         )?;
 
         // P.4.a compute and check the first output of F'
+
+        // get z_{i+1} from the F circuit
+        let z_i1 =
+            self.F
+                .generate_step_constraints(cs.clone(), self.i_usize, z_i, external_inputs)?;
+
         // Base case: u_{i+1}.x[0] == H((i+1, z_0, z_{i+1}, U_{\bot})
         // Non-base case: u_{i+1}.x[0] == H((i+1, z_0, z_{i+1}, U_{i+1})
         let (u_i1_x, _) = U_i1.clone().hash(

--- a/folding-schemes/src/folding/protogalaxy/circuits.rs
+++ b/folding-schemes/src/folding/protogalaxy/circuits.rs
@@ -33,7 +33,7 @@ use crate::{
             nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
             CF1, CF2,
         },
-        traits::CommittedInstanceVarExt,
+        traits::CommittedInstanceVarOps,
     },
     frontend::FCircuit,
     transcript::{AbsorbNonNativeGadget, TranscriptVar},

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod utils;
 use circuits::AugmentedFCircuit;
 use folding::Folding;
 
-use super::traits::{CommittedInstanceExt, CommittedInstanceVarExt, WitnessExt, WitnessVarExt};
+use super::traits::{CommittedInstanceOps, CommittedInstanceVarOps, WitnessOps, WitnessVarOps};
 
 /// Configuration for ProtoGalaxy's CycleFold circuit
 pub struct ProtoGalaxyCycleFoldConfig<C: CurveGroup> {
@@ -85,7 +85,7 @@ impl<C: CurveGroup> CommittedInstance<C> {
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceExt<C> for CommittedInstance<C> {
+impl<C: CurveGroup> CommittedInstanceOps<C> for CommittedInstance<C> {
     type Var = CommittedInstanceVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {
@@ -151,7 +151,7 @@ impl<C: CurveGroup> R1CSVar<C::ScalarField> for CommittedInstanceVar<C> {
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVarExt<C> for CommittedInstanceVar<C> {
+impl<C: CurveGroup> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -206,7 +206,7 @@ impl<F: PrimeField> Witness<F> {
     }
 }
 
-impl<F: PrimeField> WitnessExt<F> for Witness<F> {
+impl<F: PrimeField> WitnessOps<F> for Witness<F> {
     type Var = WitnessVar<F>;
 
     fn get_openings(&self) -> Vec<(&[F], F)> {
@@ -238,7 +238,7 @@ impl<F: PrimeField> AllocVar<Witness<F>, F> for WitnessVar<F> {
     }
 }
 
-impl<F: PrimeField> WitnessVarExt<F> for WitnessVar<F> {
+impl<F: PrimeField> WitnessVarOps<F> for WitnessVar<F> {
     fn get_openings(&self) -> Vec<(&[FpVar<F>], FpVar<F>)> {
         vec![(&self.W, self.rW.clone())]
     }

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -1,14 +1,14 @@
 /// Implements the scheme described in [ProtoGalaxy](https://eprint.iacr.org/2023/1106.pdf)
 use ark_crypto_primitives::sponge::{
-    constraints::{AbsorbGadget, CryptographicSpongeVar},
-    poseidon::{constraints::PoseidonSpongeVar, PoseidonConfig, PoseidonSponge},
+    poseidon::{PoseidonConfig, PoseidonSponge},
     Absorb, CryptographicSponge,
 };
 use ark_ec::{CurveGroup, Group};
 use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
-    fields::fp::FpVar,
+    eq::EqGadget,
+    fields::{fp::FpVar, FieldVar},
     groups::{CurveVar, GroupOpsBounds},
     R1CSVar, ToConstraintFieldGadget,
 };
@@ -43,6 +43,8 @@ pub(crate) mod utils;
 
 use circuits::AugmentedFCircuit;
 use folding::Folding;
+
+use super::traits::{CommittedInstanceExt, CommittedInstanceVarExt, WitnessExt, WitnessVarExt};
 
 /// Configuration for ProtoGalaxy's CycleFold circuit
 pub struct ProtoGalaxyCycleFoldConfig<C: CurveGroup> {
@@ -83,30 +85,15 @@ impl<C: CurveGroup> CommittedInstance<C> {
     }
 }
 
-impl<C: CurveGroup> CommittedInstance<C>
-where
-    C::ScalarField: Absorb,
-    C::BaseField: PrimeField,
-{
-    /// hash implements the committed instance hash compatible with the gadget implemented in
-    /// CommittedInstanceVar.hash.
-    /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and `U_i` is the
-    /// `CommittedInstance`.
-    pub fn hash(
-        &self,
-        sponge: &PoseidonSponge<C::ScalarField>,
-        pp_hash: C::ScalarField,
-        i: C::ScalarField,
-        z_0: Vec<C::ScalarField>,
-        z_i: Vec<C::ScalarField>,
-    ) -> C::ScalarField {
-        let mut sponge = sponge.clone();
-        sponge.absorb(&pp_hash);
-        sponge.absorb(&i);
-        sponge.absorb(&z_0);
-        sponge.absorb(&z_i);
-        sponge.absorb(&self);
-        sponge.squeeze_field_elements(1)[0]
+impl<C: CurveGroup> CommittedInstanceExt<C> for CommittedInstance<C> {
+    type Var = CommittedInstanceVar<C>;
+
+    fn get_commitments(&self) -> Vec<C> {
+        vec![self.phi]
+    }
+
+    fn is_incoming(&self) -> bool {
+        self.e == Zero::zero() && self.betas.is_empty()
     }
 }
 
@@ -164,34 +151,29 @@ impl<C: CurveGroup> R1CSVar<C::ScalarField> for CommittedInstanceVar<C> {
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVar<C>
-where
-    C::ScalarField: Absorb,
-    C::BaseField: PrimeField,
-{
-    /// hash implements the committed instance hash compatible with the native implementation from
-    /// CommittedInstance.hash.
-    /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and `U` is the
-    /// `CommittedInstance`.
-    /// Additionally it returns the vector of the field elements from the self parameters, so they
-    /// can be reused in other gadgets avoiding recalculating (reconstraining) them.
-    #[allow(clippy::type_complexity)]
-    pub fn hash(
-        self,
-        sponge: &PoseidonSpongeVar<CF1<C>>,
-        pp_hash: FpVar<CF1<C>>,
-        i: FpVar<CF1<C>>,
-        z_0: Vec<FpVar<CF1<C>>>,
-        z_i: Vec<FpVar<CF1<C>>>,
-    ) -> Result<(FpVar<CF1<C>>, Vec<FpVar<CF1<C>>>), SynthesisError> {
-        let mut sponge = sponge.clone();
-        let U_vec = self.to_sponge_field_elements()?;
-        sponge.absorb(&pp_hash)?;
-        sponge.absorb(&i)?;
-        sponge.absorb(&z_0)?;
-        sponge.absorb(&z_i)?;
-        sponge.absorb(&U_vec)?;
-        Ok((sponge.squeeze_field_elements(1)?.pop().unwrap(), U_vec))
+impl<C: CurveGroup> CommittedInstanceVarExt<C> for CommittedInstanceVar<C> {
+    type PointVar = NonNativeAffineVar<C>;
+
+    fn get_commitments(&self) -> Vec<Self::PointVar> {
+        vec![self.phi.clone()]
+    }
+
+    fn get_public_inputs(&self) -> &[FpVar<CF1<C>>] {
+        &self.x
+    }
+
+    fn enforce_incoming(&self) -> Result<(), SynthesisError> {
+        if self.betas.is_empty() {
+            self.e.enforce_equal(&FpVar::zero())
+        } else {
+            Err(SynthesisError::Unsatisfiable)
+        }
+    }
+
+    fn enforce_partial_equal(&self, other: &Self) -> Result<(), SynthesisError> {
+        self.betas.enforce_equal(&other.betas)?;
+        self.e.enforce_equal(&other.e)?;
+        self.x.enforce_equal(&other.x)
     }
 }
 
@@ -221,6 +203,44 @@ impl<F: PrimeField> Witness<F> {
             e: F::zero(),
             betas: vec![],
         })
+    }
+}
+
+impl<F: PrimeField> WitnessExt<F> for Witness<F> {
+    type Var = WitnessVar<F>;
+
+    fn get_openings(&self) -> Vec<(&[F], F)> {
+        vec![(&self.w, self.r_w)]
+    }
+}
+
+/// In-circuit representation of the Witness associated to the CommittedInstance.
+#[derive(Debug, Clone)]
+pub struct WitnessVar<F: PrimeField> {
+    pub W: Vec<FpVar<F>>,
+    pub rW: FpVar<F>,
+}
+
+impl<F: PrimeField> AllocVar<Witness<F>, F> for WitnessVar<F> {
+    fn new_variable<T: Borrow<Witness<F>>>(
+        cs: impl Into<Namespace<F>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        f().and_then(|val| {
+            let cs = cs.into();
+
+            let W = Vec::new_variable(cs.clone(), || Ok(val.borrow().w.to_vec()), mode)?;
+            let rW = FpVar::new_variable(cs.clone(), || Ok(val.borrow().r_w), mode)?;
+
+            Ok(Self { W, rW })
+        })
+    }
+}
+
+impl<F: PrimeField> WitnessVarExt<F> for WitnessVar<F> {
+    fn get_openings(&self) -> Vec<(&[FpVar<F>], FpVar<F>)> {
+        vec![(&self.W, self.rW.clone())]
     }
 }
 
@@ -636,8 +656,8 @@ where
                 &sponge,
                 self.pp_hash,
                 self.i + C1::ScalarField::one(),
-                self.z_0.clone(),
-                z_i1.clone(),
+                &self.z_0,
+                &z_i1,
             );
             // `cf_U_{i+1}` (i.e., `cf_U_1`) is fixed to `cf_U_dummy`, so we
             // just use `self.cf_U_i = cf_U_0 = cf_U_dummy`.
@@ -744,8 +764,8 @@ where
                 &sponge,
                 self.pp_hash,
                 self.i + C1::ScalarField::one(),
-                self.z_0.clone(),
-                z_i1.clone(),
+                &self.z_0,
+                &z_i1,
             );
             cf_u_i1_x = cf_U_i1.hash_cyclefold(&sponge, self.pp_hash);
 
@@ -874,7 +894,7 @@ where
 
         // check that u_i's output points to the running instance
         // u_i.X[0] == H(i, z_0, z_i, U_i)
-        let expected_u_i_x = U_i.hash(&sponge, pp_hash, num_steps, z_0, z_i.clone());
+        let expected_u_i_x = U_i.hash(&sponge, pp_hash, num_steps, &z_0, &z_i);
         if expected_u_i_x != u_i.x[0] {
             return Err(Error::IVCVerificationFail);
         }

--- a/folding-schemes/src/folding/traits.rs
+++ b/folding-schemes/src/folding/traits.rs
@@ -12,9 +12,9 @@ use crate::{transcript::Transcript, Error};
 
 use super::circuits::CF1;
 
-pub trait CommittedInstanceExt<C: CurveGroup> {
+pub trait CommittedInstanceOps<C: CurveGroup> {
     /// The in-circuit representation of the committed instance.
-    type Var: AllocVar<Self, CF1<C>> + CommittedInstanceVarExt<C>;
+    type Var: AllocVar<Self, CF1<C>> + CommittedInstanceVarOps<C>;
     /// `hash` implements the committed instance hash compatible with the
     /// in-circuit implementation from `CommittedInstanceVarOps::hash`.
     ///
@@ -56,10 +56,10 @@ pub trait CommittedInstanceExt<C: CurveGroup> {
     }
 }
 
-pub trait CommittedInstanceVarExt<C: CurveGroup> {
+pub trait CommittedInstanceVarOps<C: CurveGroup> {
     type PointVar: ToConstraintFieldGadget<CF1<C>>;
     /// `hash` implements the in-circuit committed instance hash compatible with
-    /// the native implementation from `CommittedInstanceExt::hash`.
+    /// the native implementation from `CommittedInstanceOps::hash`.
     /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and
     /// `U_i` is the committed instance `self`.
     ///
@@ -105,16 +105,16 @@ pub trait CommittedInstanceVarExt<C: CurveGroup> {
     fn enforce_partial_equal(&self, other: &Self) -> Result<(), SynthesisError>;
 }
 
-pub trait WitnessExt<F: PrimeField> {
+pub trait WitnessOps<F: PrimeField> {
     /// The in-circuit representation of the witness.
-    type Var: AllocVar<Self, F> + WitnessVarExt<F>;
+    type Var: AllocVar<Self, F> + WitnessVarOps<F>;
 
     /// Returns the openings (i.e., the values being committed to and the
     /// randomness) contained in the witness.
     fn get_openings(&self) -> Vec<(&[F], F)>;
 }
 
-pub trait WitnessVarExt<F: PrimeField> {
+pub trait WitnessVarOps<F: PrimeField> {
     /// Returns the openings (i.e., the values being committed to and the
     /// randomness) contained in the witness.
     fn get_openings(&self) -> Vec<(&[FpVar<F>], FpVar<F>)>;

--- a/folding-schemes/src/folding/traits.rs
+++ b/folding-schemes/src/folding/traits.rs
@@ -1,0 +1,121 @@
+use ark_crypto_primitives::sponge::{
+    constraints::{AbsorbGadget, CryptographicSpongeVar},
+    poseidon::constraints::PoseidonSpongeVar,
+    Absorb,
+};
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
+use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar, ToConstraintFieldGadget};
+use ark_relations::r1cs::SynthesisError;
+
+use crate::{transcript::Transcript, Error};
+
+use super::circuits::CF1;
+
+pub trait CommittedInstanceExt<C: CurveGroup> {
+    /// The in-circuit representation of the committed instance.
+    type Var: AllocVar<Self, CF1<C>> + CommittedInstanceVarExt<C>;
+    /// `hash` implements the committed instance hash compatible with the
+    /// in-circuit implementation from `CommittedInstanceVarOps::hash`.
+    ///
+    /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and
+    /// `U_i` is the committed instance `self`.
+    fn hash<T: Transcript<CF1<C>>>(
+        &self,
+        sponge: &T,
+        pp_hash: CF1<C>, // public params hash
+        i: CF1<C>,
+        z_0: &[CF1<C>],
+        z_i: &[CF1<C>],
+    ) -> CF1<C>
+    where
+        CF1<C>: Absorb,
+        Self: Sized + Absorb,
+    {
+        let mut sponge = sponge.clone();
+        sponge.absorb(&pp_hash);
+        sponge.absorb(&i);
+        sponge.absorb(&z_0);
+        sponge.absorb(&z_i);
+        sponge.absorb(&self);
+        sponge.squeeze_field_elements(1)[0]
+    }
+
+    /// Returns the commitments contained in the committed instance.
+    fn get_commitments(&self) -> Vec<C>;
+
+    /// Returns `true` if the committed instance is an incoming instance, and
+    /// `false` if it is a running instance.
+    fn is_incoming(&self) -> bool;
+
+    /// Checks if the committed instance is an incoming instance.
+    fn check_incoming(&self) -> Result<(), Error> {
+        self.is_incoming()
+            .then_some(())
+            .ok_or(Error::NotIncomingCommittedInstance)
+    }
+}
+
+pub trait CommittedInstanceVarExt<C: CurveGroup> {
+    type PointVar: ToConstraintFieldGadget<CF1<C>>;
+    /// `hash` implements the in-circuit committed instance hash compatible with
+    /// the native implementation from `CommittedInstanceExt::hash`.
+    /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and
+    /// `U_i` is the committed instance `self`.
+    ///
+    /// Additionally it returns the in-circuit representation of the committed
+    /// instance `self` as a vector of field elements, so they can be reused in
+    /// other gadgets avoiding recalculating (reconstraining) them.
+    #[allow(clippy::type_complexity)]
+    fn hash(
+        &self,
+        sponge: &PoseidonSpongeVar<CF1<C>>,
+        pp_hash: &FpVar<CF1<C>>,
+        i: &FpVar<CF1<C>>,
+        z_0: &[FpVar<CF1<C>>],
+        z_i: &[FpVar<CF1<C>>],
+    ) -> Result<(FpVar<CF1<C>>, Vec<FpVar<CF1<C>>>), SynthesisError>
+    where
+        Self: AbsorbGadget<CF1<C>>,
+    {
+        let mut sponge = sponge.clone();
+        let U_vec = self.to_sponge_field_elements()?;
+        sponge.absorb(&pp_hash)?;
+        sponge.absorb(&i)?;
+        sponge.absorb(&z_0)?;
+        sponge.absorb(&z_i)?;
+        sponge.absorb(&U_vec)?;
+        Ok((sponge.squeeze_field_elements(1)?.pop().unwrap(), U_vec))
+    }
+
+    /// Returns the commitments contained in the committed instance.
+    fn get_commitments(&self) -> Vec<Self::PointVar>;
+
+    /// Returns the public inputs contained in the committed instance.
+    fn get_public_inputs(&self) -> &[FpVar<CF1<C>>];
+
+    /// Generates constraints to enforce that the committed instance is an
+    /// incoming instance.
+    fn enforce_incoming(&self) -> Result<(), SynthesisError>;
+
+    /// Generates constraints to enforce that the committed instance `self` is
+    /// partially equal to another committed instance `other`.
+    /// Here, only field elements are compared, while commitments (points) are
+    /// not.
+    fn enforce_partial_equal(&self, other: &Self) -> Result<(), SynthesisError>;
+}
+
+pub trait WitnessExt<F: PrimeField> {
+    /// The in-circuit representation of the witness.
+    type Var: AllocVar<Self, F> + WitnessVarExt<F>;
+
+    /// Returns the openings (i.e., values being committed to) contained in the
+    /// witness.
+    fn get_openings(&self) -> Vec<(&[F], F)>;
+}
+
+pub trait WitnessVarExt<F: PrimeField> {
+    /// Returns the openings (i.e., values being committed to) contained in the
+    /// witness.
+    fn get_openings(&self) -> Vec<(&[FpVar<F>], FpVar<F>)>;
+}

--- a/folding-schemes/src/folding/traits.rs
+++ b/folding-schemes/src/folding/traits.rs
@@ -109,13 +109,13 @@ pub trait WitnessExt<F: PrimeField> {
     /// The in-circuit representation of the witness.
     type Var: AllocVar<Self, F> + WitnessVarExt<F>;
 
-    /// Returns the openings (i.e., values being committed to) contained in the
-    /// witness.
+    /// Returns the openings (i.e., the values being committed to and the
+    /// randomness) contained in the witness.
     fn get_openings(&self) -> Vec<(&[F], F)>;
 }
 
 pub trait WitnessVarExt<F: PrimeField> {
-    /// Returns the openings (i.e., values being committed to) contained in the
-    /// witness.
+    /// Returns the openings (i.e., the values being committed to and the
+    /// randomness) contained in the witness.
     fn get_openings(&self) -> Vec<(&[FpVar<F>], FpVar<F>)>;
 }

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -43,6 +43,8 @@ pub enum Error {
     IVCVerificationFail,
     #[error("zkIVC verification failed")]
     zkIVCVerificationFail,
+    #[error("Committed instance is expected to an incoming (fresh) instance")]
+    NotIncomingCommittedInstance,
     #[error("R1CS instance is expected to not be relaxed")]
     R1CSUnrelaxedFail,
     #[error("Could not find the inner ConstraintSystem")]

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -43,7 +43,7 @@ pub enum Error {
     IVCVerificationFail,
     #[error("zkIVC verification failed")]
     zkIVCVerificationFail,
-    #[error("Committed instance is expected to an incoming (fresh) instance")]
+    #[error("Committed instance is expected to be an incoming (fresh) instance")]
     NotIncomingCommittedInstance,
     #[error("R1CS instance is expected to not be relaxed")]
     R1CSUnrelaxedFail,


### PR DESCRIPTION
Since #145 is a huge PR, I would like to separate it into several parts. This PR adds traits `Witness{Var}Ext` and `CommittedInstance{Var}Ext`, serving as abstractions for witnesses and committed instances in Nova, HyperNova and ProtoGalaxy.
Looking ahead, the methods in these traits are going to be used by the unified generic decider circuit in #145.

Also, the `hash` method in `CommittedInstance{Var}Ext` has a default implementation, so we can eliminate the duplicated code of `hash` for Nova's `CommittedInstance`, HyperNova's `LCCCS`, and ProtoGalaxy's `CommittedInstance`.
The signature of `hash` is also changed, where `z_0` and `z_i` are now slices rather than owned vectors.
In this way, we can avoid cloning `z_i` in augmented circuits, as `z_i` might be very large.