### PR TITLE
Feat/better browser support

### DIFF
--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -4,20 +4,40 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ark-ec = { version = "^0.4.0", default-features = false, features = ["parallel"] }
-ark-ff = { version = "^0.4.0", default-features = false, features = ["parallel", "asm"] }
-ark-poly = { version = "^0.4.0", default-features = false, features = ["parallel"] }
-ark-std = { version = "^0.4.0", default-features = false, features = ["parallel"] }
-ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = ["r1cs", "sponge", "crh", "parallel"] }
+ark-ec = { version = "^0.4.0", default-features = false, features = [
+    "parallel",
+] }
+ark-ff = { version = "^0.4.0", default-features = false, features = [
+    "parallel",
+    "asm",
+] }
+ark-poly = { version = "^0.4.0", default-features = false, features = [
+    "parallel",
+] }
+ark-std = { version = "^0.4.0", default-features = false, features = [
+    "parallel",
+] }
+ark-crypto-primitives = { version = "^0.4.0", default-features = false, features = [
+    "r1cs",
+    "sponge",
+    "crh",
+    "parallel",
+] }
 ark-grumpkin = { version = "0.4.0", default-features = false }
-ark-poly-commit = { version = "^0.4.0", default-features = false, features = ["parallel"] }
+ark-poly-commit = { version = "^0.4.0", default-features = false, features = [
+    "parallel",
+] }
 ark-relations = { version = "^0.4.0", default-features = false }
 # this is patched at the workspace level
-ark-r1cs-std = { version = "0.4.0", default-features = false, features = ["parallel"] }
+ark-r1cs-std = { version = "0.4.0", default-features = false, features = [
+    "parallel",
+] }
 ark-snark = { version = "^0.4.0", default-features = false }
 ark-serialize = { version = "^0.4.0", default-features = false }
 ark-circom = { git = "https://github.com/arnaucube/circom-compat", default-features = false }
-ark-groth16 = { version = "^0.4.0", default-features = false, features = ["parallel"]}
+ark-groth16 = { version = "^0.4.0", default-features = false, features = [
+    "parallel",
+] }
 ark-bn254 = { version = "^0.4.0", default-features = false }
 thiserror = "1.0"
 rayon = "1"
@@ -27,26 +47,30 @@ color-eyre = "=0.6.2"
 sha3 = "0.10"
 ark-noname = { git = "https://github.com/dmpierre/ark-noname", branch = "feat/sonobe-integration" }
 noname = { git = "https://github.com/dmpierre/noname" }
-serde_json = "1.0.85"                                                                # to (de)serialize JSON
+serde_json = "1.0.85" # to (de)serialize JSON
 serde = "1.0.203"
-acvm = { git = "https://github.com/noir-lang/noir", rev="2b4853e", default-features = false }
-noir_arkworks_backend = { package="arkworks_backend", git = "https://github.com/dmpierre/arkworks_backend", branch = "feat/sonobe-integration" }
+acvm = { git = "https://github.com/noir-lang/noir", rev = "2b4853e", default-features = false }
+noir_arkworks_backend = { package = "arkworks_backend", git = "https://github.com/dmpierre/arkworks_backend", branch = "feat/sonobe-integration" }
 log = "0.4"
 
 # tmp import for espresso's sumcheck
-espresso_subroutines = {git="https://github.com/EspressoSystems/hyperplonk", package="subroutines"}
+espresso_subroutines = { git = "https://github.com/EspressoSystems/hyperplonk", package = "subroutines" }
+# Dependencies needed for browser folding
+byteorder = { version = "1.4.3", optional = true }
 
 [dev-dependencies]
-ark-pallas = {version="0.4.0", features=["r1cs"]}
-ark-vesta = {version="0.4.0", features=["r1cs"]}
-ark-bn254 = {version="0.4.0", features=["r1cs"]}
-ark-grumpkin = {version="0.4.0", features=["r1cs"]}
+ark-pallas = { version = "0.4.0", features = ["r1cs"] }
+ark-vesta = { version = "0.4.0", features = ["r1cs"] }
+ark-bn254 = { version = "0.4.0", features = ["r1cs"] }
+ark-grumpkin = { version = "0.4.0", features = ["r1cs"] }
 # Note: do not use the MNTx_298 curves in practice due security reasons, here
 # we only use them in the tests.
