### PR TITLE
add benchmarks & initial profiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,22 @@ jobs:
       - name: Run examples
         run: cargo run --release --example 2>&1 | grep -E '^ ' | xargs -n1 cargo run --release --example
 
+  # run the benchmarks with the flag `--no-run` to ensure that they compile,
+  # but without executing them.
+  bench:
+    if: github.event.pull_request.draft == false
+    name: Bench compile
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --no-run
+
   fmt:
     if: github.event.pull_request.draft == false
     name: Rustfmt

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,5 @@
+# benchmarks
+
+Run: `cargo bench`
+
+To run a specific benchmark, for example Nova benchmark, run: `cargo bench nova`

--- a/benches/README.md
+++ b/benches/README.md
@@ -2,4 +2,4 @@
 
 Run: `cargo bench`
 
-To run a specific benchmark, for example Nova benchmark, run: `cargo bench nova`
+To run a specific benchmark, for example Nova benchmark, run: `cargo bench --bench=nova`

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,5 +1,10 @@
 # benchmarks
+*Note: we're starting to benchmark & profile Sonobe, current results are pre-optimizations.*
 
-Run: `cargo bench`
+- Benchmark
+    - Run: `cargo bench`
+    - To run a specific benchmark, for example Nova's benchmark, run: `cargo bench --bench=nova`
+- Profiling
+    - eg. `cargo bench --bench=nova -- --profile-time 3`
 
-To run a specific benchmark, for example Nova benchmark, run: `cargo bench --bench=nova`
+

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,0 +1,57 @@
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
+use criterion::*;
+
+use folding_schemes::{
+    frontend::{utils::CustomFCircuit, FCircuit},
+    Error, FoldingScheme,
+};
+
+pub(crate) fn bench_ivc_opt<
+    C1: CurveGroup,
+    C2: CurveGroup,
+    FS: FoldingScheme<C1, C2, CustomFCircuit<C1::ScalarField>>,
+>(
+    c: &mut Criterion,
+    name: String,
+    n: usize,
+    prep_param: FS::PreprocessorParam,
+) -> Result<(), Error>
+where
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2::BaseField: PrimeField,
+{
+    let fcircuit_size = 1 << n; // 2^n
+
+    let f_circuit = CustomFCircuit::<C1::ScalarField>::new(fcircuit_size)?;
+
+    let mut rng = rand::rngs::OsRng;
+
+    // prepare the FS prover & verifier params
+    let fs_params = FS::preprocess(&mut rng, &prep_param)?;
+
+    let z_0 = vec![C1::ScalarField::from(3_u32)];
+    let mut fs = FS::init(&fs_params, f_circuit, z_0)?;
+
+    // warmup steps
+    for _ in 0..5 {
+        fs.prove_step(rng, vec![], None)?;
+    }
+
+    let mut group = c.benchmark_group(format!(
+        "{} - FCircuit: {} (2^{}) constraints",
+        name, fcircuit_size, n
+    ));
+    group.significance_level(0.1).sample_size(10);
+    group.bench_function("prove_step", |b| {
+        b.iter(|| black_box(fs.clone()).prove_step(rng, vec![], None).unwrap())
+    });
+
+    // verify the IVCProof
+    let ivc_proof = fs.ivc_proof();
+    group.bench_function("verify", |b| {
+        b.iter(|| FS::verify(black_box(fs_params.1.clone()), black_box(ivc_proof.clone())).unwrap())
+    });
+    group.finish();
+    Ok(())
+}

--- a/benches/hypernova.rs
+++ b/benches/hypernova.rs
@@ -7,7 +7,7 @@ use ark_vesta::{constraints::GVar as vesta_GVar, Projective as vesta_G};
 
 use folding_schemes::{
     commitment::pedersen::Pedersen,
-    folding::nova::{Nova, PreprocessorParam},
+    folding::{hypernova::HyperNova, nova::PreprocessorParam},
     frontend::{utils::CustomFCircuit, FCircuit},
     transcript::poseidon::poseidon_canonical_config,
 };
