### PR TITLE
fix: typos in documentation files

### DIFF
--- a/solidity-verifiers/README.md
+++ b/solidity-verifiers/README.md
@@ -1,6 +1,6 @@
 # `solidity-verifiers`
 
 This crate implements templating logic to output verifier contracts for `sonobe`-generated decider proofs.
-This crate is accompanied with the [cli](https://github.com/privacy-scaling-explorations/sonobe/tree/main/cli) crate, which allows to generate the Solidity contracts from the command line.
+This crate is accompanied by the [cli](https://github.com/privacy-scaling-explorations/sonobe/tree/main/cli) crate, which allows to generate the Solidity contracts from the command line.
 
 To run the tests it needs [solc](https://docs.soliditylang.org/en/latest/installing-solidity.html) installed.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `accompanied with` to `accompanied by`

Please review the changes and let me know if any additional changes are needed.