-ark-mnt4-298 = {version="0.4.0", features=["r1cs"]}
-ark-mnt6-298 = {version="0.4.0", features=["r1cs"]}
+ark-mnt4-298 = { version = "0.4.0", features = ["r1cs"] }
+ark-mnt6-298 = { version = "0.4.0", features = ["r1cs"] }
 rand = "0.8.5"
-tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
+tracing = { version = "0.1", default-features = false, features = [
+    "attributes",
+] }
 tracing-subscriber = { version = "0.2" }
 
 # This allows the crate to be built when targeting WASM.
@@ -58,6 +82,7 @@ getrandom = { version = "0.2", features = ["js"] }
 default = ["ark-circom/default", "parallel"]
 parallel = []
 wasm = ["ark-circom/wasm"]
+browser = ["wasm", "byteorder"]
 light-test = []
 
 
@@ -72,3 +97,6 @@ path = "../examples/multi_inputs.rs"
 [[example]]
 name = "external_inputs"
 path = "../examples/external_inputs.rs"
+
+[lib]
+crate-type = ["cdylib", "rlib"]

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -410,6 +410,9 @@ where
 
         // get z_{i+1} from the F circuit
         let i_usize = self.i_usize.unwrap_or(0);
+
+        // If we are in the browser-frontend case. The witness is already loaded within
+        // self.F.witness. This was done at `self.prove_step()` fn.
         let z_i1 = self
             .F
             .generate_step_constraints(cs.clone(), i_usize, z_i, external_inputs)?;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -642,10 +642,31 @@ where
     fn prove_step(
         &mut self,
         mut rng: impl RngCore,
+        // This contains the full witness when we're in the browser-frontend case
         external_inputs: Vec<C1::ScalarField>,
         // Nova does not support multi-instances folding
         _other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error> {
+        // Slice and separate between external inputs and frontend witness.
+        let (frontend_witness, external_inputs) =
+            if external_inputs.len() > self.F.external_inputs_len() {
+                (
+                    // Full circom witness trace
+                    Some(external_inputs[..].to_vec()),
+                    // Extracted external inputs from circom trace
+                    external_inputs[1 + self.F.state_len() * 2
+                        ..1 + self.F.state_len() * 2 + self.F.external_inputs_len()]
+                        .to_vec(),
+                )
+            } else {
+                (None, external_inputs)
+            };
+
+        // If we are in the browser-case (frontend_witness = Some(witness)) then we load the witness into the FCircuit.
+        if let Some(witness) = frontend_witness {
+            self.F.load_witness(witness)
+        };
+
         // ensure that commitments are blinding if user has specified so.
         if H && self.i >= C1::ScalarField::one() {
             let blinding_commitments = if self.i == C1::ScalarField::one() {

--- a/folding-schemes/src/frontend/circom/browser.rs
+++ b/folding-schemes/src/frontend/circom/browser.rs
@@ -1,0 +1,177 @@
+use crate::frontend::FCircuit;
+use crate::frontend::FpVar::Var;
+use crate::Error;
+use ark_circom::circom::{CircomCircuit, R1CS as CircomR1CS};
+use ark_circom::circom::{R1CSFile, R1CS};
+use ark_ff::{BigInteger, PrimeField};
+use ark_r1cs_std::alloc::AllocVar;
+use ark_r1cs_std::fields::fp::FpVar;
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
+use ark_std::fmt::Debug;
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::{BufReader, Cursor, Read};
+use std::usize;
+
+/// This circuit is the one we will use in order to fold from the browser.
+///
+/// A clear example on how to do all of this can be seen at:
+/// <https://github.com/CPerezz/wasm-sonobe-integration>
+#[derive(Clone, Debug)]
+pub struct CircomFCircuitBrowser<F: PrimeField> {
+    pub state_len: usize,
+    pub external_inputs_len: usize,
+    pub witness: Vec<F>,
+    pub r1cs: CircomR1CS<F>,
+}
+
+impl<F: PrimeField> FCircuit<F> for CircomFCircuitBrowser<F> {
+    /// (r1cs_file_bytes,  state_len, external_inputs_len)
+    type Params = (Vec<u8>, usize, usize);
+
+    fn new(params: Self::Params) -> Result<Self, Error> {
+        let (r1cs_bytes, state_len, external_inputs_len) = params;
+        let reader = BufReader::new(Cursor::new(&r1cs_bytes[..]));
+
+        let mut r1cs: R1CS<F> = R1CSFile::<F>::new(reader)
+            .expect("Error reading R1cs")
+            .into();
+
+        // That's some weird magic. Ask @dmpierre
+        r1cs.wire_mapping = None;
+
+        Ok(Self {
+            state_len,
+            external_inputs_len,
+            witness: vec![F::zero(); r1cs.num_variables],
+            r1cs,
+        })
+    }
+
+    fn state_len(&self) -> usize {
+        self.state_len
+    }
+    fn external_inputs_len(&self) -> usize {
+        self.external_inputs_len
+    }
+
+    fn step_native(
+        &self,
+        _i: usize,
+        z_i: Vec<F>,
+        external_inputs: Vec<F>,
+    ) -> Result<Vec<F>, Error> {
+        // Should we keep these?
+        assert_eq!(z_i.len(), self.state_len());
+        assert_eq!(external_inputs.len(), self.external_inputs_len());
+
+        // Extracts the z_i1(next state) from the witness vector and external inputs.
+        let z_i1 = z_i[..self.state_len()].to_vec();
+        Ok(z_i1)
+    }
+
+    fn generate_step_constraints(
+        &self,
+        cs: ConstraintSystemRef<F>,
+        _i: usize,
+        z_i: Vec<FpVar<F>>,
+        // This in reality contains the `witness` passed from the `prove_step` call from the
+        // browser.
+        _external_inputs: Vec<FpVar<F>>,
+    ) -> Result<Vec<FpVar<F>>, SynthesisError> {
+        // Since public inputs are already allocated variables, we will tell `circom-compat` to not re-allocate those
+        let mut already_allocated_public_inputs = vec![];
+        for var in z_i.iter() {
+            match var {
+                Var(var) => already_allocated_public_inputs.push(var.variable),
+                _ => return Err(SynthesisError::Unsatisfiable), // allocated z_i should be Var
+            }
+        }
+
+        // Initializes the CircomCircuit.
+        let circom_circuit = CircomCircuit {
+            r1cs: self.r1cs.clone(),
+            witness: Some(self.witness.clone()),
+            public_inputs_indexes: already_allocated_public_inputs,
+            // Since public inputs are already allocated variables, we will tell `circom-compat` to not re-allocate those
+            allocate_inputs_as_witnesses: true,
+        };
+
+        // Generates the constraints for the circom_circuit.
+        circom_circuit.generate_constraints(cs.clone())?;
+
+        // Extracts the z_i1(next state) from the witness vector.
+        let z_i1: Vec<FpVar<F>> = Vec::<FpVar<F>>::new_witness(cs.clone(), || {
+            Ok(self.witness[1..1 + self.state_len()].to_vec())
+        })?;
+
+        Ok(z_i1)
+    }
+
+    fn load_witness(&mut self, witness: Vec<F>) {
+        self.witness = witness;
+    }
+}
+
+/// Load Circom-generated witness from u8 array by a reader.
+///
+/// This fn has been taken from <https://github.com/nalinbhardwaj/Nova-Scotia/blob/main/src/circom/file.rs>
+pub fn load_witness_from_bin_reader<R: Read, F: PrimeField>(mut reader: R) -> Vec<F> {
+    let mut wtns_header = [0u8; 4];
+    reader.read_exact(&mut wtns_header).expect("read_error");
+    if wtns_header != [119, 116, 110, 115] {
+        // ruby -e 'p "wtns".bytes' => [119, 116, 110, 115]
+        panic!("invalid file header");
+    }
+    let version = reader.read_u32::<LittleEndian>().expect("read_error");
+    // println!("wtns version {}", version);
+    if version > 2 {
+        panic!("unsupported file version");
+    }
+    let num_sections = reader.read_u32::<LittleEndian>().expect("read_error");
+    if num_sections != 2 {
+        panic!("invalid num sections");
+    }
+    // read the first section
+    let sec_type = reader.read_u32::<LittleEndian>().expect("read_error");
+    if sec_type != 1 {
+        panic!("invalid section type");
+    }
+    let sec_size = reader.read_u64::<LittleEndian>().expect("read_error");
+    if sec_size != 4 + 32 + 4 {
+        panic!("invalid section len")
+    }
+    let field_size: u32 = reader.read_u32::<LittleEndian>().expect("read_error");
+    if field_size != 32 {
+        panic!("invalid field byte size");
+    }
+    let mut prime = vec![0u8; field_size as usize];
+    reader.read_exact(&mut prime).expect("read_error");
+    // if prime != hex!("010000f093f5e1439170b97948e833285d588181b64550b829a031e1724e6430") {
+    //     panic!("invalid curve prime {:?}", prime);
+    // }
+    let witness_len: u32 = reader.read_u32::<LittleEndian>().expect("read_error");
+    // println!("witness len {}", witness_len);
+    let sec_type = reader.read_u32::<LittleEndian>().expect("read_error");
+    if sec_type != 2 {
+        panic!("invalid section type");
+    }
+    let sec_size = reader.read_u64::<LittleEndian>().expect("read_error");
+    if sec_size != (witness_len * field_size) as u64 {
+        panic!("invalid witness section size");
+    }
+    let mut result = Vec::with_capacity(witness_len as usize);
+    for _ in 0..witness_len {
+        result.push(read_field::<&mut R, F>(&mut reader).expect("read_error"));
+    }
+    result
+}
+
+fn read_field<R: Read, F: PrimeField>(
+    mut reader: R,
+) -> Result<F, ark_serialize::SerializationError> {
+    let mut repr: Vec<u8> = F::ZERO.into_bigint().to_bytes_le();
+    for digit in repr.iter_mut() {
+        *digit = reader.read_u8()?;
+    }
+    Ok(F::from_le_bytes_mod_order(&repr[..]))
+}

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -13,7 +13,10 @@ use num_bigint::BigInt;
 use std::rc::Rc;
 use std::{fmt, usize};
 
+pub mod browser;
 pub mod utils;
+
+pub use browser::{load_witness_from_bin_reader, CircomFCircuitBrowser};
 use utils::CircomWrapper;
 
 type ClosurePointer<F> = Rc<dyn Fn(usize, Vec<F>, Vec<F>) -> Result<Vec<F>, Error>>;
@@ -33,7 +36,8 @@ impl<F: PrimeField> fmt::Debug for CustomStepNative<F> {
     }
 }
 
-/// Define CircomFCircuit
+/// This circuit is the one we will use in order to fold circom circuits
+/// from a non-browser environment.
 #[derive(Clone, Debug)]
 pub struct CircomFCircuit<F: PrimeField> {
     circom_wrapper: CircomWrapper<F>,

--- a/folding-schemes/src/frontend/circom/mod.rs
+++ b/folding-schemes/src/frontend/circom/mod.rs
@@ -13,9 +13,11 @@ use num_bigint::BigInt;
 use std::rc::Rc;
 use std::{fmt, usize};
 
+#[cfg(feature = "browser")]
 pub mod browser;
 pub mod utils;
 
+#[cfg(feature = "browser")]
 pub use browser::{load_witness_from_bin_reader, CircomFCircuitBrowser};
 use utils::CircomWrapper;
 

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -48,6 +48,13 @@ pub trait FCircuit<F: PrimeField>: Clone + Debug {
         z_i: Vec<FpVar<F>>,
         external_inputs: Vec<FpVar<F>>, // inputs that are not part of the state
     ) -> Result<Vec<FpVar<F>>, SynthesisError>;
+
+    /// Allows to load pre-generated witness into the FCircuit implementor.
+    /// This is only needed by the browser use cases where we have already computed our
+    /// witness there. And we need a way to load it into the FCircuit since it's already computed.
+    ///
+    /// By default this method will simply do nothing. Only in the browser FCircuit implementors this will have usage.
+    fn load_witness(&mut self, _witness: Vec<F>) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR resolves #155 

The current approach, allows to:

1. Re-use the same traits to fit-in the Circom browser folding.
2. Allows to receive the Circom-generated witness from the browser and load them into the circuit in order to fold via `prove_step`.
3. Implements a mechanism that allows to keep having the same exact APIs (Exept for the addition of `load_witness` trait fn for `FCircuit`.

Current benchmarks situate the folding cost within the browser in arround 3.9s. Which is definitely not good. But better than the current status.

An example on how to use this can actually be seen at https://github.com/CPerezz/wasm-sonobe-integration