### PR TITLE
Resolve the stack overflow issue when evaluating polynomials in-circuit

### DIFF
--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -26,7 +26,6 @@ use super::{
     nimfs::{NIMFSProof, NIMFS},
     HyperNova, Witness, CCCS, LCCCS,
 };
-use crate::{commitment::{pedersen::Params as PedersenParams, CommitmentScheme}, folding::nova::decider_eth_circuit::evaluate_gadget};
 use crate::folding::circuits::{
     cyclefold::{CycleFoldCommittedInstance, CycleFoldWitness},
     CF1, CF2,
@@ -41,6 +40,10 @@ use crate::Error;
 use crate::{
     arith::{ccs::CCS, r1cs::R1CS},
     folding::traits::{CommittedInstanceVarOps, Dummy, WitnessVarOps},
+};
+use crate::{
+    commitment::{pedersen::Params as PedersenParams, CommitmentScheme},
+    folding::nova::decider_eth_circuit::evaluate_gadget,
 };
 
 /// In-circuit representation of the Witness associated to the CommittedInstance.

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -25,7 +25,9 @@ use core::marker::PhantomData;
 
 use super::{
     circuits::{ChallengeGadget, CommittedInstanceVar},
-    decider_eth_circuit::{evaluate_gadget, KZGChallengesGadget, R1CSVar, RelaxedR1CSGadget, WitnessVar},
+    decider_eth_circuit::{
+        evaluate_gadget, KZGChallengesGadget, R1CSVar, RelaxedR1CSGadget, WitnessVar,
+    },
     nifs::NIFS,
     traits::NIFSTrait,
     CommittedInstance, Nova, Witness,

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -477,6 +477,7 @@ where
         incircuit_c_W.enforce_equal(&cs_c_W)?;
         incircuit_c_E.enforce_equal(&cs_c_E)?;
 
+        // 7.2. check eval_W==p_W(c_W) and eval_E==p_E(c_E)
         let incircuit_eval_W = evaluate_gadget::<CF1<C2>>(cf_W_i.W, incircuit_c_W)?;
         let incircuit_eval_E = evaluate_gadget::<CF1<C2>>(cf_W_i.E, incircuit_c_E)?;
         incircuit_eval_W.enforce_equal(&eval_W)?;

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -25,7 +25,7 @@ use core::marker::PhantomData;
 
 use super::{
     circuits::{ChallengeGadget, CommittedInstanceVar},
-    decider_eth_circuit::{KZGChallengesGadget, R1CSVar, RelaxedR1CSGadget, WitnessVar},
+    decider_eth_circuit::{evaluate_gadget, KZGChallengesGadget, R1CSVar, RelaxedR1CSGadget, WitnessVar},
     nifs::NIFS,
     traits::NIFSTrait,
     CommittedInstance, Nova, Witness,
@@ -239,10 +239,10 @@ where
         let cs_c_E = FpVar::<CF1<C1>>::new_input(cs.clone(), || {
             Ok(self.cs_c_E.unwrap_or_else(CF1::<C1>::zero))
         })?;
-        let _eval_W = FpVar::<CF1<C1>>::new_input(cs.clone(), || {
+        let eval_W = FpVar::<CF1<C1>>::new_input(cs.clone(), || {
             Ok(self.eval_W.unwrap_or_else(CF1::<C1>::zero))
         })?;
-        let _eval_E = FpVar::<CF1<C1>>::new_input(cs.clone(), || {
+        let eval_E = FpVar::<CF1<C1>>::new_input(cs.clone(), || {
             Ok(self.eval_E.unwrap_or_else(CF1::<C1>::zero))
         })?;
 
@@ -296,15 +296,11 @@ where
         incircuit_c_W.enforce_equal(&cs_c_W)?;
         incircuit_c_E.enforce_equal(&cs_c_E)?;
 
-        // Check 5.2 is temporary disabled due
-        // https://github.com/privacy-scaling-explorations/sonobe/issues/80
-        log::warn!("[WARNING]: issue #80 (https://github.com/privacy-scaling-explorations/sonobe/issues/80) is not resolved yet.");
-        //
         // 5.2. check eval_W==p_W(c_W) and eval_E==p_E(c_E)
-        // let incircuit_eval_W = evaluate_gadget::<CF1<C1>>(W_i1.W, incircuit_c_W)?;
-        // let incircuit_eval_E = evaluate_gadget::<CF1<C1>>(W_i1.E, incircuit_c_E)?;
-        // incircuit_eval_W.enforce_equal(&eval_W)?;
-        // incircuit_eval_E.enforce_equal(&eval_E)?;
+        let incircuit_eval_W = evaluate_gadget::<CF1<C1>>(W_i1.W, incircuit_c_W)?;
+        let incircuit_eval_E = evaluate_gadget::<CF1<C1>>(W_i1.E, incircuit_c_E)?;
+        incircuit_eval_W.enforce_equal(&eval_W)?;
+        incircuit_eval_E.enforce_equal(&eval_E)?;
 
         // 1.1.b check that the NIFS.V challenge matches the one from the public input (so we avoid
         //   the verifier computing it)
@@ -451,7 +447,7 @@ where
 
         // 6. check RelaxedR1CS of cf_U_i
         let cf_z_U = [vec![cf_U_i.u.clone()], cf_U_i.x.to_vec(), cf_W_i.W.to_vec()].concat();
-        RelaxedR1CSGadget::check_native(cf_r1cs, cf_W_i.E, cf_U_i.u.clone(), cf_z_U)?;
+        RelaxedR1CSGadget::check_native(cf_r1cs, cf_W_i.E.clone(), cf_U_i.u.clone(), cf_z_U)?;
 
         // `transcript` is for challenge generation.
         let mut transcript =
@@ -466,10 +462,10 @@ where
             Ok(self.cs_c_E.unwrap_or_else(CF1::<C2>::zero))
         })?;
         // allocate the inputs for the check 7.2
-        let _eval_W = FpVar::<CF1<C2>>::new_input(cs.clone(), || {
+        let eval_W = FpVar::<CF1<C2>>::new_input(cs.clone(), || {
             Ok(self.eval_W.unwrap_or_else(CF1::<C2>::zero))
         })?;
-        let _eval_E = FpVar::<CF1<C2>>::new_input(cs.clone(), || {
+        let eval_E = FpVar::<CF1<C2>>::new_input(cs.clone(), || {
             Ok(self.eval_E.unwrap_or_else(CF1::<C2>::zero))
         })?;
 
@@ -479,14 +475,10 @@ where
         incircuit_c_W.enforce_equal(&cs_c_W)?;
         incircuit_c_E.enforce_equal(&cs_c_E)?;
 
-        // Check 7.2 is temporary disabled due
-        // https://github.com/privacy-scaling-explorations/sonobe/issues/80
-        log::warn!("[WARNING]: issue #80 (https://github.com/privacy-scaling-explorations/sonobe/issues/80) is not resolved yet.");
-        // 7.2. check eval_W==p_W(c_W) and eval_E==p_E(c_E)
-        // let incircuit_eval_W = evaluate_gadget::<CF1<C1>>(W_i1.W, incircuit_c_W)?;
-        // let incircuit_eval_E = evaluate_gadget::<CF1<C1>>(W_i1.E, incircuit_c_E)?;
-        // incircuit_eval_W.enforce_equal(&eval_W)?;
-        // incircuit_eval_E.enforce_equal(&eval_E)?;
+        let incircuit_eval_W = evaluate_gadget::<CF1<C2>>(cf_W_i.W, incircuit_c_W)?;
+        let incircuit_eval_E = evaluate_gadget::<CF1<C2>>(cf_W_i.E, incircuit_c_E)?;
+        incircuit_eval_W.enforce_equal(&eval_W)?;
+        incircuit_eval_E.enforce_equal(&eval_E)?;
 
         Ok(())
     }


### PR DESCRIPTION
This PR uncomments the code for evaluating polynomials in-circuit, because the stack overflow issue was already addressed in https://github.com/arkworks-rs/r1cs-std/pull/145. There was another issue in `r1cs-std` that caused panics during polynomial interpolation, which is now fixed in https://github.com/winderica/r1cs-std/commit/70602229ba8c497e23619d3dd8a6be9b35db7c42 (corresponding PR: https://github.com/arkworks-rs/r1cs-std/pull/148).

Closes #80 and #130.