### PR TITLE
Reduce time for native computation in `prove_step`

### DIFF
--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -112,9 +112,13 @@ pub mod tests {
     use ark_r1cs_std::R1CSVar;
     use ark_relations::r1cs::ConstraintSystem;
 
-    fn external_inputs_step_native<F: PrimeField>(z_i: Vec<F>, external_inputs: Vec<F>) -> Vec<F> {
+    fn external_inputs_step_native<F: PrimeField + Absorb>(
+        z_i: Vec<F>,
+        external_inputs: Vec<F>,
+        poseidon_config: &PoseidonConfig<F>,
+    ) -> Vec<F> {
         let hash_input: [F; 2] = [z_i[0], external_inputs[0]];
-        let h = CRH::<F>::evaluate(&self.poseidon_config, hash_input).unwrap();
+        let h = CRH::<F>::evaluate(poseidon_config, hash_input).unwrap();
         vec![h]
     }
 
@@ -125,11 +129,12 @@ pub mod tests {
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circuit = ExternalInputsCircuit::<Fr>::new(poseidon_config)?;
+        let circuit = ExternalInputsCircuit::<Fr>::new(poseidon_config.clone())?;
         let z_i = vec![Fr::from(1_u32)];
         let external_inputs = vec![Fr::from(3_u32)];
 
-        let z_i1 = external_inputs_step_native(z_i.clone(), external_inputs.clone())?;
+        let z_i1 =
+            external_inputs_step_native(z_i.clone(), external_inputs.clone(), &poseidon_config);
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let external_inputsVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(external_inputs))?;

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -55,14 +55,6 @@ impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
     fn external_inputs_len(&self) -> usize {
         0
     }
-    fn step_native(
-        &self,
-        _i: usize,
-        z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
-    }
     fn generate_step_constraints(
         &self,
         cs: ConstraintSystemRef<F>,

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -40,24 +40,6 @@ impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
     fn external_inputs_len(&self) -> usize {
         0
     }
-
-    /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
-    /// z_{i+1}
-    fn step_native(
-        &self,
-        _i: usize,
-        z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        let a = z_i[0] + F::from(4_u32);
-        let b = z_i[1] + F::from(40_u32);
-        let c = z_i[2] * F::from(4_u32);
-        let d = z_i[3] * F::from(40_u32);
-        let e = z_i[4] + F::from(100_u32);
-
-        Ok(vec![a, b, c, d, e])
-    }
-
     /// generates the constraints for the step of F for the given z_i
     fn generate_step_constraints(
         &self,
@@ -86,6 +68,16 @@ pub mod tests {
     use ark_r1cs_std::{alloc::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 
+    fn multi_inputs_step_native<F: PrimeField>(z_i: Vec<F>) -> Vec<F> {
+        let a = z_i[0] + F::from(4_u32);
+        let b = z_i[1] + F::from(40_u32);
+        let c = z_i[2] * F::from(4_u32);
+        let d = z_i[3] * F::from(40_u32);
+        let e = z_i[4] + F::from(100_u32);
+
+        vec![a, b, c, d, e]
+    }
+
     // test to check that the MultiInputsFCircuit computes the same values inside and outside the circuit
     #[test]
     fn test_f_circuit() -> Result<(), Error> {
@@ -100,7 +92,7 @@ pub mod tests {
             Fr::from(1_u32),
         ];
 
-        let z_i1 = circuit.step_native(0, z_i.clone(), vec![])?;
+        let z_i1 = multi_inputs_step_native(z_i.clone())?;
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let computed_z_i1Var =

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -92,7 +92,7 @@ pub mod tests {
             Fr::from(1_u32),
         ];
 
-        let z_i1 = multi_inputs_step_native(z_i.clone())?;
+        let z_i1 = multi_inputs_step_native(z_i.clone());
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let computed_z_i1Var =

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -66,7 +66,7 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
 pub mod tests {
     use super::*;
     use ark_crypto_primitives::crh::{sha256::Sha256, CRHScheme};
-    use ark_ff::ToConstraintField;
+    use ark_ff::{BigInteger, ToConstraintField};
     use ark_r1cs_std::{alloc::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
 
@@ -85,7 +85,7 @@ pub mod tests {
         let circuit = Sha256FCircuit::<Fr>::new(())?;
         let z_i = vec![Fr::from(1_u32)];
 
-        let z_i1 = sha256_step_native(z_i.clone())?;
+        let z_i1 = sha256_step_native(z_i.clone());
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let computed_z_i1Var =

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -4,13 +4,10 @@
 #![allow(clippy::upper_case_acronyms)]
 
 use ark_crypto_primitives::crh::{
-    sha256::{
-        constraints::{Sha256Gadget, UnitVar},
-        Sha256,
-    },
-    CRHScheme, CRHSchemeGadget,
+    sha256::constraints::{Sha256Gadget, UnitVar},
+    CRHSchemeGadget,
 };
-use ark_ff::{BigInteger, PrimeField, ToConstraintField};
+use ark_ff::PrimeField;
 use ark_r1cs_std::{
     convert::{ToBytesGadget, ToConstraintFieldGadget},
     fields::fp::FpVar,
@@ -49,21 +46,6 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
     fn external_inputs_len(&self) -> usize {
         0
     }
-
-    /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
-    /// z_{i+1}
-    fn step_native(
-        &self,
-        _i: usize,
-        z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        let out_bytes = Sha256::evaluate(&(), z_i[0].into_bigint().to_bytes_le()).unwrap();
-        let out: Vec<F> = out_bytes.to_field_elements().unwrap();
-
-        Ok(vec![out[0]])
-    }
-
     /// generates the constraints for the step of F for the given z_i
     fn generate_step_constraints(
         &self,
@@ -83,8 +65,17 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use ark_crypto_primitives::crh::{sha256::Sha256, CRHScheme};
+    use ark_ff::ToConstraintField;
     use ark_r1cs_std::{alloc::AllocVar, R1CSVar};
     use ark_relations::r1cs::ConstraintSystem;
+
+    fn sha256_step_native<F: PrimeField>(z_i: Vec<F>) -> Vec<F> {
+        let out_bytes = Sha256::evaluate(&(), z_i[0].into_bigint().to_bytes_le()).unwrap();
+        let out: Vec<F> = out_bytes.to_field_elements().unwrap();
+
+        vec![out[0]]
+    }
 
     // test to check that the Sha256FCircuit computes the same values inside and outside the circuit
     #[test]
@@ -94,7 +85,7 @@ pub mod tests {
         let circuit = Sha256FCircuit::<Fr>::new(())?;
         let z_i = vec![Fr::from(1_u32)];
 
-        let z_i1 = circuit.step_native(0, z_i.clone(), vec![])?;
+        let z_i1 = sha256_step_native(z_i.clone())?;
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let computed_z_i1Var =

--- a/experimental-frontends/src/noir/mod.rs
+++ b/experimental-frontends/src/noir/mod.rs
@@ -180,10 +180,7 @@ mod tests {
     use crate::noir::NoirFCircuit;
 
     /// Native implementation of `src/noir/test_folder/test_circuit`
-    fn external_inputs_step_native<F: PrimeField>(
-        z_i: Vec<F>,
-        external_inputs: Vec<F>,
-    ) -> Vec<F> {
+    fn external_inputs_step_native<F: PrimeField>(z_i: Vec<F>, external_inputs: Vec<F>) -> Vec<F> {
         let xx = external_inputs[0] * z_i[0];
         let yy = external_inputs[1] * z_i[1];
         vec![xx, yy]

--- a/experimental-frontends/src/noname/mod.rs
+++ b/experimental-frontends/src/noname/mod.rs
@@ -101,10 +101,7 @@ mod tests {
     use ark_relations::r1cs::ConstraintSystem;
 
     /// Native implementation of `NONAME_CIRCUIT_EXTERNAL_INPUTS`
-    fn external_inputs_step_native<F: PrimeField>(
-        z_i: Vec<F>,
-        external_inputs: Vec<F>,
-    ) -> Vec<F> {
+    fn external_inputs_step_native<F: PrimeField>(z_i: Vec<F>, external_inputs: Vec<F>) -> Vec<F> {
         let xx = external_inputs[0] + z_i[0];
         let yy = external_inputs[1] * z_i[1];
         assert_eq!(yy, xx);

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -9,6 +9,7 @@ use ark_r1cs_std::{
     eq::EqGadget,
     fields::fp::FpVar,
     prelude::CurveVar,
+    R1CSVar,
 };
 use ark_relations::r1cs::{
     ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError,
@@ -443,8 +444,6 @@ pub struct CycleFoldCircuit<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CF2<CFG::
     pub r_bits: Option<Vec<bool>>,
     /// points to be folded in the CycleFoldCircuit
     pub points: Option<Vec<CFG::C>>,
-    /// public inputs (cf_u_{i+1}.x)
-    pub x: Option<Vec<CF2<CFG::C>>>,
 }
 
 impl<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CF2<CFG::C>>> CycleFoldCircuit<CFG, GC> {
@@ -454,7 +453,6 @@ impl<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CF2<CFG::C>>> CycleFoldCircuit<C
             _gc: PhantomData,
             r_bits: None,
             points: None,
-            x: None,
         }
     }
 }
@@ -497,12 +495,6 @@ impl<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CF2<CFG::C>>> ConstraintSynthesi
             p_folded = p_folded.scalar_mul_le(r_bits.iter())? + points[i].clone();
         }
 
-        let x = Vec::new_input(cs.clone(), || {
-            Ok(self.x.unwrap_or(vec![CF2::<CFG::C>::zero(); CFG::IO_LEN]))
-        })?;
-        #[cfg(test)]
-        assert_eq!(x.len(), CFG::IO_LEN); // non-constrained sanity check
-
         // Check that the points coordinates are placed as the public input x:
         // In Nova, this is: x == [r, p1, p2, p3] (wheere p3 is the p_folded).
         // In multifolding schemes such as HyperNova, this is:
@@ -520,13 +512,19 @@ impl<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CF2<CFG::C>>> ConstraintSynthesi
             .flatten()
             .collect();
 
-        let computed_x = [
+        let x = [
             r_fp,
             points_aux,
             p_folded.to_constraint_field()?[..2].to_vec(),
         ]
         .concat();
-        computed_x.enforce_equal(&x)?;
+        #[cfg(test)]
+        assert_eq!(x.len(), CFG::IO_LEN); // non-constrained sanity check
+
+        // This line "converts" `x` from a witness to a public input.
+        // Instead of directly modifying the constraint system, we explicitly
+        // allocate a public input and enforce that its value is indeed `x`.
+        Vec::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         Ok(())
     }
@@ -607,7 +605,6 @@ pub fn fold_cyclefold_circuit<CFG, C1, GC1, C2, GC2, CS2, const H: bool>(
     pp_hash: C1::ScalarField,               // public params hash
     cf_W_i: CycleFoldWitness<C2>,           // witness of the running instance
     cf_U_i: CycleFoldCommittedInstance<C2>, // running instance
-    cf_u_i_x: Vec<C2::ScalarField>,
     cf_circuit: CycleFoldCircuit<CFG, GC1>,
     mut rng: impl RngCore,
 ) -> Result<
@@ -639,9 +636,6 @@ where
 
     let cs2 = cs2.into_inner().ok_or(Error::NoInnerConstraintSystem)?;
     let (cf_w_i, cf_x_i) = extract_w_x::<C1::BaseField>(&cs2);
-    if cf_x_i != cf_u_i_x {
-        return Err(Error::NotEqual);
-    }
 
     #[cfg(test)]
     assert_eq!(cf_x_i.len(), CFG::IO_LEN);
@@ -767,10 +761,11 @@ pub mod tests {
             _gc: PhantomData,
             r_bits: Some(rho_bits),
             points: Some(points),
-            x: Some(x.clone()),
         };
         cf_circuit.generate_constraints(cs.clone())?;
         assert!(cs.is_satisfied()?);
+        // `instance_assignment[0]` is the constant term 1
+        assert_eq!(&cs.borrow().unwrap().instance_assignment[1..], &x);
         Ok(())
     }
 

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -524,6 +524,12 @@ impl<CFG: CycleFoldConfig, GC: CurveVar<CFG::C, CF2<CFG::C>>> ConstraintSynthesi
         // This line "converts" `x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `x`.
+        // While comparing `x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `x` computed in-circuit.
         Vec::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         Ok(())

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -922,7 +922,6 @@ mod tests {
         },
         frontend::utils::CubicFCircuit,
         transcript::poseidon::poseidon_canonical_config,
-        utils::get_cm_coordinates,
     };
 
     #[test]
@@ -1341,25 +1340,8 @@ mod tests {
                 u_i1_x = U_i1.hash(&sponge, pp_hash, iFr + Fr::one(), &z_0, &z_i1);
 
                 let rho_bits = rho.into_bigint().to_bits_le()[..NOVA_N_BITS_RO].to_vec();
-                let rho_Fq = Fq::from_bigint(BigInteger::from_bits_le(&rho_bits))
-                    .ok_or(Error::OutOfBounds)?;
 
                 // CycleFold part:
-                // get the vector used as public inputs 'x' in the CycleFold circuit
-                let cf_u_i_x = [
-                    vec![rho_Fq],
-                    get_cm_coordinates(&U_i.C),
-                    Us.iter()
-                        .flat_map(|Us_i| get_cm_coordinates(&Us_i.C))
-                        .collect(),
-                    get_cm_coordinates(&u_i.C),
-                    us.iter()
-                        .flat_map(|us_i| get_cm_coordinates(&us_i.C))
-                        .collect(),
-                    get_cm_coordinates(&U_i1.C),
-                ]
-                .concat();
-
                 let cf_circuit = HyperNovaCycleFoldCircuit::<Projective, GVar, MU, NU> {
                     _gc: PhantomData,
                     r_bits: Some(rho_bits.clone()),
@@ -1372,7 +1354,6 @@ mod tests {
                         ]
                         .concat(),
                     ),
-                    x: Some(cf_u_i_x.clone()),
                 };
 
                 // ensure that the CycleFoldCircuit is well defined
@@ -1396,7 +1377,6 @@ mod tests {
                     pp_hash,
                     cf_W_i.clone(), // CycleFold running instance witness
                     cf_U_i.clone(), // CycleFold running instance
-                    cf_u_i_x,       // CycleFold incoming instance
                     cf_circuit,
                     &mut rng,
                 )?;

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -920,7 +920,7 @@ mod tests {
             },
             traits::CommittedInstanceOps,
         },
-        frontend::utils::CubicFCircuit,
+        frontend::utils::{cubic_step_native, CubicFCircuit},
         transcript::poseidon::poseidon_canonical_config,
     };
 
@@ -1272,7 +1272,7 @@ mod tests {
             let all_Ws = [vec![W_i.clone()], Ws].concat();
             let all_ws = [vec![w_i.clone()], ws].concat();
 
-            let z_i1 = F_circuit.step_native(i, z_i.clone(), vec![])?;
+            let z_i1 = cubic_step_native(z_i.clone());
 
             let (U_i1, W_i1);
 

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -812,6 +812,12 @@ where
         // This line "converts" `x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `x`.
+        // While comparing `x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `x` computed in-circuit.
         FpVar::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         // convert rho_bits of the rho_vec to a `NonNativeFieldVar`
@@ -876,6 +882,12 @@ where
         // This line "converts" `cf_x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `cf_x`.
+        // While comparing `cf_x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `cf_x` computed in-circuit.
         FpVar::new_input(cs.clone(), || cf_x.value())?.enforce_equal(&cf_x)?;
 
         Ok(z_i1)

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -505,13 +505,11 @@ pub struct AugmentedFCircuit<
     pub(super) us: Option<Vec<CCCS<C1>>>, // other u_i's to be folded that are not the main incoming instance
     pub(super) U_i1_C: Option<C1>,        // U_{i+1}.C
     pub(super) F: FC,                     // F circuit
-    pub(super) x: Option<CF1<C1>>,        // public input (u_{i+1}.x[0])
     pub(super) nimfs_proof: Option<NIMFSProof<C1>>,
 
     // cyclefold verifier on C1
     pub(super) cf_u_i_cmW: Option<C2>, // input, cf_u_i.cmW
     pub(super) cf_U_i: Option<CycleFoldCommittedInstance<C2>>, // input, RelaxedR1CS CycleFold instance
-    pub(super) cf_x: Option<CF1<C1>>,                          // public input (cf_u_{i+1}.x[1])
     pub(super) cf_cmT: Option<C2>,
 }
 
@@ -552,11 +550,9 @@ where
             us: None,
             U_i1_C: None,
             F: F_circuit,
-            x: None,
             nimfs_proof: None,
             cf_u_i_cmW: None,
             cf_U_i: None,
-            cf_x: None,
             cf_cmT: None,
         })
     }
@@ -642,12 +638,10 @@ where
                 us: Some(us),
                 U_i1_C: Some(U_i1.C),
                 F: self.F.clone(),
-                x: Some(C1::ScalarField::zero()),
                 nimfs_proof: Some(nimfs_proof),
                 // cyclefold values
                 cf_u_i_cmW: None,
                 cf_U_i: None,
-                cf_x: None,
                 cf_cmT: None,
             };
 
@@ -690,20 +684,18 @@ where
     }
 }
 
-impl<C1, C2, GC2, FC, const MU: usize, const NU: usize> ConstraintSynthesizer<CF1<C1>>
-    for AugmentedFCircuit<C1, C2, GC2, FC, MU, NU>
+impl<C1, C2, GC2, FC, const MU: usize, const NU: usize> AugmentedFCircuit<C1, C2, GC2, FC, MU, NU>
 where
-    C1: CurveGroup,
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     C2: CurveGroup,
     GC2: CurveVar<C2, CF2<C2>>,
     FC: FCircuit<CF1<C1>>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2::BaseField: PrimeField + Absorb,
 {
-    fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {
+    pub fn compute_next_state(
+        self,
+        cs: ConstraintSystemRef<CF1<C1>>,
+    ) -> Result<Vec<FpVar<CF1<C1>>>, SynthesisError> {
         let pp_hash = FpVar::<CF1<C1>>::new_witness(cs.clone(), || {
             Ok(self.pp_hash.unwrap_or_else(CF1::<C1>::zero))
         })?;
@@ -816,8 +808,11 @@ where
             &z_0,
             &z_i1,
         )?;
-        let x = FpVar::new_input(cs.clone(), || Ok(self.x.unwrap_or(u_i1_x_base.value()?)))?;
-        x.enforce_equal(&is_basecase.select(&u_i1_x_base, &u_i1_x)?)?;
+        let x = is_basecase.select(&u_i1_x_base, &u_i1_x)?;
+        // This line "converts" `x` from a witness to a public input.
+        // Instead of directly modifying the constraint system, we explicitly
+        // allocate a public input and enforce that its value is indeed `x`.
+        FpVar::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         // convert rho_bits of the rho_vec to a `NonNativeFieldVar`
         let mut rho_bits_resized = rho_bits.clone();
@@ -877,12 +872,27 @@ where
         let (cf_u_i1_x_base, _) =
             CycleFoldCommittedInstanceVar::<C2, GC2>::new_constant(cs.clone(), cf_u_dummy)?
                 .hash(&sponge, pp_hash)?;
-        let cf_x = FpVar::new_input(cs.clone(), || {
-            Ok(self.cf_x.unwrap_or(cf_u_i1_x_base.value()?))
-        })?;
-        cf_x.enforce_equal(&is_basecase.select(&cf_u_i1_x_base, &cf_u_i1_x)?)?;
+        let cf_x = is_basecase.select(&cf_u_i1_x_base, &cf_u_i1_x)?;
+        // This line "converts" `cf_x` from a witness to a public input.
+        // Instead of directly modifying the constraint system, we explicitly
+        // allocate a public input and enforce that its value is indeed `cf_x`.
+        FpVar::new_input(cs.clone(), || cf_x.value())?.enforce_equal(&cf_x)?;
 
-        Ok(())
+        Ok(z_i1)
+    }
+}
+
+impl<C1, C2, GC2, FC, const MU: usize, const NU: usize> ConstraintSynthesizer<CF1<C1>>
+    for AugmentedFCircuit<C1, C2, GC2, FC, MU, NU>
+where
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: CurveGroup,
+    GC2: CurveVar<C2, CF2<C2>>,
+    FC: FCircuit<CF1<C1>>,
+    C2::BaseField: PrimeField + Absorb,
+{
+    fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {
+        self.compute_next_state(cs).map(|_| ())
     }
 }
 
@@ -1267,15 +1277,18 @@ mod tests {
 
             let (U_i1, W_i1);
 
+            let u_i1_x;
+            let cf_u_i1_x;
+
             if i == 0 {
                 W_i1 = Witness::<Fr>::dummy(&ccs);
                 U_i1 = LCCCS::dummy(&ccs);
 
-                let u_i1_x = U_i1.hash(&sponge, pp_hash, Fr::one(), &z_0, &z_i1);
+                u_i1_x = U_i1.hash(&sponge, pp_hash, Fr::one(), &z_0, &z_i1);
 
                 // hash the initial (dummy) CycleFold instance, which is used as the 2nd public
                 // input in the AugmentedFCircuit
-                let cf_u_i1_x = cf_U_i.hash_cyclefold(&sponge, pp_hash);
+                cf_u_i1_x = cf_U_i.hash_cyclefold(&sponge, pp_hash);
 
                 augmented_f_circuit = AugmentedFCircuit::<
                     Projective,
@@ -1301,13 +1314,11 @@ mod tests {
                     us: Some(us.clone()),
                     U_i1_C: Some(U_i1.C),
                     F: F_circuit,
-                    x: Some(u_i1_x),
                     nimfs_proof: None,
 
                     // cyclefold values
                     cf_u_i_cmW: None,
                     cf_U_i: None,
-                    cf_x: Some(cf_u_i1_x),
                     cf_cmT: None,
                 };
             } else {
@@ -1327,7 +1338,7 @@ mod tests {
                 // sanity check: check the folded instance relation
                 ccs.check_relation(&W_i1, &U_i1)?;
 
-                let u_i1_x = U_i1.hash(&sponge, pp_hash, iFr + Fr::one(), &z_0, &z_i1);
+                u_i1_x = U_i1.hash(&sponge, pp_hash, iFr + Fr::one(), &z_0, &z_i1);
 
                 let rho_bits = rho.into_bigint().to_bits_le()[..NOVA_N_BITS_RO].to_vec();
                 let rho_Fq = Fq::from_bigint(BigInteger::from_bits_le(&rho_bits))
@@ -1392,7 +1403,7 @@ mod tests {
 
                 // hash the CycleFold folded instance, which is used as the 2nd public input in the
                 // AugmentedFCircuit
-                let cf_u_i1_x = cf_U_i1.hash_cyclefold(&sponge, pp_hash);
+                cf_u_i1_x = cf_U_i1.hash_cyclefold(&sponge, pp_hash);
 
                 augmented_f_circuit = AugmentedFCircuit::<
                     Projective,
@@ -1418,13 +1429,11 @@ mod tests {
                     us: Some(us.clone()),
                     U_i1_C: Some(U_i1.C),
                     F: F_circuit,
-                    x: Some(u_i1_x),
                     nimfs_proof: Some(nimfs_proof),
 
                     // cyclefold values
                     cf_u_i_cmW: Some(cf_u_i.cmW),
                     cf_U_i: Some(cf_U_i),
-                    cf_x: Some(cf_u_i1_x),
                     cf_cmT: Some(cf_cmT),
                 };
 
@@ -1441,7 +1450,7 @@ mod tests {
             assert!(cs.is_satisfied()?);
 
             let (r1cs_w_i1, r1cs_x_i1) = extract_w_x::<Fr>(&cs); // includes 1 and public inputs
-            assert_eq!(r1cs_x_i1[0], augmented_f_circuit.x.unwrap());
+            assert_eq!(r1cs_x_i1[0], u_i1_x);
             let r1cs_z = [vec![Fr::one()], r1cs_x_i1.clone(), r1cs_w_i1.clone()].concat();
             // compute committed instances, w_{i+1}, u_{i+1}, which will be used as w_i, u_i, so we
             // assign them directly to w_i, u_i.
@@ -1455,8 +1464,8 @@ mod tests {
             // sanity checks
             assert_eq!(w_i.w, r1cs_w_i1);
             assert_eq!(u_i.x, r1cs_x_i1);
-            assert_eq!(u_i.x[0], augmented_f_circuit.x.unwrap());
-            assert_eq!(u_i.x[1], augmented_f_circuit.cf_x.unwrap());
+            assert_eq!(u_i.x[0], u_i1_x);
+            assert_eq!(u_i.x[1], cf_u_i1_x);
             let expected_u_i1_x = U_i1.hash(&sponge, pp_hash, iFr + Fr::one(), &z_0, &z_i1);
             let expected_cf_U_i1_x = cf_U_i.hash_cyclefold(&sponge, pp_hash);
             // u_i is already u_i1 at this point, check that has the expected value at x[0]

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -248,6 +248,12 @@ where
         // This line "converts" `x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `x`.
+        // While comparing `x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `x` computed in-circuit.
         FpVar::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         // CycleFold part
@@ -331,6 +337,12 @@ where
         // This line "converts" `cf_x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `cf_x`.
+        // While comparing `cf_x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `cf_x` computed in-circuit.
         FpVar::new_input(cs.clone(), || cf_x.value())?.enforce_equal(&cf_x)?;
 
         Ok(z_i1)

--- a/folding-schemes/src/folding/protogalaxy/circuits.rs
+++ b/folding-schemes/src/folding/protogalaxy/circuits.rs
@@ -394,6 +394,12 @@ where
         // This line "converts" `x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `x`.
+        // While comparing `x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `x` computed in-circuit.
         FpVar::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         // CycleFold part
@@ -468,6 +474,12 @@ where
         // This line "converts" `cf_x` from a witness to a public input.
         // Instead of directly modifying the constraint system, we explicitly
         // allocate a public input and enforce that its value is indeed `cf_x`.
+        // While comparing `cf_x` with itself seems redundant, this is necessary
+        // because:
+        // - `.value()` allows an honest prover to extract public inputs without
+        //   computing them outside the circuit.
+        // - `.enforce_equal()` prevents a malicious prover from claiming wrong
+        //   public inputs that are not the honest `cf_x` computed in-circuit.
         FpVar::new_input(cs.clone(), || cf_x.value())?.enforce_equal(&cf_x)?;
 
         Ok(z_i1)

--- a/folding-schemes/src/folding/protogalaxy/circuits.rs
+++ b/folding-schemes/src/folding/protogalaxy/circuits.rs
@@ -255,7 +255,6 @@ pub struct AugmentedFCircuit<
     pub(super) U_i1_phi: C1,
     pub(super) F_coeffs: Vec<CF1<C1>>,
     pub(super) K_coeffs: Vec<CF1<C1>>,
-    pub(super) x: Option<CF1<C1>>, // public input (u_{i+1}.x[0])
 
     pub(super) phi_stars: Vec<C1>,
 
@@ -264,7 +263,6 @@ pub struct AugmentedFCircuit<
     pub(super) cf_U_i: CycleFoldCommittedInstance<C2>, // input
     pub(super) cf1_cmT: C2,
     pub(super) cf2_cmT: C2,
-    pub(super) cf_x: Option<CF1<C1>>, // public input (u_{i+1}.x[1])
 }
 
 impl<C1: CurveGroup, C2: CurveGroup, GC2: CurveVar<C2, CF2<C2>>, FC: FCircuit<CF1<C1>>>
@@ -297,19 +295,17 @@ impl<C1: CurveGroup, C2: CurveGroup, GC2: CurveVar<C2, CF2<C2>>, FC: FCircuit<CF
             K_coeffs: vec![CF1::<C1>::zero(); d * k + 1],
             phi_stars: vec![C1::zero(); k],
             F: F_circuit,
-            x: None,
             // cyclefold values
             cf1_u_i_cmW: C2::zero(),
             cf2_u_i_cmW: C2::zero(),
             cf_U_i: cf_u_dummy,
             cf1_cmT: C2::zero(),
             cf2_cmT: C2::zero(),
-            cf_x: None,
         }
     }
 }
 
-impl<C1, C2, GC2, FC> ConstraintSynthesizer<CF1<C1>> for AugmentedFCircuit<C1, C2, GC2, FC>
+impl<C1, C2, GC2, FC> AugmentedFCircuit<C1, C2, GC2, FC>
 where
     C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     C2: CurveGroup,
@@ -317,7 +313,10 @@ where
     FC: FCircuit<CF1<C1>>,
     C2::BaseField: PrimeField + Absorb,
 {
-    fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {
+    pub fn compute_next_state(
+        self,
+        cs: ConstraintSystemRef<CF1<C1>>,
+    ) -> Result<Vec<FpVar<CF1<C1>>>, SynthesisError> {
         let pp_hash = FpVar::<CF1<C1>>::new_witness(cs.clone(), || Ok(self.pp_hash))?;
         let i = FpVar::<CF1<C1>>::new_witness(cs.clone(), || Ok(self.i))?;
         let z_0 = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || Ok(self.z_0))?;
@@ -391,8 +390,11 @@ where
             &z_0,
             &z_i1,
         )?;
-        let x = FpVar::new_input(cs.clone(), || Ok(self.x.unwrap_or(u_i1_x_base.value()?)))?;
-        x.enforce_equal(&is_basecase.select(&u_i1_x_base, &u_i1_x)?)?;
+        let x = is_basecase.select(&u_i1_x_base, &u_i1_x)?;
+        // This line "converts" `x` from a witness to a public input.
+        // Instead of directly modifying the constraint system, we explicitly
+        // allocate a public input and enforce that its value is indeed `x`.
+        FpVar::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
 
         // CycleFold part
         // C.1. Compute cf1_u_i.x and cf2_u_i.x
@@ -462,12 +464,26 @@ where
         let (cf_u_i1_x_base, _) =
             CycleFoldCommittedInstanceVar::<C2, GC2>::new_constant(cs.clone(), cf_u_dummy)?
                 .hash(&sponge, pp_hash.clone())?;
-        let cf_x = FpVar::new_input(cs.clone(), || {
-            Ok(self.cf_x.unwrap_or(cf_u_i1_x_base.value()?))
-        })?;
-        cf_x.enforce_equal(&is_basecase.select(&cf_u_i1_x_base, &cf_u_i1_x)?)?;
+        let cf_x = is_basecase.select(&cf_u_i1_x_base, &cf_u_i1_x)?;
+        // This line "converts" `cf_x` from a witness to a public input.
+        // Instead of directly modifying the constraint system, we explicitly
+        // allocate a public input and enforce that its value is indeed `cf_x`.
+        FpVar::new_input(cs.clone(), || cf_x.value())?.enforce_equal(&cf_x)?;
 
-        Ok(())
+        Ok(z_i1)
+    }
+}
+
+impl<C1, C2, GC2, FC> ConstraintSynthesizer<CF1<C1>> for AugmentedFCircuit<C1, C2, GC2, FC>
+where
+    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: CurveGroup,
+    GC2: CurveVar<C2, CF2<C2>>,
+    FC: FCircuit<CF1<C1>>,
+    C2::BaseField: PrimeField + Absorb,
+{
+    fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {
+        self.compute_next_state(cs).map(|_| ())
     }
 }
 

--- a/folding-schemes/src/frontend/utils.rs
+++ b/folding-schemes/src/frontend/utils.rs
@@ -33,14 +33,6 @@ impl<F: PrimeField> FCircuit<F> for DummyCircuit {
     fn external_inputs_len(&self) -> usize {
         self.external_inputs_len
     }
-    fn step_native(
-        &self,
-        _i: usize,
-        _z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        Ok(vec![F::zero(); self.state_len])
-    }
     fn generate_step_constraints(
         &self,
         cs: ConstraintSystemRef<F>,
@@ -74,14 +66,6 @@ impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
     fn external_inputs_len(&self) -> usize {
         0
     }
-    fn step_native(
-        &self,
-        _i: usize,
-        z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
-    }
     fn generate_step_constraints(
         &self,
         cs: ConstraintSystemRef<F>,
@@ -94,6 +78,13 @@ impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
 
         Ok(vec![&z_i * &z_i * &z_i + &z_i + &five])
     }
+}
+
+/// Native implementation of `CubicFCircuit`
+#[cfg(test)]
+pub fn cubic_step_native<F: PrimeField>(z_i: Vec<F>) -> Vec<F> {
+    let z = z_i[0];
+    vec![z * z * z + z + F::from(5)]
 }
 
 /// CustomFCircuit is a circuit that has the number of constraints specified in the
@@ -119,18 +110,6 @@ impl<F: PrimeField> FCircuit<F> for CustomFCircuit<F> {
     fn external_inputs_len(&self) -> usize {
         0
     }
-    fn step_native(
-        &self,
-        _i: usize,
-        z_i: Vec<F>,
-        _external_inputs: Vec<F>,
-    ) -> Result<Vec<F>, Error> {
-        let mut z_i1 = z_i[0];
-        for _ in 0..self.n_constraints - 1 {
-            z_i1 = z_i1.square();
-        }
-        Ok(vec![z_i1])
-    }
     fn generate_step_constraints(
         &self,
         _cs: ConstraintSystemRef<F>,
@@ -145,6 +124,16 @@ impl<F: PrimeField> FCircuit<F> for CustomFCircuit<F> {
 
         Ok(vec![z_i1])
     }
+}
+
+/// Native implementation of `CubicFCircuit`
+#[cfg(test)]
+pub fn custom_step_native<F: PrimeField>(z_i: Vec<F>, n_constraints: usize) -> Vec<F> {
+    let mut z_i1 = z_i[0];
+    for _ in 0..n_constraints - 1 {
+        z_i1 = z_i1.square();
+    }
+    vec![z_i1]
 }
 
 /// WrapperCircuit is a circuit that wraps any circuit that implements the FCircuit trait. This

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -208,14 +208,6 @@ mod tests {
         fn external_inputs_len(&self) -> usize {
             0
         }
-        fn step_native(
-            &self,
-            _i: usize,
-            z_i: Vec<F>,
-            _external_inputs: Vec<F>,
-        ) -> Result<Vec<F>, Error> {
-            Ok(vec![z_i[0] * z_i[0] * z_i[0] + z_i[0] + F::from(5_u32)])
-        }
         fn generate_step_constraints(
             &self,
             cs: ConstraintSystemRef<F>,
@@ -251,24 +243,6 @@ mod tests {
         fn external_inputs_len(&self) -> usize {
             0
         }
-
-        /// computes the next state values in place, assigning z_{i+1} into z_i, and computing the new
-        /// z_{i+1}
-        fn step_native(
-            &self,
-            _i: usize,
-            z_i: Vec<F>,
-            _external_inputs: Vec<F>,
-        ) -> Result<Vec<F>, Error> {
-            let a = z_i[0] + F::from(4_u32);
-            let b = z_i[1] + F::from(40_u32);
-            let c = z_i[2] * F::from(4_u32);
-            let d = z_i[3] * F::from(40_u32);
-            let e = z_i[4] + F::from(100_u32);
-
-            Ok(vec![a, b, c, d, e])
-        }
-
         /// generates the constraints for the step of F for the given z_i
         fn generate_step_constraints(
             &self,


### PR DESCRIPTION
This PR provides a tiny optimization of `prove_step` and avoids *natively* computing values that are also derived *in-circuit*. More specifically, sometimes we have two versions (native and in-circuit) of the same computation, and the native part is in fact unnecessary because we can extract the results from the circuit.

For example:
- Instead of running `step_native` to obtain the next state $z_{i + 1}$, we modify the augmented circuit which now returns the result of `generate_step_constraints`, and the native value $z_{i + 1}$ is now retrieved by calling `.value()` on the in-circuit variable.
  - A possible downside of removing `step_native` is that, if the user implements `generate_step_constraints` and `step_native` with inconsistent behaviors (e.g., when `step_native` is correct but `generate_step_constraints` has bugs), then $z_{i + 1}$ will become incorrect. For this, we may recommend the user to write unit tests for their step circuits.
- Instead of computing public inputs natively for the augmented circuit and the CycleFold circuit, we do the computation solely in circuit and mark the results as public.

The performance gain is not very significant because `step_native` is not the bottleneck, but the additional benefit is that we can have cleaner and less duplicated code.