### PR TITLE
Typo Update README.md

### DIFF
--- a/solidity-verifiers/README.md
+++ b/solidity-verifiers/README.md
@@ -1,6 +1,6 @@
 # `solidity-verifiers`
 
 This crate implements templating logic to output verifier contracts for `sonobe`-generated decider proofs.
-This crate is accompanied with the [cli](https://github.com/privacy-scaling-explorations/sonobe/tree/main/cli) crate, which allows to generate the Solidity contracts from the command line.
+This crate is accompanied by the [cli](https://github.com/privacy-scaling-explorations/sonobe/tree/main/cli) crate, which allows to generate the Solidity contracts from the command line.
 
 To run the tests it needs [solc](https://docs.soliditylang.org/en/latest/installing-solidity.html) installed.


### PR DESCRIPTION
#### Description:
The original text contains a small grammatical issue in the phrase:  
**"This crate is accompanied with the [cli] crate"**.  
The correct preposition to use here is "by" instead of "with." The revised sentence reads:  
**"This crate is accompanied by the [cli] crate"**.

This change improves the grammatical correctness and clarity of the description.

#### Importance:
This is a minor issue, but correcting it ensures proper usage of prepositions and enhances the overall professionalism and readability of the documentation.