@@ -15,7 +15,7 @@ use folding_schemes::{
 mod common;
 use common::bench_ivc_opt;
 
-fn bench_nova_ivc(c: &mut Criterion) {
+fn bench_hypernova_ivc(c: &mut Criterion) {
     let poseidon_config = poseidon_canonical_config::<pallas_Fr>();
 
     // iterate over the powers of n
@@ -27,7 +27,7 @@ fn bench_nova_ivc(c: &mut Criterion) {
         bench_ivc_opt::<
             pallas_G,
             vesta_G,
-            Nova<
+            HyperNova<
                 pallas_G,
                 pallas_GVar,
                 vesta_G,
@@ -35,9 +35,16 @@ fn bench_nova_ivc(c: &mut Criterion) {
                 CustomFCircuit<pallas_Fr>,
                 Pedersen<pallas_G>,
                 Pedersen<vesta_G>,
+                1,
+                1,
                 false,
             >,
-        >(c, "Nova - Pallas-Vesta curves".to_string(), *n, prep_param)
+        >(
+            c,
+            "HyperNova - Pallas-Vesta curves".to_string(),
+            *n,
+            prep_param,
+        )
         .unwrap();
     }
 
@@ -50,7 +57,7 @@ fn bench_nova_ivc(c: &mut Criterion) {
         bench_ivc_opt::<
             bn_G,
             grumpkin_G,
-            Nova<
+            HyperNova<
                 bn_G,
                 bn_GVar,
                 grumpkin_G,
@@ -58,11 +65,13 @@ fn bench_nova_ivc(c: &mut Criterion) {
                 CustomFCircuit<bn_Fr>,
                 Pedersen<bn_G>,
                 Pedersen<grumpkin_G>,
+                1,
+                1,
                 false,
             >,
         >(
             c,
-            "Nova - BN254-Grumpkin curves".to_string(),
+            "HyperNova - BN254-Grumpkin curves".to_string(),
             *n,
             prep_param,
         )
@@ -70,5 +79,5 @@ fn bench_nova_ivc(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_nova_ivc);
+criterion_group!(benches, bench_hypernova_ivc);
 criterion_main!(benches);

--- a/benches/nova.rs
+++ b/benches/nova.rs
@@ -1,0 +1,117 @@
+use ark_ec::CurveGroup;
+use ark_ff::PrimeField;
+use criterion::*;
+
+use ark_bn254::{constraints::GVar as bn_GVar, Fr as bn_Fr, G1Projective as bn_G};
+use ark_grumpkin::{constraints::GVar as grumpkin_GVar, Projective as grumpkin_G};
+use ark_pallas::{constraints::GVar as pallas_GVar, Fr as pallas_Fr, Projective as pallas_G};
+use ark_vesta::{constraints::GVar as vesta_GVar, Projective as vesta_G};
+
+use folding_schemes::{
+    commitment::pedersen::Pedersen,
+    folding::nova::{Nova, PreprocessorParam},
+    frontend::{utils::CustomFCircuit, FCircuit},
+    transcript::poseidon::poseidon_canonical_config,
+    Error, FoldingScheme,
+};
+
+fn bench_nova_ivc(c: &mut Criterion) {
+    bench_nova_ivc_opt::<
+        pallas_G,
+        vesta_G,
+        Nova<
+            pallas_G,
+            pallas_GVar,
+            vesta_G,
+            vesta_GVar,
+            CustomFCircuit<pallas_Fr>,
+            Pedersen<pallas_G>,
+            Pedersen<vesta_G>,
+            false,
+        >,
+    >(c, "Nova - Pallas-Vesta curves".to_string())
+    .unwrap();
+
+    bench_nova_ivc_opt::<
+        bn_G,
+        grumpkin_G,
+        Nova<
+            bn_G,
+            bn_GVar,
+            grumpkin_G,
+            grumpkin_GVar,
+            CustomFCircuit<bn_Fr>,
+            Pedersen<bn_G>,
+            Pedersen<grumpkin_G>,
+            false,
+        >,
+    >(c, "Nova - BN254-Grumpkin curves".to_string())
+    .unwrap();
+}
+fn bench_nova_ivc_opt<
+    C1: CurveGroup,
+    C2: CurveGroup,
+    FS: FoldingScheme<
+        C1,
+        C2,
+        CustomFCircuit<C1::ScalarField>,
+        PreprocessorParam = PreprocessorParam<
+            C1,
+            C2,
+            CustomFCircuit<C1::ScalarField>,
+            Pedersen<C1>,
+            Pedersen<C2>,
+            false,
+        >,
+    >,
+>(
+    c: &mut Criterion,
+    name: String,
+) -> Result<(), Error>
+where
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2::BaseField: PrimeField,
+{
+    // iterate over the powers of n
+    for n in [10, 14, 15, 16, 17, 18, 19, 20].iter() {
+        let fcircuit_size = 1 << n; // 2^n
+
+        let f_circuit = CustomFCircuit::<C1::ScalarField>::new(fcircuit_size)?;
+
+        let poseidon_config = poseidon_canonical_config::<C1::ScalarField>();
+        let mut rng = rand::rngs::OsRng;
+
+        // prepare the Nova prover & verifier params
+        let prep_param: FS::PreprocessorParam =
+            PreprocessorParam::new(poseidon_config.clone(), f_circuit);
+        let fs_params = FS::preprocess(&mut rng, &prep_param)?;
+
+        let z_0 = vec![C1::ScalarField::from(3_u32)];
+        let mut fs = FS::init(&fs_params, f_circuit, z_0)?;
+
+        // warmup steps
+        for _ in 0..5 {
+            fs.prove_step(rng, vec![], None)?;
+        }
+
+        let mut group = c.benchmark_group(format!(
+            "{} - FCircuit: {} (2^{}) constraints",
+            name, fcircuit_size, n
+        ));
+        group.significance_level(0.1).sample_size(10);
+        group.bench_function("prove_step", |b| {
+            b.iter(|| fs.prove_step(rng, vec![], None).unwrap())
+        });
+
+        // verify the IVCProof
+        let ivc_proof = fs.ivc_proof();
+        group.bench_function("verify", |b| {
+            b.iter(|| FS::verify(fs_params.1.clone(), ivc_proof.clone()).unwrap())
+        });
+        group.finish();
+    }
+    Ok(())
+}
+
+criterion_group!(benches, bench_nova_ivc);
+criterion_main!(benches);

--- a/benches/nova.rs
+++ b/benches/nova.rs
@@ -1,4 +1,8 @@
 use criterion::*;
+use pprof::{
+    criterion::{Output, PProfProfiler},
+    flamegraph::Options,
+};
 
 use ark_bn254::{constraints::GVar as bn_GVar, Fr as bn_Fr, G1Projective as bn_G};
 use ark_grumpkin::{constraints::GVar as grumpkin_GVar, Projective as grumpkin_G};
@@ -70,5 +74,9 @@ fn bench_nova_ivc(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_nova_ivc);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_nova_ivc
+}
 criterion_main!(benches);

--- a/benches/nova.rs
+++ b/benches/nova.rs
@@ -1,8 +1,5 @@
 use criterion::*;
-use pprof::{
-    criterion::{Output, PProfProfiler},
-    flamegraph::Options,
-};
+use pprof::criterion::{Output, PProfProfiler};
 
 use ark_bn254::{constraints::GVar as bn_GVar, Fr as bn_Fr, G1Projective as bn_G};
 use ark_grumpkin::{constraints::GVar as grumpkin_GVar, Projective as grumpkin_G};

--- a/benches/protogalaxy.rs
+++ b/benches/protogalaxy.rs
@@ -7,7 +7,7 @@ use ark_vesta::{constraints::GVar as vesta_GVar, Projective as vesta_G};
 
 use folding_schemes::{
     commitment::pedersen::Pedersen,
-    folding::nova::{Nova, PreprocessorParam},
+    folding::protogalaxy::ProtoGalaxy,
     frontend::{utils::CustomFCircuit, FCircuit},
     transcript::poseidon::poseidon_canonical_config,
 };
@@ -15,19 +15,19 @@ use folding_schemes::{
 mod common;
 use common::bench_ivc_opt;
 
-fn bench_nova_ivc(c: &mut Criterion) {
+fn bench_protogalaxy_ivc(c: &mut Criterion) {
     let poseidon_config = poseidon_canonical_config::<pallas_Fr>();
 
     // iterate over the powers of n
     for n in [0_usize, 14, 16, 18, 19, 20, 21, 22].iter() {
         let fcircuit_size = 1 << n; // 2^n
         let fcircuit = CustomFCircuit::<pallas_Fr>::new(fcircuit_size).unwrap();
-        let prep_param = PreprocessorParam::new(poseidon_config.clone(), fcircuit);
+        let prep_param = (poseidon_config.clone(), fcircuit);
 
         bench_ivc_opt::<
             pallas_G,
             vesta_G,
-            Nova<
+            ProtoGalaxy<
                 pallas_G,
                 pallas_GVar,
                 vesta_G,
@@ -35,9 +35,13 @@ fn bench_nova_ivc(c: &mut Criterion) {
                 CustomFCircuit<pallas_Fr>,
                 Pedersen<pallas_G>,
                 Pedersen<vesta_G>,
-                false,
             >,
-        >(c, "Nova - Pallas-Vesta curves".to_string(), *n, prep_param)
+        >(
+            c,
+            "ProtoGalaxy - Pallas-Vesta curves".to_string(),
+            *n,
+            prep_param,
+        )
         .unwrap();
     }
 
@@ -45,12 +49,12 @@ fn bench_nova_ivc(c: &mut Criterion) {
     for n in [0_usize, 14, 16, 18, 19, 20, 21, 22].iter() {
         let fcircuit_size = 1 << n; // 2^n
         let fcircuit = CustomFCircuit::<bn_Fr>::new(fcircuit_size).unwrap();
-        let prep_param = PreprocessorParam::new(poseidon_config.clone(), fcircuit);
+        let prep_param = (poseidon_config.clone(), fcircuit);
 
         bench_ivc_opt::<
             bn_G,
             grumpkin_G,
-            Nova<
+            ProtoGalaxy<
                 bn_G,
                 bn_GVar,
                 grumpkin_G,
@@ -58,11 +62,10 @@ fn bench_nova_ivc(c: &mut Criterion) {
                 CustomFCircuit<bn_Fr>,
                 Pedersen<bn_G>,
                 Pedersen<grumpkin_G>,
-                false,
             >,
         >(
             c,
-            "Nova - BN254-Grumpkin curves".to_string(),
+            "ProtoGalaxy - BN254-Grumpkin curves".to_string(),
             *n,
             prep_param,
         )
@@ -70,5 +73,5 @@ fn bench_nova_ivc(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_nova_ivc);
+criterion_group!(benches, bench_protogalaxy_ivc);
 criterion_main!(benches);

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -62,6 +62,16 @@ name = "nova"
 path = "../benches/nova.rs"
 harness = false
 
+[[bench]]
+name = "hypernova"
+path = "../benches/hypernova.rs"
+harness = false
+
+[[bench]]
+name = "protogalaxy"
+path = "../benches/protogalaxy.rs"
+harness = false
+
 [[example]]
 name = "sha256"
 path = "../examples/sha256.rs"

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -42,6 +42,10 @@ num-bigint = {version = "0.4", features = ["rand"]}
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
 tracing-subscriber = { version = "0.2" }
 
+# for benchmarks
+criterion = "0.5"
+pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
+
 # This allows the crate to be built when targeting WASM.
 # See more at: https://docs.rs/getrandom/#webassembly-support 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
@@ -52,6 +56,11 @@ default = ["parallel"]
 parallel = []
 light-test = []
 
+
+[[bench]]
+name = "nova"
+path = "../benches/nova.rs"
+harness = false
 
 [[example]]
 name = "sha256"

--- a/folding-schemes/src/frontend/utils.rs
+++ b/folding-schemes/src/frontend/utils.rs
@@ -1,7 +1,9 @@
 use ark_ff::PrimeField;
-use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar};
+use ark_r1cs_std::{
+    alloc::AllocVar,
+    fields::{fp::FpVar, FieldVar},
+};
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-#[cfg(test)]
 use ark_std::marker::PhantomData;
 use ark_std::{fmt::Debug, Zero};
 
@@ -96,14 +98,12 @@ impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
 
 /// CustomFCircuit is a circuit that has the number of constraints specified in the
 /// `n_constraints` parameter. Note that the generated circuit will have very sparse matrices.
-#[cfg(test)]
 #[derive(Clone, Copy, Debug)]
 pub struct CustomFCircuit<F: PrimeField> {
     _f: PhantomData<F>,
     pub n_constraints: usize,
 }
 
-#[cfg(test)]
 impl<F: PrimeField> FCircuit<F> for CustomFCircuit<F> {
     type Params = usize;
 
@@ -125,22 +125,22 @@ impl<F: PrimeField> FCircuit<F> for CustomFCircuit<F> {
         z_i: Vec<F>,
         _external_inputs: Vec<F>,
     ) -> Result<Vec<F>, Error> {
-        let mut z_i1 = F::one();
+        let mut z_i1 = z_i[0];
         for _ in 0..self.n_constraints - 1 {
-            z_i1 *= z_i[0];
+            z_i1 = z_i1.square();
         }
         Ok(vec![z_i1])
     }
     fn generate_step_constraints(
         &self,
-        cs: ConstraintSystemRef<F>,
+        _cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
         _external_inputs: Vec<FpVar<F>>,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
-        let mut z_i1 = FpVar::<F>::new_witness(cs.clone(), || Ok(F::one()))?;
+        let mut z_i1 = z_i[0].clone();
         for _ in 0..self.n_constraints - 1 {
-            z_i1 *= z_i[0].clone();
+            z_i1 = z_i1.square()?;
         }
 
         Ok(vec![z_i1])


### PR DESCRIPTION
- add IVC benchmarks for Nova, HyperNova, ProtoGalaxy
  - reusing same benchmarks code between the different schemes, where for each scheme we only have to add the code setting the configuration (ie. curves used, number of constraints, etc)
- add benchmarks compilation to the GitHub CI, without running them (to ensure that they compile, without spending the time to run them in the CI)