### PR TITLE
Refactor and simplify the design of traits

### DIFF
--- a/benches/common.rs
+++ b/benches/common.rs
@@ -1,26 +1,20 @@
-use ark_ec::CurveGroup;
-use ark_ff::PrimeField;
 use criterion::*;
 
 use folding_schemes::{
     frontend::{utils::CustomFCircuit, FCircuit},
-    Error, FoldingScheme,
+    Error, FoldingScheme, SonobeCurve,
 };
 
 pub(crate) fn bench_ivc_opt<
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: SonobeCurve,
     FS: FoldingScheme<C1, C2, CustomFCircuit<C1::ScalarField>>,
 >(
     c: &mut Criterion,
     name: String,
     n: usize,
     prep_param: FS::PreprocessorParam,
-) -> Result<(), Error>
-where
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2::BaseField: PrimeField,
-{
+) -> Result<(), Error> {
     let fcircuit_size = 1 << n; // 2^n
 
     let f_circuit = CustomFCircuit::<C1::ScalarField>::new(fcircuit_size)?;

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -2,12 +2,12 @@ use criterion::*;
 
 use folding_schemes::{
     frontend::{utils::CustomFCircuit, FCircuit},
-    Error, FoldingScheme, SonobeCurve,
+    Curve, Error, FoldingScheme,
 };
 
 pub(crate) fn bench_ivc_opt<
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FS: FoldingScheme<C1, C2, CustomFCircuit<C1::ScalarField>>,
 >(
     c: &mut Criterion,

--- a/benches/hypernova.rs
+++ b/benches/hypernova.rs
@@ -1,10 +1,10 @@
 use criterion::*;
 use pprof::criterion::{Output, PProfProfiler};
 
-use ark_bn254::{constraints::GVar as bn_GVar, Fr as bn_Fr, G1Projective as bn_G};
-use ark_grumpkin::{constraints::GVar as grumpkin_GVar, Projective as grumpkin_G};
-use ark_pallas::{constraints::GVar as pallas_GVar, Fr as pallas_Fr, Projective as pallas_G};
-use ark_vesta::{constraints::GVar as vesta_GVar, Projective as vesta_G};
+use ark_bn254::{Fr as bn_Fr, G1Projective as bn_G};
+use ark_grumpkin::Projective as grumpkin_G;
+use ark_pallas::{Fr as pallas_Fr, Projective as pallas_G};
+use ark_vesta::Projective as vesta_G;
 
 use folding_schemes::{
     commitment::pedersen::Pedersen,
@@ -30,9 +30,7 @@ fn bench_hypernova_ivc(c: &mut Criterion) {
             vesta_G,
             HyperNova<
                 pallas_G,
-                pallas_GVar,
                 vesta_G,
-                vesta_GVar,
                 CustomFCircuit<pallas_Fr>,
                 Pedersen<pallas_G>,
                 Pedersen<vesta_G>,
@@ -60,9 +58,7 @@ fn bench_hypernova_ivc(c: &mut Criterion) {
             grumpkin_G,
             HyperNova<
                 bn_G,
-                bn_GVar,
                 grumpkin_G,
-                grumpkin_GVar,
                 CustomFCircuit<bn_Fr>,
                 Pedersen<bn_G>,
                 Pedersen<grumpkin_G>,

--- a/benches/nova.rs
+++ b/benches/nova.rs
@@ -1,10 +1,10 @@
 use criterion::*;
 use pprof::criterion::{Output, PProfProfiler};
 
-use ark_bn254::{constraints::GVar as bn_GVar, Fr as bn_Fr, G1Projective as bn_G};
-use ark_grumpkin::{constraints::GVar as grumpkin_GVar, Projective as grumpkin_G};
-use ark_pallas::{constraints::GVar as pallas_GVar, Fr as pallas_Fr, Projective as pallas_G};
-use ark_vesta::{constraints::GVar as vesta_GVar, Projective as vesta_G};
+use ark_bn254::{Fr as bn_Fr, G1Projective as bn_G};
+use ark_grumpkin::Projective as grumpkin_G;
+use ark_pallas::{Fr as pallas_Fr, Projective as pallas_G};
+use ark_vesta::Projective as vesta_G;
 
 use folding_schemes::{
     commitment::pedersen::Pedersen,
@@ -30,9 +30,7 @@ fn bench_nova_ivc(c: &mut Criterion) {
             vesta_G,
             Nova<
                 pallas_G,
-                pallas_GVar,
                 vesta_G,
-                vesta_GVar,
                 CustomFCircuit<pallas_Fr>,
                 Pedersen<pallas_G>,
                 Pedersen<vesta_G>,
@@ -53,9 +51,7 @@ fn bench_nova_ivc(c: &mut Criterion) {
             grumpkin_G,
             Nova<
                 bn_G,
-                bn_GVar,
                 grumpkin_G,
-                grumpkin_GVar,
                 CustomFCircuit<bn_Fr>,
                 Pedersen<bn_G>,
                 Pedersen<grumpkin_G>,

--- a/benches/protogalaxy.rs
+++ b/benches/protogalaxy.rs
@@ -1,10 +1,10 @@
 use criterion::*;
 use pprof::criterion::{Output, PProfProfiler};
 
-use ark_bn254::{constraints::GVar as bn_GVar, Fr as bn_Fr, G1Projective as bn_G};
-use ark_grumpkin::{constraints::GVar as grumpkin_GVar, Projective as grumpkin_G};
-use ark_pallas::{constraints::GVar as pallas_GVar, Fr as pallas_Fr, Projective as pallas_G};
-use ark_vesta::{constraints::GVar as vesta_GVar, Projective as vesta_G};
+use ark_bn254::{Fr as bn_Fr, G1Projective as bn_G};
+use ark_grumpkin::Projective as grumpkin_G;
+use ark_pallas::{Fr as pallas_Fr, Projective as pallas_G};
+use ark_vesta::Projective as vesta_G;
 
 use folding_schemes::{
     commitment::pedersen::Pedersen,
@@ -30,9 +30,7 @@ fn bench_protogalaxy_ivc(c: &mut Criterion) {
             vesta_G,
             ProtoGalaxy<
                 pallas_G,
-                pallas_GVar,
                 vesta_G,
-                vesta_GVar,
                 CustomFCircuit<pallas_Fr>,
                 Pedersen<pallas_G>,
                 Pedersen<vesta_G>,
@@ -57,9 +55,7 @@ fn bench_protogalaxy_ivc(c: &mut Criterion) {
             grumpkin_G,
             ProtoGalaxy<
                 bn_G,
-                bn_GVar,
                 grumpkin_G,
-                grumpkin_GVar,
                 CustomFCircuit<bn_Fr>,
                 Pedersen<bn_G>,
                 Pedersen<grumpkin_G>,

--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -9,10 +9,10 @@
 /// - generate the Solidity contract that verifies the proof
 /// - verify the proof in the EVM
 ///
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
+use ark_bn254::{Bn254, Fr, G1Projective as G1};
 
 use ark_groth16::Groth16;
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
+use ark_grumpkin::Projective as G2;
 
 use std::path::PathBuf;
 use std::time::Instant;
@@ -67,13 +67,10 @@ fn main() -> Result<(), Error> {
     let f_circuit_params = (r1cs_path.into(), wasm_path.into(), 1, 2);
     let f_circuit = CircomFCircuit::<Fr>::new(f_circuit_params)?;
 
-    pub type N =
-        Nova<G1, GVar, G2, GVar2, CircomFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
+    pub type N = Nova<G1, G2, CircomFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
     pub type D = DeciderEth<
         G1,
-        GVar,
         G2,
-        GVar2,
         CircomFCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<G2>,

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -3,7 +3,7 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
+use ark_bn254::{Bn254, Fr, G1Projective as Projective};
 use ark_crypto_primitives::{
     crh::{
         poseidon::constraints::{CRHGadget, CRHParametersVar},
@@ -12,7 +12,7 @@ use ark_crypto_primitives::{
     sponge::{poseidon::PoseidonConfig, Absorb},
 };
 use ark_ff::PrimeField;
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+use ark_grumpkin::Projective as Projective2;
 use ark_r1cs_std::alloc::AllocVar;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
@@ -169,9 +169,7 @@ fn main() -> Result<(), Error> {
     /// trait, and the rest of our code would be working without needing to be updated.
     type N = Nova<
         Projective,
-        GVar,
         Projective2,
-        GVar2,
         ExternalInputsCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<Projective2>,

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -9,10 +9,10 @@
 /// - generate the Solidity contract that verifies the proof
 /// - verify the proof in the EVM
 ///
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
+use ark_bn254::{Bn254, Fr, G1Projective as G1};
 use ark_ff::PrimeField;
 use ark_groth16::Groth16;
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
+use ark_grumpkin::Projective as G2;
 use ark_r1cs_std::alloc::AllocVar;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
@@ -76,19 +76,9 @@ fn main() -> Result<(), Error> {
 
     let f_circuit = CubicFCircuit::<Fr>::new(())?;
 
-    pub type N =
-        Nova<G1, GVar, G2, GVar2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
-    pub type D = DeciderEth<
-        G1,
-        GVar,
-        G2,
-        GVar2,
-        CubicFCircuit<Fr>,
-        KZG<'static, Bn254>,
-        Pedersen<G2>,
-        Groth16<Bn254>,
-        N,
-    >;
+    pub type N = Nova<G1, G2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
+    pub type D =
+        DeciderEth<G1, G2, CubicFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, Groth16<Bn254>, N>;
 
     let poseidon_config = poseidon_canonical_config::<Fr>();
     let mut rng = ark_std::rand::rngs::OsRng;

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -10,8 +10,8 @@ use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+use ark_bn254::{Bn254, Fr, G1Projective as Projective};
+use ark_grumpkin::Projective as Projective2;
 
 use folding_schemes::commitment::{kzg::KZG, pedersen::Pedersen};
 use folding_schemes::folding::nova::{Nova, PreprocessorParam};
@@ -123,9 +123,7 @@ fn main() -> Result<(), Error> {
     /// trait, and the rest of our code would be working without needing to be updated.
     type N = Nova<
         Projective,
-        GVar,
         Projective2,
-        GVar2,
         MultiInputsFCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<Projective2>,

--- a/examples/noir_full_flow.rs
+++ b/examples/noir_full_flow.rs
@@ -9,10 +9,10 @@
 /// - generate the Solidity contract that verifies the proof
 /// - verify the proof in the EVM
 ///
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
+use ark_bn254::{Bn254, Fr, G1Projective as G1};
 
 use ark_groth16::Groth16;
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
+use ark_grumpkin::Projective as G2;
 
 use experimental_frontends::noir::NoirFCircuit;
 use folding_schemes::{
@@ -49,18 +49,9 @@ fn main() -> Result<(), Error> {
         0,
     ))?;
 
-    pub type N = Nova<G1, GVar, G2, GVar2, NoirFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
-    pub type D = DeciderEth<
-        G1,
-        GVar,
-        G2,
-        GVar2,
-        NoirFCircuit<Fr>,
-        KZG<'static, Bn254>,
-        Pedersen<G2>,
-        Groth16<Bn254>,
-        N,
-    >;
+    pub type N = Nova<G1, G2, NoirFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>>;
+    pub type D =
+        DeciderEth<G1, G2, NoirFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, Groth16<Bn254>, N>;
 
     let poseidon_config = poseidon_canonical_config::<Fr>();
     let mut rng = ark_std::rand::rngs::OsRng;

--- a/examples/noname_full_flow.rs
+++ b/examples/noname_full_flow.rs
@@ -9,11 +9,11 @@
 /// - generate the Solidity contract that verifies the proof
 /// - verify the proof in the EVM
 ///
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
+use ark_bn254::{Bn254, Fr, G1Projective as G1};
 use noname::backends::r1cs::R1csBn254Field;
 
 use ark_groth16::Groth16;
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
+use ark_grumpkin::Projective as G2;
 
 use experimental_frontends::noname::NonameFCircuit;
 use folding_schemes::{
@@ -61,20 +61,11 @@ fn main() -> Result<(), Error> {
     let f_circuit_params = (NONAME_CIRCUIT_EXTERNAL_INPUTS.to_owned(), 2, 2);
     let f_circuit = NonameFCircuit::<Fr, R1csBn254Field>::new(f_circuit_params)?;
 
-    pub type N = Nova<
-        G1,
-        GVar,
-        G2,
-        GVar2,
-        NonameFCircuit<Fr, R1csBn254Field>,
-        KZG<'static, Bn254>,
-        Pedersen<G2>,
-    >;
+    pub type N =
+        Nova<G1, G2, NonameFCircuit<Fr, R1csBn254Field>, KZG<'static, Bn254>, Pedersen<G2>>;
     pub type D = DeciderEth<
         G1,
-        GVar,
         G2,
-        GVar2,
         NonameFCircuit<Fr, R1csBn254Field>,
         KZG<'static, Bn254>,
         Pedersen<G2>,

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -16,8 +16,8 @@ use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
 use core::marker::PhantomData;
 use std::time::Instant;
 
-use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
-use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+use ark_bn254::{Bn254, Fr, G1Projective as Projective};
+use ark_grumpkin::Projective as Projective2;
 
 use folding_schemes::commitment::{kzg::KZG, pedersen::Pedersen};
 use folding_schemes::folding::nova::{Nova, PreprocessorParam};
@@ -107,9 +107,7 @@ fn main() -> Result<(), Error> {
     /// trait, and the rest of our code would be working without needing to be updated.
     type N = Nova<
         Projective,
-        GVar,
         Projective2,
-        GVar2,
         Sha256FCircuit<Fr>,
         KZG<'static, Bn254>,
         Pedersen<Projective2>,

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -1,7 +1,7 @@
 use ark_relations::r1cs::SynthesisError;
 use ark_std::rand::RngCore;
 
-use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Error, SonobeCurve};
+use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Curve, Error};
 
 pub mod ccs;
 pub mod r1cs;
@@ -122,7 +122,7 @@ pub trait ArithSerializer {
 /// in a plain R1CS.
 ///
 /// [HyperNova]: https://eprint.iacr.org/2023/573.pdf
-pub trait ArithSampler<C: SonobeCurve, W, U>: Arith<W, U> {
+pub trait ArithSampler<C: Curve, W, U>: Arith<W, U> {
     /// Samples a random witness and instance that satisfy the constraint system.
     fn sample_witness_instance<CS: CommitmentScheme<C, true>>(
         &self,

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -1,8 +1,7 @@
-use ark_ec::CurveGroup;
 use ark_relations::r1cs::SynthesisError;
 use ark_std::rand::RngCore;
 
-use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Error};
+use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Error, SonobeCurve};
 
 pub mod ccs;
 pub mod r1cs;
@@ -123,7 +122,7 @@ pub trait ArithSerializer {
 /// in a plain R1CS.
 ///
 /// [HyperNova]: https://eprint.iacr.org/2023/573.pdf
-pub trait ArithSampler<C: CurveGroup, W, U>: Arith<W, U> {
+pub trait ArithSampler<C: SonobeCurve, W, U>: Arith<W, U> {
     /// Samples a random witness and instance that satisfy the constraint system.
     fn sample_witness_instance<CS: CommitmentScheme<C, true>>(
         &self,

--- a/folding-schemes/src/arith/r1cs/circuits.rs
+++ b/folding-schemes/src/arith/r1cs/circuits.rs
@@ -95,7 +95,7 @@ pub mod tests {
         },
         CRHScheme, CRHSchemeGadget,
     };
-    use ark_ec::CurveGroup;
+
     use ark_ff::BigInteger;
     use ark_pallas::{Fq, Fr, Projective};
     use ark_r1cs_std::{eq::EqGadget, fields::fp::FpVar, uint8::UInt8};
@@ -104,7 +104,7 @@ pub mod tests {
         rand::{thread_rng, Rng},
         One, UniformRand,
     };
-    use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_vesta::Projective as Projective2;
 
     use super::*;
     use crate::arith::{
@@ -131,9 +131,9 @@ pub mod tests {
         },
         FCircuit,
     };
-    use crate::Error;
+    use crate::{Error, SonobeCurve};
 
-    fn prepare_instances<C: CurveGroup, CS: CommitmentScheme<C>, R: Rng>(
+    fn prepare_instances<C: SonobeCurve, CS: CommitmentScheme<C>, R: Rng>(
         mut rng: R,
         r1cs: &R1CS<C::ScalarField>,
         z: &[C::ScalarField],
@@ -295,7 +295,7 @@ pub mod tests {
         // non-natively
         let cs = ConstraintSystem::<Fr>::new_ref();
         let wVar = CycleFoldWitnessVar::new_witness(cs.clone(), || Ok(w))?;
-        let uVar = CycleFoldCommittedInstanceVar::<_, GVar2>::new_witness(cs.clone(), || Ok(u))?;
+        let uVar = CycleFoldCommittedInstanceVar::new_witness(cs.clone(), || Ok(u))?;
         let r1csVar =
             R1CSMatricesVar::<Fq, NonNativeUintVar<Fr>>::new_witness(cs.clone(), || Ok(r1cs))?;
         r1csVar.enforce_relation(&wVar, &uVar)?;

--- a/folding-schemes/src/arith/r1cs/circuits.rs
+++ b/folding-schemes/src/arith/r1cs/circuits.rs
@@ -131,9 +131,9 @@ pub mod tests {
         },
         FCircuit,
     };
-    use crate::{Error, SonobeCurve};
+    use crate::{Curve, Error};
 
-    fn prepare_instances<C: SonobeCurve, CS: CommitmentScheme<C>, R: Rng>(
+    fn prepare_instances<C: Curve, CS: CommitmentScheme<C>, R: Rng>(
         mut rng: R,
         r1cs: &R1CS<C::ScalarField>,
         z: &[C::ScalarField],

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -30,10 +30,10 @@ use crate::utils::{
     powers_of,
     vec::{vec_add, vec_scalar_mul},
 };
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof<C: SonobeCurve> {
+pub struct Proof<C: Curve> {
     a: C::ScalarField,
     l: Vec<C::ScalarField>,
     r: Vec<C::ScalarField>,
@@ -44,12 +44,12 @@ pub struct Proof<C: SonobeCurve> {
 /// IPA implements the Inner Product Argument protocol following the CommitmentScheme trait. The
 /// `H` parameter indicates if to use the commitment in hiding mode or not.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct IPA<C: SonobeCurve, const H: bool = false> {
+pub struct IPA<C: Curve, const H: bool = false> {
     _c: PhantomData<C>,
 }
 
 /// Implements the CommitmentScheme trait for IPA
-impl<C: SonobeCurve, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
+impl<C: Curve, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
     type ProverParams = PedersenParams<C>;
     type VerifierParams = PedersenParams<C>;
     type Proof = (Proof<C>, C::ScalarField, C::ScalarField); // (proof, v=p(x), r=blinding factor)
@@ -436,14 +436,14 @@ fn s_b_inner_gadget<F: PrimeField, CF: PrimeField>(
     Ok(c)
 }
 
-pub struct ProofVar<C: SonobeCurve> {
+pub struct ProofVar<C: Curve> {
     a: EmulatedFpVar<C::ScalarField, CF2<C>>,
     l: Vec<EmulatedFpVar<C::ScalarField, CF2<C>>>,
     r: Vec<EmulatedFpVar<C::ScalarField, CF2<C>>>,
     L: Vec<C::Var>,
     R: Vec<C::Var>,
 }
-impl<C: SonobeCurve> AllocVar<Proof<C>, CF2<C>> for ProofVar<C> {
+impl<C: Curve> AllocVar<Proof<C>, CF2<C>> for ProofVar<C> {
     fn new_variable<T: Borrow<Proof<C>>>(
         cs: impl Into<Namespace<CF2<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -474,11 +474,11 @@ impl<C: SonobeCurve> AllocVar<Proof<C>, CF2<C>> for ProofVar<C> {
 /// IPAGadget implements the circuit that verifies an IPA Proof. The `H` parameter indicates if to
 /// use the commitment in hiding mode or not, reducing a bit the number of constraints needed in
 /// the later case.
-pub struct IPAGadget<C: SonobeCurve, const H: bool = false> {
+pub struct IPAGadget<C: Curve, const H: bool = false> {
     _c: PhantomData<C>,
 }
 
-impl<C: SonobeCurve, const H: bool> IPAGadget<C, H> {
+impl<C: Curve, const H: bool> IPAGadget<C, H> {
     /// Verify the IPA opening proof, K=log2(d), where d is the degree of the committed polynomial,
     /// and H indicates if the commitment is in hiding mode and thus uses blinding factors, if not,
     /// there are some constraints saved.

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -7,12 +7,13 @@
 /// i. <s, b> computation is done in log time following a modification of the equation 3 in section
 /// 3.2 from the paper.
 /// ii. s computation is done in 2^{k+1}-2 instead of k*2^k.
-use ark_ec::{AffineRepr, CurveGroup};
+use ark_ec::AffineRepr;
 use ark_ff::{Field, PrimeField};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     boolean::Boolean,
     convert::ToBitsGadget,
+    eq::EqGadget,
     fields::{emulated_fp::EmulatedFpVar, FieldVar},
     prelude::CurveVar,
 };
@@ -23,15 +24,16 @@ use core::{borrow::Borrow, marker::PhantomData};
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use super::{pedersen::Params as PedersenParams, CommitmentScheme};
+use crate::folding::circuits::CF2;
 use crate::transcript::Transcript;
 use crate::utils::{
     powers_of,
     vec::{vec_add, vec_scalar_mul},
 };
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof<C: CurveGroup> {
+pub struct Proof<C: SonobeCurve> {
     a: C::ScalarField,
     l: Vec<C::ScalarField>,
     r: Vec<C::ScalarField>,
@@ -42,12 +44,12 @@ pub struct Proof<C: CurveGroup> {
 /// IPA implements the Inner Product Argument protocol following the CommitmentScheme trait. The
 /// `H` parameter indicates if to use the commitment in hiding mode or not.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct IPA<C: CurveGroup, const H: bool = false> {
+pub struct IPA<C: SonobeCurve, const H: bool = false> {
     _c: PhantomData<C>,
 }
 
 /// Implements the CommitmentScheme trait for IPA
-impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
+impl<C: SonobeCurve, const H: bool> CommitmentScheme<C, H> for IPA<C, H> {
     type ProverParams = PedersenParams<C>;
     type VerifierParams = PedersenParams<C>;
     type Proof = (Proof<C>, C::ScalarField, C::ScalarField); // (proof, v=p(x), r=blinding factor)
@@ -434,40 +436,35 @@ fn s_b_inner_gadget<F: PrimeField, CF: PrimeField>(
     Ok(c)
 }
 
-pub type CF<C> = <<C as CurveGroup>::BaseField as Field>::BasePrimeField;
-
-pub struct ProofVar<C: CurveGroup, GC: CurveVar<C, CF<C>>> {
-    a: EmulatedFpVar<C::ScalarField, CF<C>>,
-    l: Vec<EmulatedFpVar<C::ScalarField, CF<C>>>,
-    r: Vec<EmulatedFpVar<C::ScalarField, CF<C>>>,
-    L: Vec<GC>,
-    R: Vec<GC>,
+pub struct ProofVar<C: SonobeCurve> {
+    a: EmulatedFpVar<C::ScalarField, CF2<C>>,
+    l: Vec<EmulatedFpVar<C::ScalarField, CF2<C>>>,
+    r: Vec<EmulatedFpVar<C::ScalarField, CF2<C>>>,
+    L: Vec<C::Var>,
+    R: Vec<C::Var>,
 }
-impl<C, GC> AllocVar<Proof<C>, CF<C>> for ProofVar<C, GC>
-where
-    C: CurveGroup,
-    GC: CurveVar<C, CF<C>>,
-    <C as ark_ec::CurveGroup>::BaseField: PrimeField,
-{
+impl<C: SonobeCurve> AllocVar<Proof<C>, CF2<C>> for ProofVar<C> {
     fn new_variable<T: Borrow<Proof<C>>>(
-        cs: impl Into<Namespace<CF<C>>>,
+        cs: impl Into<Namespace<CF2<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
         mode: AllocationMode,
     ) -> Result<Self, SynthesisError> {
         f().and_then(|val| {
             let cs = cs.into();
 
-            let a = EmulatedFpVar::<C::ScalarField, CF<C>>::new_variable(
+            let a = EmulatedFpVar::<C::ScalarField, CF2<C>>::new_variable(
                 cs.clone(),
                 || Ok(val.borrow().a),
                 mode,
             )?;
-            let l: Vec<EmulatedFpVar<C::ScalarField, CF<C>>> =
+            let l: Vec<EmulatedFpVar<C::ScalarField, CF2<C>>> =
                 Vec::new_variable(cs.clone(), || Ok(val.borrow().l.clone()), mode)?;
-            let r: Vec<EmulatedFpVar<C::ScalarField, CF<C>>> =
+            let r: Vec<EmulatedFpVar<C::ScalarField, CF2<C>>> =
                 Vec::new_variable(cs.clone(), || Ok(val.borrow().r.clone()), mode)?;
-            let L: Vec<GC> = Vec::new_variable(cs.clone(), || Ok(val.borrow().L.clone()), mode)?;
-            let R: Vec<GC> = Vec::new_variable(cs.clone(), || Ok(val.borrow().R.clone()), mode)?;
+            let L: Vec<C::Var> =
+                Vec::new_variable(cs.clone(), || Ok(val.borrow().L.clone()), mode)?;
+            let R: Vec<C::Var> =
+                Vec::new_variable(cs.clone(), || Ok(val.borrow().R.clone()), mode)?;
 
             Ok(Self { a, l, r, L, R })
         })
@@ -477,36 +474,26 @@ where
 /// IPAGadget implements the circuit that verifies an IPA Proof. The `H` parameter indicates if to
 /// use the commitment in hiding mode or not, reducing a bit the number of constraints needed in
 /// the later case.
-pub struct IPAGadget<C, GC, const H: bool = false>
-where
-    C: CurveGroup,
-    GC: CurveVar<C, CF<C>>,
-{
-    _cf: PhantomData<CF<C>>,
+pub struct IPAGadget<C: SonobeCurve, const H: bool = false> {
     _c: PhantomData<C>,
-    _gc: PhantomData<GC>,
 }
 
-impl<C, GC, const H: bool> IPAGadget<C, GC, H>
-where
-    C: CurveGroup,
-    GC: CurveVar<C, CF<C>>,
-{
+impl<C: SonobeCurve, const H: bool> IPAGadget<C, H> {
     /// Verify the IPA opening proof, K=log2(d), where d is the degree of the committed polynomial,
     /// and H indicates if the commitment is in hiding mode and thus uses blinding factors, if not,
     /// there are some constraints saved.
     #[allow(clippy::too_many_arguments)]
     pub fn verify<const K: usize>(
-        g: &[GC],                                 // params.generators
-        h: &GC,                                   // params.h
-        x: &EmulatedFpVar<C::ScalarField, CF<C>>, // evaluation point, challenge
-        v: &EmulatedFpVar<C::ScalarField, CF<C>>, // value at evaluation point
-        P: &GC,                                   // commitment
-        p: &ProofVar<C, GC>,
-        r: &EmulatedFpVar<C::ScalarField, CF<C>>, // blinding factor
-        u: &[EmulatedFpVar<C::ScalarField, CF<C>>; K], // challenges
-        U: &GC,                                   // challenge
-    ) -> Result<Boolean<CF<C>>, SynthesisError> {
+        g: &[C::Var],                              // params.generators
+        h: &C::Var,                                // params.h
+        x: &EmulatedFpVar<C::ScalarField, CF2<C>>, // evaluation point, challenge
+        v: &EmulatedFpVar<C::ScalarField, CF2<C>>, // value at evaluation point
+        P: &C::Var,                                // commitment
+        p: &ProofVar<C>,
+        r: &EmulatedFpVar<C::ScalarField, CF2<C>>, // blinding factor
+        u: &[EmulatedFpVar<C::ScalarField, CF2<C>>; K], // challenges
+        U: &C::Var,                                // challenge
+    ) -> Result<Boolean<CF2<C>>, SynthesisError> {
         if p.L.len() != K || p.R.len() != K {
             return Err(SynthesisError::Unsatisfiable);
         }
@@ -516,7 +503,7 @@ where
         let mut r = r.clone();
 
         // compute u[i]^-1 once
-        let mut u_invs = vec![EmulatedFpVar::<C::ScalarField, CF<C>>::zero(); u.len()];
+        let mut u_invs = vec![EmulatedFpVar::<C::ScalarField, CF2<C>>::zero(); u.len()];
         for (j, u_j) in u.iter().enumerate() {
             u_invs[j] = u_j.inverse()?;
         }
@@ -531,7 +518,7 @@ where
         }
 
         // msm: G=<G, s>
-        let mut G = GC::zero();
+        let mut G = C::Var::zero();
         for (i, s_i) in s.iter().enumerate() {
             G += g[i].scalar_mul_le(s_i.to_bits_le()?.iter())?;
         }
@@ -681,7 +668,7 @@ mod tests {
         let challengeVar = EmulatedFpVar::<Fr, Fq>::new_witness(cs.clone(), || Ok(challenge))?;
         let vVar = EmulatedFpVar::<Fr, Fq>::new_witness(cs.clone(), || Ok(proof.1))?;
         let cmVar = GVar::new_witness(cs.clone(), || Ok(cm))?;
-        let proofVar = ProofVar::<Projective, GVar>::new_witness(cs.clone(), || Ok(proof.0))?;
+        let proofVar = ProofVar::<Projective>::new_witness(cs.clone(), || Ok(proof.0))?;
         let r_blindVar = EmulatedFpVar::<Fr, Fq>::new_witness(cs.clone(), || Ok(r_blind))?;
         let uVar_vec = Vec::<EmulatedFpVar<Fr, Fq>>::new_witness(cs.clone(), || Ok(u))?;
         let uVar: [EmulatedFpVar<Fr, Fq>; k] = uVar_vec.try_into().map_err(|_| {
@@ -693,7 +680,7 @@ mod tests {
         })?;
         let UVar = GVar::new_witness(cs.clone(), || Ok(U))?;
 
-        let v = IPAGadget::<Projective, GVar, hiding>::verify::<k>(
+        let v = IPAGadget::<Projective, hiding>::verify::<k>(
             &gVar,
             &hVar,
             &challengeVar,

--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -24,17 +24,17 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use super::CommitmentScheme;
 use crate::transcript::Transcript;
 use crate::utils::vec::poly_from_vec;
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// ProverKey defines a similar struct as in ark_poly_commit::kzg10::Powers, but instead of
 /// depending on the Pairing trait it depends on the SonobeCurve trait.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
-pub struct ProverKey<'a, C: SonobeCurve> {
+pub struct ProverKey<'a, C: Curve> {
     /// Group elements of the form `β^i G`, for different values of `i`.
     pub powers_of_g: Cow<'a, [C::Affine]>,
 }
 
-impl<'a, C: SonobeCurve> CanonicalSerialize for ProverKey<'a, C> {
+impl<'a, C: Curve> CanonicalSerialize for ProverKey<'a, C> {
     fn serialize_with_mode<W: std::io::prelude::Write>(
         &self,
         mut writer: W,
@@ -48,7 +48,7 @@ impl<'a, C: SonobeCurve> CanonicalSerialize for ProverKey<'a, C> {
     }
 }
 
-impl<'a, C: SonobeCurve> CanonicalDeserialize for ProverKey<'a, C> {
+impl<'a, C: Curve> CanonicalDeserialize for ProverKey<'a, C> {
     fn deserialize_with_mode<R: std::io::prelude::Read>(
         reader: R,
         compress: ark_serialize::Compress,
@@ -61,7 +61,7 @@ impl<'a, C: SonobeCurve> CanonicalDeserialize for ProverKey<'a, C> {
     }
 }
 
-impl<'a, C: SonobeCurve> Valid for ProverKey<'a, C> {
+impl<'a, C: Curve> Valid for ProverKey<'a, C> {
     fn check(&self) -> Result<(), ark_serialize::SerializationError> {
         match self.powers_of_g.clone() {
             Cow::Borrowed(powers) => powers.to_vec().check(),
@@ -71,7 +71,7 @@ impl<'a, C: SonobeCurve> Valid for ProverKey<'a, C> {
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof<C: SonobeCurve> {
+pub struct Proof<C: Curve> {
     pub eval: C::ScalarField,
     pub proof: C,
 }
@@ -83,7 +83,7 @@ pub struct KZG<'a, E: Pairing, const H: bool = false> {
     _e: PhantomData<E>,
 }
 
-impl<'a, E: Pairing<G1: SonobeCurve>, const H: bool> CommitmentScheme<E::G1, H> for KZG<'a, E, H> {
+impl<'a, E: Pairing<G1: Curve>, const H: bool> CommitmentScheme<E::G1, H> for KZG<'a, E, H> {
     type ProverParams = ProverKey<'a, E::G1>;
     type VerifierParams = VerifierKey<E>;
     type Proof = Proof<E::G1>;

--- a/folding-schemes/src/commitment/mod.rs
+++ b/folding-schemes/src/commitment/mod.rs
@@ -3,7 +3,7 @@ use ark_std::fmt::Debug;
 use ark_std::rand::RngCore;
 
 use crate::transcript::Transcript;
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 pub mod ipa;
 pub mod kzg;
@@ -11,7 +11,7 @@ pub mod pedersen;
 
 /// CommitmentScheme defines the vector commitment scheme trait. Where `H` indicates if to use the
 /// commitment in hiding mode or not.
-pub trait CommitmentScheme<C: SonobeCurve, const H: bool = false>: Clone + Debug {
+pub trait CommitmentScheme<C: Curve, const H: bool = false>: Clone + Debug {
     type ProverParams: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
     type VerifierParams: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
     type Proof: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
@@ -130,10 +130,7 @@ mod tests {
         Ok(())
     }
 
-    fn test_homomorphic_property_using_Commitment_trait_opt<
-        C: SonobeCurve,
-        CS: CommitmentScheme<C>,
-    >(
+    fn test_homomorphic_property_using_Commitment_trait_opt<C: Curve, CS: CommitmentScheme<C>>(
         poseidon_config: &PoseidonConfig<C::ScalarField>,
         prover_params: &CS::ProverParams,
         verifier_params: &CS::VerifierParams,

--- a/folding-schemes/src/commitment/mod.rs
+++ b/folding-schemes/src/commitment/mod.rs
@@ -1,10 +1,9 @@
-use ark_ec::CurveGroup;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::fmt::Debug;
 use ark_std::rand::RngCore;
 
 use crate::transcript::Transcript;
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 pub mod ipa;
 pub mod kzg;
@@ -12,7 +11,7 @@ pub mod pedersen;
 
 /// CommitmentScheme defines the vector commitment scheme trait. Where `H` indicates if to use the
 /// commitment in hiding mode or not.
-pub trait CommitmentScheme<C: CurveGroup, const H: bool = false>: Clone + Debug {
+pub trait CommitmentScheme<C: SonobeCurve, const H: bool = false>: Clone + Debug {
     type ProverParams: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
     type VerifierParams: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
     type Proof: Clone + Debug + CanonicalSerialize + CanonicalDeserialize;
@@ -74,7 +73,7 @@ mod tests {
     use ark_bn254::{Bn254, Fr, G1Projective as G1};
     use ark_crypto_primitives::sponge::{
         poseidon::{PoseidonConfig, PoseidonSponge},
-        Absorb, CryptographicSponge,
+        CryptographicSponge,
     };
     use ark_poly_commit::kzg10::VerifierKey;
     use ark_std::Zero;
@@ -132,7 +131,7 @@ mod tests {
     }
 
     fn test_homomorphic_property_using_Commitment_trait_opt<
-        C: CurveGroup,
+        C: SonobeCurve,
         CS: CommitmentScheme<C>,
     >(
         poseidon_config: &PoseidonConfig<C::ScalarField>,
@@ -141,10 +140,7 @@ mod tests {
         r: C::ScalarField,
         v_1: &[C::ScalarField],
         v_2: &[C::ScalarField],
-    ) -> Result<(), Error>
-    where
-        C::ScalarField: Absorb,
-    {
+    ) -> Result<(), Error> {
         // compute the commitment of the two vectors using the given CommitmentScheme
         let cm_1 = CS::commit(prover_params, v_1, &C::ScalarField::zero())?;
         let cm_2 = CS::commit(prover_params, v_2, &C::ScalarField::zero())?;

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -1,4 +1,3 @@
-use ark_ec::CurveGroup;
 use ark_r1cs_std::{boolean::Boolean, convert::ToBitsGadget, prelude::CurveVar};
 use ark_relations::r1cs::SynthesisError;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
@@ -8,28 +7,28 @@ use super::CommitmentScheme;
 use crate::folding::circuits::CF2;
 use crate::transcript::Transcript;
 use crate::utils::vec::{vec_add, vec_scalar_mul};
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof<C: CurveGroup> {
+pub struct Proof<C: SonobeCurve> {
     pub R: C,
     pub u: Vec<C::ScalarField>,
     pub r_u: C::ScalarField, // blind
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Params<C: CurveGroup> {
+pub struct Params<C: SonobeCurve> {
     pub h: C,
     pub generators: Vec<C::Affine>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Pedersen<C: CurveGroup, const H: bool = false> {
+pub struct Pedersen<C: SonobeCurve, const H: bool = false> {
     _c: PhantomData<C>,
 }
 
 /// Implements the CommitmentScheme trait for Pedersen commitments
-impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
+impl<C: SonobeCurve, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
     type ProverParams = Params<C>;
     type VerifierParams = Params<C>;
     type Proof = Proof<C>;
@@ -175,28 +174,18 @@ impl<C: CurveGroup, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
     }
 }
 
-pub struct PedersenGadget<C, GC, const H: bool = false>
-where
-    C: CurveGroup,
-    GC: CurveVar<C, CF2<C>>,
-{
-    _cf: PhantomData<CF2<C>>,
+pub struct PedersenGadget<C: SonobeCurve, const H: bool = false> {
     _c: PhantomData<C>,
-    _gc: PhantomData<GC>,
 }
 
-impl<C, GC, const H: bool> PedersenGadget<C, GC, H>
-where
-    C: CurveGroup,
-    GC: CurveVar<C, CF2<C>>,
-{
+impl<C: SonobeCurve, const H: bool> PedersenGadget<C, H> {
     pub fn commit(
-        h: &GC,
-        g: &[GC],
+        h: &C::Var,
+        g: &[C::Var],
         v: &[Vec<Boolean<CF2<C>>>],
         r: &[Boolean<CF2<C>>],
-    ) -> Result<GC, SynthesisError> {
-        let mut res = GC::zero();
+    ) -> Result<C::Var, SynthesisError> {
+        let mut res = C::Var::zero();
         if H {
             res += h.scalar_mul_le(r.iter())?;
         }
@@ -294,7 +283,7 @@ mod tests {
         let expected_cmVar = GVar::new_witness(cs.clone(), || Ok(cm))?;
 
         // use the gadget
-        let cmVar = PedersenGadget::<Projective, GVar, hiding>::commit(&hVar, &gVar, &vVar, &rVar)?;
+        let cmVar = PedersenGadget::<Projective, hiding>::commit(&hVar, &gVar, &vVar, &rVar)?;
         cmVar.enforce_equal(&expected_cmVar)?;
         Ok(())
     }

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -7,28 +7,28 @@ use super::CommitmentScheme;
 use crate::folding::circuits::CF2;
 use crate::transcript::Transcript;
 use crate::utils::vec::{vec_add, vec_scalar_mul};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Proof<C: SonobeCurve> {
+pub struct Proof<C: Curve> {
     pub R: C,
     pub u: Vec<C::ScalarField>,
     pub r_u: C::ScalarField, // blind
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Params<C: SonobeCurve> {
+pub struct Params<C: Curve> {
     pub h: C,
     pub generators: Vec<C::Affine>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Pedersen<C: SonobeCurve, const H: bool = false> {
+pub struct Pedersen<C: Curve, const H: bool = false> {
     _c: PhantomData<C>,
 }
 
 /// Implements the CommitmentScheme trait for Pedersen commitments
-impl<C: SonobeCurve, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
+impl<C: Curve, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
     type ProverParams = Params<C>;
     type VerifierParams = Params<C>;
     type Proof = Proof<C>;
@@ -174,11 +174,11 @@ impl<C: SonobeCurve, const H: bool> CommitmentScheme<C, H> for Pedersen<C, H> {
     }
 }
 
-pub struct PedersenGadget<C: SonobeCurve, const H: bool = false> {
+pub struct PedersenGadget<C: Curve, const H: bool = false> {
     _c: PhantomData<C>,
 }
 
-impl<C: SonobeCurve, const H: bool> PedersenGadget<C, H> {
+impl<C: Curve, const H: bool> PedersenGadget<C, H> {
     pub fn commit(
         h: &C::Var,
         g: &[C::Var],

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -33,7 +33,7 @@ use crate::{
         ArithGadget,
     },
     folding::traits::InputizeNonNative,
-    SonobeCurve,
+    Curve,
 };
 
 /// Re-export the Nova committed instance as `CycleFoldCommittedInstance` and
@@ -42,7 +42,7 @@ pub use crate::folding::nova::{
     CommittedInstance as CycleFoldCommittedInstance, Witness as CycleFoldWitness,
 };
 
-impl<C: SonobeCurve> InputizeNonNative<CF2<C>> for CycleFoldCommittedInstance<C> {
+impl<C: Curve> InputizeNonNative<CF2<C>> for CycleFoldCommittedInstance<C> {
     /// Returns the internal representation in the same order as how the value
     /// is allocated in `CycleFoldCommittedInstanceVar::new_input`.
     fn inputize_nonnative(&self) -> Vec<CF2<C>> {
@@ -59,13 +59,13 @@ impl<C: SonobeCurve> InputizeNonNative<CF2<C>> for CycleFoldCommittedInstance<C>
 /// CycleFoldCommittedInstanceVar is the CycleFold CommittedInstance represented
 /// in folding verifier circuit
 #[derive(Debug, Clone)]
-pub struct CycleFoldCommittedInstanceVar<C: SonobeCurve> {
+pub struct CycleFoldCommittedInstanceVar<C: Curve> {
     pub cmE: C::Var,
     pub u: NonNativeUintVar<CF2<C>>,
     pub cmW: C::Var,
     pub x: Vec<NonNativeUintVar<CF2<C>>>,
 }
-impl<C: SonobeCurve> AllocVar<CycleFoldCommittedInstance<C>, CF2<C>>
+impl<C: Curve> AllocVar<CycleFoldCommittedInstance<C>, CF2<C>>
     for CycleFoldCommittedInstanceVar<C>
 {
     fn new_variable<T: Borrow<CycleFoldCommittedInstance<C>>>(
@@ -88,7 +88,7 @@ impl<C: SonobeCurve> AllocVar<CycleFoldCommittedInstance<C>, CF2<C>>
     }
 }
 
-impl<C: SonobeCurve> AbsorbNonNative for CycleFoldCommittedInstance<C> {
+impl<C: Curve> AbsorbNonNative for CycleFoldCommittedInstance<C> {
     // Compatible with the in-circuit `CycleFoldCommittedInstanceVar::to_native_sponge_field_elements`
     fn to_native_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
         self.u.to_native_sponge_field_elements(dest);
@@ -102,7 +102,7 @@ impl<C: SonobeCurve> AbsorbNonNative for CycleFoldCommittedInstance<C> {
     }
 }
 
-impl<C: SonobeCurve> AbsorbNonNativeGadget<C::BaseField> for CycleFoldCommittedInstanceVar<C> {
+impl<C: Curve> AbsorbNonNativeGadget<C::BaseField> for CycleFoldCommittedInstanceVar<C> {
     /// Extracts the underlying field elements from `CycleFoldCommittedInstanceVar`, in the order
     /// of `u`, `x`, `cmE.x`, `cmE.y`, `cmW.x`, `cmW.y`, `cmE.is_inf || cmW.is_inf` (|| is for
     /// concat).
@@ -129,7 +129,7 @@ impl<C: SonobeCurve> AbsorbNonNativeGadget<C::BaseField> for CycleFoldCommittedI
     }
 }
 
-impl<C: SonobeCurve> CycleFoldCommittedInstance<C> {
+impl<C: Curve> CycleFoldCommittedInstance<C> {
     /// hash_cyclefold implements the committed instance hash compatible with the
     /// in-circuit implementation `CycleFoldCommittedInstanceVar::hash`.
     /// Returns `H(U_i)`, where `U_i` is a `CycleFoldCommittedInstance`.
@@ -145,7 +145,7 @@ impl<C: SonobeCurve> CycleFoldCommittedInstance<C> {
     }
 }
 
-impl<C: SonobeCurve> CycleFoldCommittedInstanceVar<C> {
+impl<C: Curve> CycleFoldCommittedInstanceVar<C> {
     /// hash implements the committed instance hash compatible with the native
     /// implementation `CycleFoldCommittedInstance::hash_cyclefold`.
     /// Returns `H(U_i)`, where `U` is a `CycleFoldCommittedInstanceVar`.
@@ -175,14 +175,14 @@ impl<C: SonobeCurve> CycleFoldCommittedInstanceVar<C> {
 /// non-native representation, since it is used to represent the CycleFold witness. This struct is
 /// used in the Decider circuit.
 #[derive(Debug, Clone)]
-pub struct CycleFoldWitnessVar<C: SonobeCurve> {
+pub struct CycleFoldWitnessVar<C: Curve> {
     pub E: Vec<NonNativeUintVar<CF2<C>>>,
     pub rE: NonNativeUintVar<CF2<C>>,
     pub W: Vec<NonNativeUintVar<CF2<C>>>,
     pub rW: NonNativeUintVar<CF2<C>>,
 }
 
-impl<C: SonobeCurve> AllocVar<CycleFoldWitness<C>, CF2<C>> for CycleFoldWitnessVar<C> {
+impl<C: Curve> AllocVar<CycleFoldWitness<C>, CF2<C>> for CycleFoldWitnessVar<C> {
     fn new_variable<T: Borrow<CycleFoldWitness<C>>>(
         cs: impl Into<Namespace<CF2<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -205,11 +205,11 @@ impl<C: SonobeCurve> AllocVar<CycleFoldWitness<C>, CF2<C>> for CycleFoldWitnessV
 /// This is the gadget used in the AugmentedFCircuit to verify the CycleFold instances folding,
 /// which checks the correct RLC of u,x,cmE,cmW (hence the name containing 'Full', since it checks
 /// all the RLC values, not only the native ones). It assumes that ci2.cmE=0, ci2.u=1.
-pub struct NIFSFullGadget<C: SonobeCurve> {
+pub struct NIFSFullGadget<C: Curve> {
     _c: PhantomData<C>,
 }
 
-impl<C: SonobeCurve> NIFSFullGadget<C> {
+impl<C: Curve> NIFSFullGadget<C> {
     pub fn fold_committed_instance(
         r_bits: Vec<Boolean<CF2<C>>>,
         cmT: C::Var,
@@ -261,7 +261,7 @@ impl<C: SonobeCurve> NIFSFullGadget<C> {
     }
 }
 
-impl<C: SonobeCurve> ArithGadget<CycleFoldWitnessVar<C>, CycleFoldCommittedInstanceVar<C>>
+impl<C: Curve> ArithGadget<CycleFoldWitnessVar<C>, CycleFoldCommittedInstanceVar<C>>
     for R1CSMatricesVar<CF1<C>, NonNativeUintVar<CF2<C>>>
 {
     type Evaluation = (Vec<NonNativeUintVar<CF2<C>>>, Vec<NonNativeUintVar<CF2<C>>>);
@@ -285,10 +285,10 @@ impl<C: SonobeCurve> ArithGadget<CycleFoldWitnessVar<C>, CycleFoldCommittedInsta
 
 /// CycleFoldChallengeGadget computes the RO challenge used for the CycleFold instances NIFS, it contains a
 /// rust-native and a in-circuit compatible versions.
-pub struct CycleFoldChallengeGadget<C: SonobeCurve> {
+pub struct CycleFoldChallengeGadget<C: Curve> {
     _c: PhantomData<C>, // Nova's Curve2, the one used for the CycleFold circuit
 }
-impl<C: SonobeCurve> CycleFoldChallengeGadget<C> {
+impl<C: Curve> CycleFoldChallengeGadget<C> {
     pub fn get_challenge_native<T: Transcript<C::BaseField>>(
         transcript: &mut T,
         pp_hash: C::BaseField, // public params hash
@@ -345,7 +345,7 @@ pub trait CycleFoldConfig {
         Self::RANDOMNESS_BIT_LENGTH.div_ceil(Self::FIELD_CAPACITY) + 2 * Self::N_INPUT_POINTS + 2
     };
 
-    type C: SonobeCurve;
+    type C: Curve;
 }
 
 /// CycleFoldCircuit contains the constraints that check the correct fold of the committed
@@ -380,7 +380,7 @@ impl<CFG: CycleFoldConfig> ConstraintSynthesizer<CF2<CFG::C>> for CycleFoldCircu
                 .r_bits
                 .unwrap_or(vec![false; CFG::RANDOMNESS_BIT_LENGTH]))
         })?;
-        let points = Vec::<<CFG::C as SonobeCurve>::Var>::new_witness(cs.clone(), || {
+        let points = Vec::<<CFG::C as Curve>::Var>::new_witness(cs.clone(), || {
             Ok(self
                 .points
                 .unwrap_or(vec![CFG::C::zero(); CFG::N_INPUT_POINTS]))
@@ -454,11 +454,11 @@ impl<CFG: CycleFoldConfig> ConstraintSynthesizer<CF2<CFG::C>> for CycleFoldCircu
 /// different fields than the main NIFS impls (Nova, Mova, Ova). Could be abstracted, but it's a
 /// tradeoff between overcomplexity at the NIFSTrait and the (not much) need of generalization at
 /// the CycleFoldNIFS.
-pub struct CycleFoldNIFS<C2: SonobeCurve, CS2: CommitmentScheme<C2, H>, const H: bool = false> {
+pub struct CycleFoldNIFS<C2: Curve, CS2: CommitmentScheme<C2, H>, const H: bool = false> {
     _c2: PhantomData<C2>,
     _cs: PhantomData<CS2>,
 }
-impl<C2: SonobeCurve, CS2: CommitmentScheme<C2, H>, const H: bool> CycleFoldNIFS<C2, CS2, H> {
+impl<C2: Curve, CS2: CommitmentScheme<C2, H>, const H: bool> CycleFoldNIFS<C2, CS2, H> {
     fn prove(
         cf_r_Fq: C2::ScalarField, // C2::Fr==C1::Fq
         cf_W_i: &CycleFoldWitness<C2>,
@@ -515,7 +515,7 @@ pub fn fold_cyclefold_circuit<CFG, C2, CS2, const H: bool>(
 >
 where
     CFG: CycleFoldConfig,
-    C2: SonobeCurve<ScalarField = CF2<CFG::C>, BaseField = CF1<CFG::C>>,
+    C2: Curve<ScalarField = CF2<CFG::C>, BaseField = CF1<CFG::C>>,
     CS2: CommitmentScheme<C2, H>,
 {
     let cs2 = ConstraintSystem::new_ref();
@@ -582,11 +582,11 @@ pub mod tests {
     use crate::transcript::poseidon::poseidon_canonical_config;
     use crate::utils::get_cm_coordinates;
 
-    struct TestCycleFoldConfig<C: SonobeCurve, const N: usize> {
+    struct TestCycleFoldConfig<C: Curve, const N: usize> {
         _c: PhantomData<C>,
     }
 
-    impl<C: SonobeCurve, const N: usize> CycleFoldConfig for TestCycleFoldConfig<C, N> {
+    impl<C: Curve, const N: usize> CycleFoldConfig for TestCycleFoldConfig<C, N> {
         const RANDOMNESS_BIT_LENGTH: usize = NOVA_N_BITS_RO;
         const N_INPUT_POINTS: usize = N;
         type C = C;

--- a/folding-schemes/src/folding/circuits/decider/mod.rs
+++ b/folding-schemes/src/folding/circuits/decider/mod.rs
@@ -14,7 +14,7 @@ use crate::folding::traits::{CommittedInstanceOps, CommittedInstanceVarOps, Dumm
 use crate::transcript::{Transcript, TranscriptVar};
 use crate::utils::vec::poly_from_vec;
 use crate::{arith::Arith, folding::circuits::CF1};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 pub mod off_chain;
 pub mod on_chain;
@@ -24,11 +24,7 @@ pub mod on_chain;
 pub struct KZGChallengesGadget {}
 
 impl KZGChallengesGadget {
-    pub fn get_challenges_native<
-        C: SonobeCurve,
-        T: Transcript<CF1<C>>,
-        U: CommittedInstanceOps<C>,
-    >(
+    pub fn get_challenges_native<C: Curve, T: Transcript<CF1<C>>, U: CommittedInstanceOps<C>>(
         transcript: &mut T,
         U_i: &U,
     ) -> Vec<CF1<C>> {
@@ -41,7 +37,7 @@ impl KZGChallengesGadget {
     }
 
     pub fn get_challenges_gadget<
-        C: SonobeCurve,
+        C: Curve,
         S: CryptographicSponge,
         T: TranscriptVar<CF1<C>, S>,
         U: CommittedInstanceVarOps<C>,
@@ -99,7 +95,7 @@ impl EvalGadget {
 /// In the future, we may introduce a better solution that uses a trait for all
 /// folding schemes that specifies their native and in-circuit behaviors.
 pub trait DeciderEnabledNIFS<
-    C: SonobeCurve,
+    C: Curve,
     RU: CommittedInstanceOps<C>, // Running instance
     IU: CommittedInstanceOps<C>, // Incoming instance
     W: WitnessOps<CF1<C>>,

--- a/folding-schemes/src/folding/circuits/decider/off_chain.rs
+++ b/folding-schemes/src/folding/circuits/decider/off_chain.rs
@@ -5,10 +5,8 @@
 use ark_crypto_primitives::sponge::{
     constraints::{AbsorbGadget, CryptographicSpongeVar},
     poseidon::{constraints::PoseidonSpongeVar, PoseidonConfig},
-    Absorb,
 };
-use ark_ec::CurveGroup;
-use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar, prelude::CurveVar};
+use ark_r1cs_std::{alloc::AllocVar, eq::EqGadget, fields::fp::FpVar};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_std::{marker::PhantomData, Zero};
 
@@ -29,6 +27,7 @@ use crate::{
         nova::{decider_eth_circuit::WitnessVar, nifs::nova_circuits::CommittedInstanceVar},
         traits::{CommittedInstanceOps, CommittedInstanceVarOps, Dummy, WitnessOps, WitnessVarOps},
     },
+    SonobeCurve,
 };
 
 use super::DeciderEnabledNIFS;
@@ -36,9 +35,8 @@ use super::DeciderEnabledNIFS;
 /// Circuit that implements part of the in-circuit checks needed for the offchain verification over
 /// the Curve2's BaseField (=Curve1's ScalarField).
 pub struct GenericOffchainDeciderCircuit1<
-    C1: CurveGroup,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     RU: CommittedInstanceOps<C1>,       // Running instance
     IU: CommittedInstanceOps<C1>,       // Incoming instance
     W: WitnessOps<CF1<C1>>,             // Witness
@@ -46,7 +44,6 @@ pub struct GenericOffchainDeciderCircuit1<
     AVar: ArithGadget<W::Var, RU::Var>, // In-circuit representation of `A`
     D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
 > {
-    pub _gc2: PhantomData<GC2>,
     pub _avar: PhantomData<AVar>,
     /// Constraint system of the Augmented Function circuit
     pub arith: A,
@@ -79,9 +76,8 @@ pub struct GenericOffchainDeciderCircuit1<
 }
 
 impl<
-        C1: CurveGroup,
-        C2: CurveGroup<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
-        GC2: CurveVar<C2, CF2<C2>>,
+        C1: SonobeCurve,
+        C2: SonobeCurve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
         RU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         IU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         W: WitnessOps<CF1<C1>> + for<'a> Dummy<&'a A>,
@@ -97,7 +93,7 @@ impl<
         D::RandomnessDummyCfg,
         usize,
         usize,
-    )> for GenericOffchainDeciderCircuit1<C1, C2, GC2, RU, IU, W, A, AVar, D>
+    )> for GenericOffchainDeciderCircuit1<C1, C2, RU, IU, W, A, AVar, D>
 {
     fn dummy(
         (
@@ -119,7 +115,6 @@ impl<
         ),
     ) -> Self {
         Self {
-            _gc2: PhantomData,
             _avar: PhantomData,
             poseidon_config,
             pp_hash: Zero::zero(),
@@ -143,9 +138,8 @@ impl<
 }
 
 impl<
-        C1: CurveGroup,
-        C2: CurveGroup<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
-        GC2: CurveVar<C2, CF2<C2>>,
+        C1: SonobeCurve,
+        C2: SonobeCurve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
         RU: CommittedInstanceOps<C1>,
         IU: CommittedInstanceOps<C1>,
         W: WitnessOps<CF1<C1>>,
@@ -153,10 +147,9 @@ impl<
         AVar: ArithGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
         D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
     > ConstraintSynthesizer<CF1<C1>>
-    for GenericOffchainDeciderCircuit1<C1, C2, GC2, RU, IU, W, A, AVar, D>
+    for GenericOffchainDeciderCircuit1<C1, C2, RU, IU, W, A, AVar, D>
 where
     RU::Var: AbsorbGadget<CF1<C1>> + CommittedInstanceVarOps<C1, PointVar = NonNativeAffineVar<C1>>,
-    CF1<C1>: Absorb,
 {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {
         let arith = AVar::new_witness(cs.clone(), || Ok(&self.arith))?;
@@ -177,7 +170,7 @@ where
         U_i1.get_commitments().enforce_equal(&U_i1_commitments)?;
 
         let cf_U_i =
-            CycleFoldCommittedInstanceVar::<C2, GC2>::new_input(cs.clone(), || Ok(self.cf_U_i))?;
+            CycleFoldCommittedInstanceVar::<C2>::new_input(cs.clone(), || Ok(self.cf_U_i))?;
 
         // allocate the inputs for the checks 7.1 and 7.2
         let kzg_challenges = Vec::new_input(cs.clone(), || Ok(self.kzg_challenges))?;
@@ -234,7 +227,7 @@ where
 
 /// Circuit that implements part of the in-circuit checks needed for the offchain verification over
 /// the Curve1's BaseField (=Curve2's ScalarField).
-pub struct GenericOffchainDeciderCircuit2<C2: CurveGroup> {
+pub struct GenericOffchainDeciderCircuit2<C2: SonobeCurve> {
     /// R1CS of the CycleFold circuit
     pub cf_arith: R1CS<CF1<C2>>,
     pub poseidon_config: PoseidonConfig<CF1<C2>>,
@@ -250,7 +243,7 @@ pub struct GenericOffchainDeciderCircuit2<C2: CurveGroup> {
     pub kzg_evaluations: Vec<CF1<C2>>,
 }
 
-impl<C2: CurveGroup> Dummy<(R1CS<CF1<C2>>, PoseidonConfig<CF1<C2>>, usize)>
+impl<C2: SonobeCurve> Dummy<(R1CS<CF1<C2>>, PoseidonConfig<CF1<C2>>, usize)>
     for GenericOffchainDeciderCircuit2<C2>
 {
     fn dummy(
@@ -272,7 +265,7 @@ impl<C2: CurveGroup> Dummy<(R1CS<CF1<C2>>, PoseidonConfig<CF1<C2>>, usize)>
     }
 }
 
-impl<C2: CurveGroup> ConstraintSynthesizer<CF1<C2>> for GenericOffchainDeciderCircuit2<C2> {
+impl<C2: SonobeCurve> ConstraintSynthesizer<CF1<C2>> for GenericOffchainDeciderCircuit2<C2> {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C2>>) -> Result<(), SynthesisError> {
         let cf_r1cs = R1CSMatricesVar::<CF1<C2>, FpVar<CF1<C2>>>::new_witness(cs.clone(), || {
             Ok(self.cf_arith.clone())

--- a/folding-schemes/src/folding/circuits/decider/off_chain.rs
+++ b/folding-schemes/src/folding/circuits/decider/off_chain.rs
@@ -27,7 +27,7 @@ use crate::{
         nova::{decider_eth_circuit::WitnessVar, nifs::nova_circuits::CommittedInstanceVar},
         traits::{CommittedInstanceOps, CommittedInstanceVarOps, Dummy, WitnessOps, WitnessVarOps},
     },
-    SonobeCurve,
+    Curve,
 };
 
 use super::DeciderEnabledNIFS;
@@ -35,8 +35,8 @@ use super::DeciderEnabledNIFS;
 /// Circuit that implements part of the in-circuit checks needed for the offchain verification over
 /// the Curve2's BaseField (=Curve1's ScalarField).
 pub struct GenericOffchainDeciderCircuit1<
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     RU: CommittedInstanceOps<C1>,       // Running instance
     IU: CommittedInstanceOps<C1>,       // Incoming instance
     W: WitnessOps<CF1<C1>>,             // Witness
@@ -76,8 +76,8 @@ pub struct GenericOffchainDeciderCircuit1<
 }
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
+        C1: Curve,
+        C2: Curve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
         RU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         IU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         W: WitnessOps<CF1<C1>> + for<'a> Dummy<&'a A>,
@@ -138,8 +138,8 @@ impl<
 }
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
+        C1: Curve,
+        C2: Curve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
         RU: CommittedInstanceOps<C1>,
         IU: CommittedInstanceOps<C1>,
         W: WitnessOps<CF1<C1>>,
@@ -227,7 +227,7 @@ where
 
 /// Circuit that implements part of the in-circuit checks needed for the offchain verification over
 /// the Curve1's BaseField (=Curve2's ScalarField).
-pub struct GenericOffchainDeciderCircuit2<C2: SonobeCurve> {
+pub struct GenericOffchainDeciderCircuit2<C2: Curve> {
     /// R1CS of the CycleFold circuit
     pub cf_arith: R1CS<CF1<C2>>,
     pub poseidon_config: PoseidonConfig<CF1<C2>>,
@@ -243,7 +243,7 @@ pub struct GenericOffchainDeciderCircuit2<C2: SonobeCurve> {
     pub kzg_evaluations: Vec<CF1<C2>>,
 }
 
-impl<C2: SonobeCurve> Dummy<(R1CS<CF1<C2>>, PoseidonConfig<CF1<C2>>, usize)>
+impl<C2: Curve> Dummy<(R1CS<CF1<C2>>, PoseidonConfig<CF1<C2>>, usize)>
     for GenericOffchainDeciderCircuit2<C2>
 {
     fn dummy(
@@ -265,7 +265,7 @@ impl<C2: SonobeCurve> Dummy<(R1CS<CF1<C2>>, PoseidonConfig<CF1<C2>>, usize)>
     }
 }
 
-impl<C2: SonobeCurve> ConstraintSynthesizer<CF1<C2>> for GenericOffchainDeciderCircuit2<C2> {
+impl<C2: Curve> ConstraintSynthesizer<CF1<C2>> for GenericOffchainDeciderCircuit2<C2> {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C2>>) -> Result<(), SynthesisError> {
         let cf_r1cs = R1CSMatricesVar::<CF1<C2>, FpVar<CF1<C2>>>::new_witness(cs.clone(), || {
             Ok(self.cf_arith.clone())

--- a/folding-schemes/src/folding/circuits/decider/on_chain.rs
+++ b/folding-schemes/src/folding/circuits/decider/on_chain.rs
@@ -22,7 +22,7 @@ use crate::{
         },
         traits::{CommittedInstanceOps, CommittedInstanceVarOps, Dummy, WitnessOps, WitnessVarOps},
     },
-    SonobeCurve,
+    Curve,
 };
 
 use super::DeciderEnabledNIFS;
@@ -59,8 +59,8 @@ use super::DeciderEnabledNIFS;
 ///
 /// For more details, see [https://privacy-scaling-explorations.github.io/sonobe-docs/design/nova-decider-onchain.html].
 pub struct GenericOnchainDeciderCircuit<
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     RU: CommittedInstanceOps<C1>,       // Running instance
     IU: CommittedInstanceOps<C1>,       // Incoming instance
     W: WitnessOps<CF1<C1>>,             // Witness
@@ -105,8 +105,8 @@ pub struct GenericOnchainDeciderCircuit<
 }
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
+        C1: Curve,
+        C2: Curve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
         RU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         IU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         W: WitnessOps<CF1<C1>> + for<'a> Dummy<&'a A>,
@@ -173,8 +173,8 @@ impl<
 }
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
+        C1: Curve,
+        C2: Curve<ScalarField = CF2<C1>, BaseField = CF1<C1>>,
         RU: CommittedInstanceOps<C1>,
         IU: CommittedInstanceOps<C1>,
         W: WitnessOps<CF1<C1>>,

--- a/folding-schemes/src/folding/circuits/nonnative/affine.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/affine.rs
@@ -154,8 +154,7 @@ impl<P: SWCurveConfig<BaseField: SonobeField>> AbsorbNonNative for Projective<P>
         let affine = self.into_affine();
         let (x, y) = affine.xy().unwrap_or_default();
 
-        x.to_native_sponge_field_elements(dest);
-        y.to_native_sponge_field_elements(dest);
+        [x, y].to_native_sponge_field_elements(dest);
     }
 }
 
@@ -163,9 +162,7 @@ impl<C: SonobeCurve> AbsorbNonNativeGadget<C::ScalarField> for NonNativeAffineVa
     fn to_native_sponge_field_elements(
         &self,
     ) -> Result<Vec<FpVar<C::ScalarField>>, SynthesisError> {
-        let x = self.x.to_native_sponge_field_elements()?;
-        let y = self.y.to_native_sponge_field_elements()?;
-        Ok([x, y].concat())
+        [&self.x, &self.y].to_native_sponge_field_elements()
     }
 }
 
@@ -188,9 +185,7 @@ impl<P: SWCurveConfig<BaseField: SonobeField>> InputizeNonNative<P::ScalarField>
         let affine = self.into_affine();
         let (x, y) = affine.xy().unwrap_or_default();
 
-        let x = x.inputize_nonnative();
-        let y = y.inputize_nonnative();
-        [x, y].concat()
+        [x, y].inputize_nonnative()
     }
 }
 

--- a/folding-schemes/src/folding/circuits/nonnative/uint.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/uint.rs
@@ -20,7 +20,8 @@ use num_integer::Integer;
 use crate::{
     folding::traits::{Inputize, InputizeNonNative},
     transcript::{AbsorbNonNative, AbsorbNonNativeGadget},
-    utils::gadgets::{EquivalenceGadget, MatrixGadget, SparseMatrixVar, VectorGadget}, SonobeField,
+    utils::gadgets::{EquivalenceGadget, MatrixGadget, SparseMatrixVar, VectorGadget},
+    SonobeField,
 };
 
 /// `LimbVar` represents a single limb of a non-native unsigned integer in the

--- a/folding-schemes/src/folding/circuits/nonnative/uint.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/uint.rs
@@ -807,15 +807,7 @@ impl<P: FpConfig<N>, const N: usize> AbsorbNonNative for Fp<P, N> {
             .into_bigint()
             .to_bits_le()
             .chunks(bits_per_limb)
-            .map(|chunk| {
-                let mut limb = F::zero();
-                let mut w = F::one();
-                for &b in chunk.iter() {
-                    limb += F::from(b) * w;
-                    w.double_in_place();
-                }
-                limb
-            })
+            .map(|chunk| F::from(F::BigInt::from_bits_le(chunk)))
             .collect::<Vec<F>>();
         limbs.resize(num_limbs, F::zero());
 

--- a/folding-schemes/src/folding/circuits/nonnative/uint.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/uint.rs
@@ -3,7 +3,7 @@ use std::{
     cmp::{max, min},
 };
 
-use ark_ff::{BigInteger, Field, Fp, FpConfig, One, PrimeField, Zero};
+use ark_ff::{BigInteger, Fp, FpConfig, One, PrimeField, Zero};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     boolean::Boolean,
@@ -21,7 +21,7 @@ use crate::{
     folding::traits::{Inputize, InputizeNonNative},
     transcript::{AbsorbNonNative, AbsorbNonNativeGadget},
     utils::gadgets::{EquivalenceGadget, MatrixGadget, SparseMatrixVar, VectorGadget},
-    SonobeField,
+    Field,
 };
 
 /// `LimbVar` represents a single limb of a non-native unsigned integer in the
@@ -838,7 +838,7 @@ impl<P: FpConfig<N>, const N: usize> Inputize<Self> for Fp<P, N> {
     }
 }
 
-impl<F: PrimeField, P: SonobeField> InputizeNonNative<F> for P {
+impl<F: PrimeField, P: Field> InputizeNonNative<F> for P {
     /// Returns the internal representation in the same order as how the value
     /// is allocated in `NonNativeUintVar::new_input`.
     fn inputize_nonnative(&self) -> Vec<F> {
@@ -912,6 +912,7 @@ impl<CF: PrimeField> MatrixGadget<NonNativeUintVar<CF>> for SparseMatrixVar<NonN
 
 #[cfg(test)]
 mod tests {
+    use ark_ff::Field;
     use ark_pallas::{Fq, Fr};
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::{test_rng, UniformRand};

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -14,11 +14,11 @@ use crate::folding::traits::{CommittedInstanceOps, Dummy};
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::{is_zero_vec, mat_vec_mul};
 use crate::utils::virtual_polynomial::{build_eq_x_r_vec, VirtualPolynomial};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// Committed CCS instance
 #[derive(Debug, Clone, PartialEq, Eq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct CCCS<C: SonobeCurve> {
+pub struct CCCS<C: Curve> {
     // Commitment to witness
     pub C: C,
     // Public input/output
@@ -34,7 +34,7 @@ impl<F: PrimeField> CCS<F> {
     ) -> Result<(CCCS<C>, Witness<F>), Error>
     where
         // enforce that CCS's F is the C::ScalarField
-        C: SonobeCurve<ScalarField = F>,
+        C: Curve<ScalarField = F>,
     {
         let w: Vec<F> = z[(1 + self.l)..].to_vec();
 
@@ -89,7 +89,7 @@ impl<F: PrimeField> CCS<F> {
     }
 }
 
-impl<C: SonobeCurve> Dummy<&CCS<CF1<C>>> for CCCS<C> {
+impl<C: Curve> Dummy<&CCS<CF1<C>>> for CCCS<C> {
     fn dummy(ccs: &CCS<CF1<C>>) -> Self {
         Self {
             C: C::zero(),
@@ -98,7 +98,7 @@ impl<C: SonobeCurve> Dummy<&CCS<CF1<C>>> for CCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> Arith<Witness<CF1<C>>, CCCS<C>> for CCS<CF1<C>> {
+impl<C: Curve> Arith<Witness<CF1<C>>, CCCS<C>> for CCS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     fn eval_relation(&self, w: &Witness<CF1<C>>, u: &CCCS<C>) -> Result<Self::Evaluation, Error> {
@@ -120,7 +120,7 @@ impl<C: SonobeCurve> Arith<Witness<CF1<C>>, CCCS<C>> for CCS<CF1<C>> {
     }
 }
 
-impl<C: SonobeCurve> Absorb for CCCS<C> {
+impl<C: Curve> Absorb for CCCS<C> {
     fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
         C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
@@ -131,7 +131,7 @@ impl<C: SonobeCurve> Absorb for CCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> CommittedInstanceOps<C> for CCCS<C> {
+impl<C: Curve> CommittedInstanceOps<C> for CCCS<C> {
     type Var = CCCSVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {
@@ -143,7 +143,7 @@ impl<C: SonobeCurve> CommittedInstanceOps<C> for CCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> Inputize<CF1<C>> for CCCS<C> {
+impl<C: Curve> Inputize<CF1<C>> for CCCS<C> {
     /// Returns the internal representation in the same order as how the value
     /// is allocated in `CCCSVar::new_input`.
     fn inputize(&self) -> Vec<CF1<C>> {

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -143,9 +143,11 @@ impl<C: SonobeCurve> CommittedInstanceOps<C> for CCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> Inputize<C::ScalarField, CCCSVar<C>> for CCCS<C> {
-    fn inputize(&self) -> Vec<C::ScalarField> {
-        [&self.C.inputize()[..], &self.x].concat()
+impl<C: SonobeCurve> Inputize<CF1<C>> for CCCS<C> {
+    /// Returns the internal representation in the same order as how the value
+    /// is allocated in `CCCSVar::new_input`.
+    fn inputize(&self) -> Vec<CF1<C>> {
+        [&self.C.inputize_nonnative()[..], &self.x].concat()
     }
 }
 

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -1333,9 +1333,8 @@ mod tests {
                     HyperNovaCycleFoldConfig::<Projective, MU, NU>::N_INPUT_POINTS
                 );
 
-                let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) = fold_cyclefold_circuit::<
+                let (cf_u_i, cf_W_i1, cf_U_i1, cf_cmT) = fold_cyclefold_circuit::<
                     HyperNovaCycleFoldConfig<Projective, MU, NU>,
-                    Projective,
                     Projective2,
                     Pedersen<Projective2>,
                     false,

--- a/folding-schemes/src/folding/hypernova/decider_eth.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth.rs
@@ -1,8 +1,4 @@
 /// This file implements the HyperNova's onchain (Ethereum's EVM) decider.
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
-use ark_ff::PrimeField;
-use ark_r1cs_std::prelude::CurveVar;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
@@ -16,17 +12,16 @@ use crate::commitment::{
     kzg::Proof as KZGProof, pedersen::Params as PedersenParams, CommitmentScheme,
 };
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
-use crate::folding::circuits::CF2;
 use crate::folding::nova::decider_eth::VerifierParam;
 use crate::folding::traits::{Inputize, WitnessOps};
 use crate::frontend::FCircuit;
-use crate::Error;
 use crate::{Decider as DeciderTrait, FoldingScheme};
+use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C1, CS1, S>
 where
-    C1: CurveGroup,
+    C1: SonobeCurve,
     CS1: CommitmentScheme<C1, ProverChallenge = C1::ScalarField, Challenge = C1::ScalarField>,
     S: SNARK<C1::ScalarField>,
 {
@@ -41,11 +36,9 @@ where
 
 /// Onchain Decider, for ethereum use cases
 #[derive(Clone, Debug)]
-pub struct Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS, const MU: usize, const NU: usize> {
+pub struct Decider<C1, C2, FC, CS1, CS2, S, FS, const MU: usize, const NU: usize> {
     _c1: PhantomData<C1>,
-    _gc1: PhantomData<GC1>,
     _c2: PhantomData<C2>,
-    _gc2: PhantomData<GC2>,
     _fc: PhantomData<FC>,
     _cs1: PhantomData<CS1>,
     _cs2: PhantomData<CS2>,
@@ -53,13 +46,11 @@ pub struct Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS, const MU: usize, const
     _fs: PhantomData<FS>,
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS, const MU: usize, const NU: usize>
-    DeciderTrait<C1, C2, FC, FS> for Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS, MU, NU>
+impl<C1, C2, FC, CS1, CS2, S, FS, const MU: usize, const NU: usize> DeciderTrait<C1, C2, FC, FS>
+    for Decider<C1, C2, FC, CS1, CS2, S, FS, MU, NU>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     // CS1 is a KZG commitment, where challenge is C1::Fr elem
     CS1: CommitmentScheme<
@@ -72,13 +63,8 @@ where
     CS2: CommitmentScheme<C2, ProverParams = PedersenParams<C2>>,
     S: SNARK<C1::ScalarField>,
     FS: FoldingScheme<C1, C2, FC>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     // constrain FS into HyperNova, since this is a Decider specifically for HyperNova
-    HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, false>: From<FS>,
+    HyperNova<C1, C2, FC, CS1, CS2, MU, NU, false>: From<FS>,
     crate::folding::hypernova::ProverParams<C1, C2, CS1, CS2, false>:
         From<<FS as FoldingScheme<C1, C2, FC>>::ProverParam>,
     crate::folding::hypernova::VerifierParams<C1, C2, CS1, CS2, false>:
@@ -96,7 +82,7 @@ where
         prep_param: Self::PreprocessorParam,
         fs: FS,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
-        let circuit = DeciderEthCircuit::<C1, C2, GC2>::try_from(HyperNova::from(fs))?;
+        let circuit = DeciderEthCircuit::<C1, C2>::try_from(HyperNova::from(fs))?;
 
         // get the Groth16 specific setup for the circuit
         let (g16_pk, g16_vk) = S::circuit_specific_setup(circuit, &mut rng)
@@ -104,13 +90,13 @@ where
 
         // get the FoldingScheme prover & verifier params from HyperNova
         #[allow(clippy::type_complexity)]
-        let hypernova_pp: <HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, false> as FoldingScheme<
+        let hypernova_pp: <HyperNova<C1, C2, FC, CS1, CS2, MU, NU, false> as FoldingScheme<
             C1,
             C2,
             FC,
         >>::ProverParam = prep_param.0.into();
         #[allow(clippy::type_complexity)]
-        let hypernova_vp: <HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, false> as FoldingScheme<
+        let hypernova_vp: <HyperNova<C1, C2, FC, CS1, CS2, MU, NU, false> as FoldingScheme<
             C1,
             C2,
             FC,
@@ -134,7 +120,7 @@ where
     ) -> Result<Self::Proof, Error> {
         let (snark_pk, cs_pk): (S::ProvingKey, CS1::ProverParams) = pp;
 
-        let circuit = DeciderEthCircuit::<C1, C2, GC2>::try_from(HyperNova::from(folding_scheme))?;
+        let circuit = DeciderEthCircuit::<C1, C2>::try_from(HyperNova::from(folding_scheme))?;
 
         let rho = circuit.randomness;
 
@@ -223,9 +209,9 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
+    use ark_bn254::{Bn254, Fr, G1Projective as Projective};
     use ark_groth16::Groth16;
-    use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_grumpkin::Projective as Projective2;
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
 
     use super::*;
@@ -244,9 +230,7 @@ pub mod tests {
         // use HyperNova as FoldingScheme
         type HN = HyperNova<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
@@ -256,9 +240,7 @@ pub mod tests {
         >;
         type D = Decider<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
@@ -309,9 +291,7 @@ pub mod tests {
         // use HyperNova as FoldingScheme
         type HN = HyperNova<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
@@ -321,9 +301,7 @@ pub mod tests {
         >;
         type D = Decider<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,

--- a/folding-schemes/src/folding/hypernova/decider_eth.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth.rs
@@ -13,7 +13,7 @@ use crate::commitment::{
 };
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
 use crate::folding::nova::decider_eth::VerifierParam;
-use crate::folding::traits::{Inputize, WitnessOps};
+use crate::folding::traits::WitnessOps;
 use crate::frontend::FCircuit;
 use crate::{Decider as DeciderTrait, FoldingScheme};
 use crate::{Error, SonobeCurve};
@@ -188,7 +188,7 @@ where
             &[pp_hash, i][..],
             &z_0,
             &z_i,
-            &C.inputize(),
+            &C.inputize_nonnative(),
             &[proof.kzg_challenge, proof.kzg_proof.eval, proof.rho],
         ]
         .concat();

--- a/folding-schemes/src/folding/hypernova/decider_eth.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth.rs
@@ -15,13 +15,13 @@ use crate::folding::circuits::decider::DeciderEnabledNIFS;
 use crate::folding::nova::decider_eth::VerifierParam;
 use crate::folding::traits::WitnessOps;
 use crate::frontend::FCircuit;
+use crate::{Curve, Error};
 use crate::{Decider as DeciderTrait, FoldingScheme};
-use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C1, CS1, S>
 where
-    C1: SonobeCurve,
+    C1: Curve,
     CS1: CommitmentScheme<C1, ProverChallenge = C1::ScalarField, Challenge = C1::ScalarField>,
     S: SNARK<C1::ScalarField>,
 {
@@ -49,8 +49,8 @@ pub struct Decider<C1, C2, FC, CS1, CS2, S, FS, const MU: usize, const NU: usize
 impl<C1, C2, FC, CS1, CS2, S, FS, const MU: usize, const NU: usize> DeciderTrait<C1, C2, FC, FS>
     for Decider<C1, C2, FC, CS1, CS2, S, FS, MU, NU>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     // CS1 is a KZG commitment, where challenge is C1::Fr elem
     CS1: CommitmentScheme<

--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -35,10 +35,10 @@ use crate::{
 use crate::{
     commitment::{pedersen::Params as PedersenParams, CommitmentScheme},
     folding::circuits::decider::DeciderEnabledNIFS,
-    SonobeCurve,
+    Curve,
 };
 
-impl<C: SonobeCurve> ArithGadget<WitnessVar<CF1<C>>, LCCCSVar<C>> for CCSMatricesVar<CF1<C>> {
+impl<C: Curve> ArithGadget<WitnessVar<CF1<C>>, LCCCSVar<C>> for CCSMatricesVar<CF1<C>> {
     type Evaluation = Vec<FpVar<CF1<C>>>;
 
     fn eval_relation(
@@ -110,8 +110,8 @@ pub type DeciderEthCircuit<C1, C2> = GenericOnchainDeciderCircuit<
 >;
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve,
+        C1: Curve,
+        C2: Curve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         // enforce that the CS2 is Pedersen commitment scheme, since we're at Ethereum's EVM decider
@@ -175,7 +175,7 @@ impl<
 
 pub struct DeciderHyperNovaGadget;
 
-impl<C: SonobeCurve> DeciderEnabledNIFS<C, LCCCS<C>, CCCS<C>, Witness<C::ScalarField>, CCS<CF1<C>>>
+impl<C: Curve> DeciderEnabledNIFS<C, LCCCS<C>, CCCS<C>, Witness<C::ScalarField>, CCS<CF1<C>>>
     for DeciderHyperNovaGadget
 {
     type ProofDummyCfg = (usize, usize, usize, usize);

--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -3,16 +3,14 @@
 use ark_crypto_primitives::sponge::{
     constraints::CryptographicSpongeVar,
     poseidon::{constraints::PoseidonSpongeVar, PoseidonSponge},
-    Absorb, CryptographicSponge,
+    CryptographicSponge,
 };
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     boolean::Boolean,
     eq::EqGadget,
     fields::fp::FpVar,
-    prelude::CurveVar,
 };
 use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::{borrow::Borrow, log2, marker::PhantomData};
@@ -22,7 +20,7 @@ use super::{
     nimfs::{NIMFSProof, NIMFS},
     HyperNova, Witness, CCCS, LCCCS,
 };
-use crate::folding::circuits::{decider::on_chain::GenericOnchainDeciderCircuit, CF1, CF2};
+use crate::folding::circuits::{decider::on_chain::GenericOnchainDeciderCircuit, CF1};
 use crate::folding::traits::{WitnessOps, WitnessVarOps};
 use crate::frontend::FCircuit;
 use crate::utils::gadgets::{eval_mle, MatrixGadget};
@@ -37,9 +35,10 @@ use crate::{
 use crate::{
     commitment::{pedersen::Params as PedersenParams, CommitmentScheme},
     folding::circuits::decider::DeciderEnabledNIFS,
+    SonobeCurve,
 };
 
-impl<C: CurveGroup> ArithGadget<WitnessVar<CF1<C>>, LCCCSVar<C>> for CCSMatricesVar<CF1<C>> {
+impl<C: SonobeCurve> ArithGadget<WitnessVar<CF1<C>>, LCCCSVar<C>> for CCSMatricesVar<CF1<C>> {
     type Evaluation = Vec<FpVar<CF1<C>>>;
 
     fn eval_relation(
@@ -99,10 +98,9 @@ impl<F: PrimeField> WitnessVarOps<F> for WitnessVar<F> {
     }
 }
 
-pub type DeciderEthCircuit<C1, C2, GC2> = GenericOnchainDeciderCircuit<
+pub type DeciderEthCircuit<C1, C2> = GenericOnchainDeciderCircuit<
     C1,
     C2,
-    GC2,
     LCCCS<C1>,
     CCCS<C1>,
     Witness<CF1<C1>>,
@@ -112,10 +110,8 @@ pub type DeciderEthCircuit<C1, C2, GC2> = GenericOnchainDeciderCircuit<
 >;
 
 impl<
-        C1: CurveGroup,
-        GC1: CurveVar<C1, CF2<C1>>,
-        C2: CurveGroup,
-        GC2: CurveVar<C2, CF2<C2>>,
+        C1: SonobeCurve,
+        C2: SonobeCurve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         // enforce that the CS2 is Pedersen commitment scheme, since we're at Ethereum's EVM decider
@@ -123,14 +119,11 @@ impl<
         const MU: usize,
         const NU: usize,
         const H: bool,
-    > TryFrom<HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>>
-    for DeciderEthCircuit<C1, C2, GC2>
-where
-    CF1<C1>: Absorb,
+    > TryFrom<HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>> for DeciderEthCircuit<C1, C2>
 {
     type Error = Error;
 
-    fn try_from(hn: HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>) -> Result<Self, Error> {
+    fn try_from(hn: HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>) -> Result<Self, Error> {
         // compute the U_{i+1}, W_{i+1}, by folding the last running & incoming instances
         let mut transcript = PoseidonSponge::<C1::ScalarField>::new(&hn.poseidon_config);
         transcript.absorb(&hn.pp_hash);
@@ -155,7 +148,6 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            _gc2: PhantomData,
             _avar: PhantomData,
             arith: hn.ccs,
             cf_arith: hn.cf_r1cs,
@@ -183,10 +175,8 @@ where
 
 pub struct DeciderHyperNovaGadget;
 
-impl<C: CurveGroup> DeciderEnabledNIFS<C, LCCCS<C>, CCCS<C>, Witness<C::ScalarField>, CCS<CF1<C>>>
+impl<C: SonobeCurve> DeciderEnabledNIFS<C, LCCCS<C>, CCCS<C>, Witness<C::ScalarField>, CCS<CF1<C>>>
     for DeciderHyperNovaGadget
-where
-    CF1<C>: Absorb,
 {
     type ProofDummyCfg = (usize, usize, usize, usize);
     type Proof = NIMFSProof<C>;
@@ -235,8 +225,8 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use ark_bn254::{constraints::GVar, Fr, G1Projective as Projective};
-    use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_bn254::{Fr, G1Projective as Projective};
+    use ark_grumpkin::Projective as Projective2;
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
     use ark_std::{test_rng, UniformRand};
 
@@ -291,9 +281,7 @@ pub mod tests {
 
         type HN = HyperNova<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             Pedersen<Projective>,
             Pedersen<Projective2>,
@@ -319,8 +307,7 @@ pub mod tests {
         HN::verify(hn_params.1, ivc_proof)?;
 
         // load the DeciderEthCircuit from the generated Nova instance
-        let decider_circuit =
-            DeciderEthCircuit::<Projective, Projective2, GVar2>::try_from(hypernova)?;
+        let decider_circuit = DeciderEthCircuit::<Projective, Projective2>::try_from(hypernova)?;
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -141,10 +141,12 @@ impl<C: SonobeCurve> CommittedInstanceOps<C> for LCCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> Inputize<C::ScalarField, LCCCSVar<C>> for LCCCS<C> {
-    fn inputize(&self) -> Vec<C::ScalarField> {
+impl<C: SonobeCurve> Inputize<CF1<C>> for LCCCS<C> {
+    /// Returns the internal representation in the same order as how the value
+    /// is allocated in `LCCCS::new_input`.
+    fn inputize(&self) -> Vec<CF1<C>> {
         [
-            &self.C.inputize(),
+            &self.C.inputize_nonnative(),
             &[self.u][..],
             &self.x,
             &self.r_x,

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -16,11 +16,11 @@ use crate::folding::traits::Inputize;
 use crate::folding::traits::{CommittedInstanceOps, Dummy};
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// Linearized Committed CCS instance
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct LCCCS<C: SonobeCurve> {
+pub struct LCCCS<C: Curve> {
     // Commitment to witness
     pub C: C,
     // Relaxation factor of z for folded LCCCS
@@ -42,7 +42,7 @@ impl<F: PrimeField> CCS<F> {
     ) -> Result<(LCCCS<C>, Witness<F>), Error>
     where
         // enforce that CCS's F is the C::ScalarField
-        C: SonobeCurve<ScalarField = F>,
+        C: Curve<ScalarField = F>,
     {
         let w: Vec<F> = z[(1 + self.l)..].to_vec();
         // if the commitment scheme is set to be hiding, set the random blinding parameter
@@ -77,7 +77,7 @@ impl<F: PrimeField> CCS<F> {
     }
 }
 
-impl<C: SonobeCurve> Dummy<&CCS<CF1<C>>> for LCCCS<C> {
+impl<C: Curve> Dummy<&CCS<CF1<C>>> for LCCCS<C> {
     fn dummy(ccs: &CCS<CF1<C>>) -> Self {
         Self {
             C: C::zero(),
@@ -89,7 +89,7 @@ impl<C: SonobeCurve> Dummy<&CCS<CF1<C>>> for LCCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> Arith<Witness<CF1<C>>, LCCCS<C>> for CCS<CF1<C>> {
+impl<C: Curve> Arith<Witness<CF1<C>>, LCCCS<C>> for CCS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     /// Perform the check of the LCCCS instance described at section 4.2,
@@ -115,7 +115,7 @@ impl<C: SonobeCurve> Arith<Witness<CF1<C>>, LCCCS<C>> for CCS<CF1<C>> {
     }
 }
 
-impl<C: SonobeCurve> Absorb for LCCCS<C> {
+impl<C: Curve> Absorb for LCCCS<C> {
     fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
         C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
@@ -129,7 +129,7 @@ impl<C: SonobeCurve> Absorb for LCCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> CommittedInstanceOps<C> for LCCCS<C> {
+impl<C: Curve> CommittedInstanceOps<C> for LCCCS<C> {
     type Var = LCCCSVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {
@@ -141,7 +141,7 @@ impl<C: SonobeCurve> CommittedInstanceOps<C> for LCCCS<C> {
     }
 }
 
-impl<C: SonobeCurve> Inputize<CF1<C>> for LCCCS<C> {
+impl<C: Curve> Inputize<CF1<C>> for LCCCS<C> {
     /// Returns the internal representation in the same order as how the value
     /// is allocated in `LCCCS::new_input`.
     fn inputize(&self) -> Vec<CF1<C>> {
@@ -175,7 +175,7 @@ pub mod tests {
     use crate::utils::virtual_polynomial::{build_eq_x_r_vec, VirtualPolynomial};
 
     // method for testing
-    pub fn compute_Ls<C: SonobeCurve>(
+    pub fn compute_Ls<C: Curve>(
         ccs: &CCS<C::ScalarField>,
         lcccs: &LCCCS<C>,
         z: &[C::ScalarField],

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -43,15 +43,15 @@ use crate::{
         r1cs::{extract_w_x, R1CS},
         Arith,
     },
-    FoldingScheme, MultiFolding, SonobeCurve,
+    Curve, FoldingScheme, MultiFolding,
 };
 
 /// Configuration for HyperNova's CycleFold circuit
-pub struct HyperNovaCycleFoldConfig<C: SonobeCurve, const MU: usize, const NU: usize> {
+pub struct HyperNovaCycleFoldConfig<C: Curve, const MU: usize, const NU: usize> {
     _c: PhantomData<C>,
 }
 
-impl<C: SonobeCurve, const MU: usize, const NU: usize> CycleFoldConfig
+impl<C: Curve, const MU: usize, const NU: usize> CycleFoldConfig
     for HyperNovaCycleFoldConfig<C, MU, NU>
 {
     const RANDOMNESS_BIT_LENGTH: usize = NOVA_N_BITS_RO;
@@ -97,8 +97,8 @@ impl<F: PrimeField> WitnessOps<F> for Witness<F> {
 #[derive(Debug, Clone)]
 pub struct ProverParams<C1, C2, CS1, CS2, const H: bool>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
@@ -114,8 +114,8 @@ where
 }
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve,
+        C1: Curve,
+        C2: Curve,
         CS1: CommitmentScheme<C1, H>,
         CS2: CommitmentScheme<C2, H>,
         const H: bool,
@@ -138,8 +138,8 @@ impl<
 /// Verification parameters for HyperNova-based IVC
 #[derive(Debug, Clone)]
 pub struct VerifierParams<
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
     const H: bool,
@@ -158,8 +158,8 @@ pub struct VerifierParams<
 
 impl<C1, C2, CS1, CS2, const H: bool> CanonicalSerialize for VerifierParams<C1, C2, CS1, CS2, H>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
@@ -179,8 +179,8 @@ where
 
 impl<C1, C2, CS1, CS2, const H: bool> VerifierParams<C1, C2, CS1, CS2, H>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
@@ -199,8 +199,8 @@ where
 #[derive(PartialEq, Eq, Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct IVCProof<C1, C2>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
 {
     pub i: C1::ScalarField,
     pub z_0: Vec<C1::ScalarField>,
@@ -223,8 +223,8 @@ where
 #[derive(Clone, Debug)]
 pub struct HyperNova<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
@@ -261,12 +261,12 @@ where
 impl<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool> MultiFolding<C1, C2, FC>
     for HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
 {
     type RunningInstance = (LCCCS<C1>, Witness<C1::ScalarField>);
     type IncomingInstance = (CCCS<C1>, Witness<C1::ScalarField>);
@@ -320,12 +320,12 @@ where
 impl<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
     HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
 {
     /// internal helper for new_running_instance & new_incoming_instance methods, returns the R1CS
     /// z=[u,x,w] vector to be used to create the LCCCS & CCCS fresh instances.
@@ -402,12 +402,12 @@ where
 impl<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
     FoldingScheme<C1, C2, FC> for HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
 {
     /// Reuse Nova's PreprocessorParam.
     type PreprocessorParam = PreprocessorParam<C1, C2, FC, CS1, CS2, H>;

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -763,8 +763,8 @@ where
                 ),
             };
 
-            let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
-                fold_cyclefold_circuit::<HyperNovaCycleFoldConfig<C1, MU, NU>, C1, C2, CS2, H>(
+            let (cf_u_i, cf_W_i1, cf_U_i1, cf_cmT) =
+                fold_cyclefold_circuit::<HyperNovaCycleFoldConfig<C1, MU, NU>, C2, CS2, H>(
                     &mut transcript_p,
                     self.cf_r1cs.clone(),
                     self.cf_cs_pp.clone(),

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -1,11 +1,10 @@
 /// Implements the scheme described in [HyperNova](https://eprint.iacr.org/2023/573.pdf)
 use ark_crypto_primitives::sponge::{
     poseidon::{PoseidonConfig, PoseidonSponge},
-    Absorb, CryptographicSponge,
+    CryptographicSponge,
 };
-use ark_ec::CurveGroup;
 use ark_ff::{BigInteger, PrimeField};
-use ark_r1cs_std::{prelude::CurveVar, R1CSVar};
+use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError};
 use ark_std::{fmt::Debug, marker::PhantomData, rand::RngCore, One, Zero};
@@ -27,12 +26,9 @@ use nimfs::NIMFS;
 use crate::commitment::CommitmentScheme;
 use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::{
-    circuits::{
-        cyclefold::{
-            fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldCommittedInstance, CycleFoldConfig,
-            CycleFoldWitness,
-        },
-        CF2,
+    circuits::cyclefold::{
+        fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldCommittedInstance, CycleFoldConfig,
+        CycleFoldWitness,
     },
     nova::{get_r1cs_from_cs, PreprocessorParam},
     traits::{CommittedInstanceOps, Dummy, WitnessOps},
@@ -47,15 +43,15 @@ use crate::{
         r1cs::{extract_w_x, R1CS},
         Arith,
     },
-    FoldingScheme, MultiFolding,
+    FoldingScheme, MultiFolding, SonobeCurve,
 };
 
 /// Configuration for HyperNova's CycleFold circuit
-pub struct HyperNovaCycleFoldConfig<C: CurveGroup, const MU: usize, const NU: usize> {
+pub struct HyperNovaCycleFoldConfig<C: SonobeCurve, const MU: usize, const NU: usize> {
     _c: PhantomData<C>,
 }
 
-impl<C: CurveGroup, const MU: usize, const NU: usize> CycleFoldConfig
+impl<C: SonobeCurve, const MU: usize, const NU: usize> CycleFoldConfig
     for HyperNovaCycleFoldConfig<C, MU, NU>
 {
     const RANDOMNESS_BIT_LENGTH: usize = NOVA_N_BITS_RO;
@@ -65,8 +61,8 @@ impl<C: CurveGroup, const MU: usize, const NU: usize> CycleFoldConfig
 
 /// CycleFold circuit for computing random linear combinations of group elements
 /// in HyperNova instances.
-pub type HyperNovaCycleFoldCircuit<C, GC, const MU: usize, const NU: usize> =
-    CycleFoldCircuit<HyperNovaCycleFoldConfig<C, MU, NU>, GC>;
+pub type HyperNovaCycleFoldCircuit<C, const MU: usize, const NU: usize> =
+    CycleFoldCircuit<HyperNovaCycleFoldConfig<C, MU, NU>>;
 
 /// Witness for the LCCCS & CCCS, containing the w vector, and the r_w used as randomness in the Pedersen commitment.
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
@@ -101,8 +97,8 @@ impl<F: PrimeField> WitnessOps<F> for Witness<F> {
 #[derive(Debug, Clone)]
 pub struct ProverParams<C1, C2, CS1, CS2, const H: bool>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
@@ -118,8 +114,8 @@ where
 }
 
 impl<
-        C1: CurveGroup,
-        C2: CurveGroup,
+        C1: SonobeCurve,
+        C2: SonobeCurve,
         CS1: CommitmentScheme<C1, H>,
         CS2: CommitmentScheme<C2, H>,
         const H: bool,
@@ -142,8 +138,8 @@ impl<
 /// Verification parameters for HyperNova-based IVC
 #[derive(Debug, Clone)]
 pub struct VerifierParams<
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
     const H: bool,
@@ -162,8 +158,8 @@ pub struct VerifierParams<
 
 impl<C1, C2, CS1, CS2, const H: bool> CanonicalSerialize for VerifierParams<C1, C2, CS1, CS2, H>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
@@ -183,8 +179,8 @@ where
 
 impl<C1, C2, CS1, CS2, const H: bool> VerifierParams<C1, C2, CS1, CS2, H>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
@@ -203,8 +199,8 @@ where
 #[derive(PartialEq, Eq, Debug, Clone, CanonicalSerialize, CanonicalDeserialize)]
 pub struct IVCProof<C1, C2>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
 {
     pub i: C1::ScalarField,
     pub z_0: Vec<C1::ScalarField>,
@@ -225,30 +221,14 @@ where
 /// * `MU` - the number of LCCCS instances to be folded
 /// * `NU` - the number of CCCS instances to be folded
 #[derive(Clone, Debug)]
-pub struct HyperNova<
-    C1,
-    GC1,
-    C2,
-    GC2,
-    FC,
-    CS1,
-    CS2,
-    const MU: usize,
-    const NU: usize,
-    const H: bool,
-> where
-    C1: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+pub struct HyperNova<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
+where
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {
-    _gc1: PhantomData<GC1>,
-    _c2: PhantomData<C2>,
-    _gc2: PhantomData<GC2>,
-
     /// CCS of the Augmented Function circuit
     pub ccs: CCS<C1::ScalarField>,
     /// R1CS of the CycleFold circuit
@@ -278,21 +258,15 @@ pub struct HyperNova<
     pub cf_U_i: CycleFoldCommittedInstance<C2>,
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
-    MultiFolding<C1, C2, FC> for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
+impl<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool> MultiFolding<C1, C2, FC>
+    for HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>
 where
-    C1: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
 {
     type RunningInstance = (LCCCS<C1>, Witness<C1::ScalarField>);
     type IncomingInstance = (CCCS<C1>, Witness<C1::ScalarField>);
@@ -343,21 +317,15 @@ where
     }
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
-    HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
+impl<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
+    HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>
 where
-    C1: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
 {
     /// internal helper for new_running_instance & new_incoming_instance methods, returns the R1CS
     /// z=[u,x,w] vector to be used to create the LCCCS & CCCS fresh instances.
@@ -389,9 +357,7 @@ where
         // compute u_{i+1}.x
         let U_i1 = LCCCS::dummy(&self.ccs);
 
-        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU> {
-            _c2: PhantomData,
-            _gc2: PhantomData,
+        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU> {
             poseidon_config: self.poseidon_config.clone(),
             ccs: self.ccs.clone(),
             pp_hash: Some(self.pp_hash),
@@ -433,21 +399,15 @@ where
     }
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
-    FoldingScheme<C1, C2, FC> for HyperNova<C1, GC1, C2, GC2, FC, CS1, CS2, MU, NU, H>
+impl<C1, C2, FC, CS1, CS2, const MU: usize, const NU: usize, const H: bool>
+    FoldingScheme<C1, C2, FC> for HyperNova<C1, C2, FC, CS1, CS2, MU, NU, H>
 where
-    C1: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
 {
     /// Reuse Nova's PreprocessorParam.
     type PreprocessorParam = PreprocessorParam<C1, C2, FC, CS1, CS2, H>;
@@ -473,7 +433,7 @@ where
 
         // main circuit R1CS:
         let f_circuit = FC::new(fc_params)?;
-        let augmented_F_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU>::empty(
+        let augmented_F_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU>::empty(
             &poseidon_config,
             f_circuit.clone(),
             None,
@@ -504,7 +464,7 @@ where
 
         // main circuit R1CS:
         let f_circuit = FC::new(fc_params)?;
-        let augmented_F_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU>::empty(
+        let augmented_F_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU>::empty(
             &poseidon_config,
             f_circuit.clone(),
             None,
@@ -512,7 +472,7 @@ where
         let ccs = augmented_F_circuit.ccs;
 
         // CycleFold circuit R1CS
-        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, GC1, MU, NU>::empty();
+        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, MU, NU>::empty();
         let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
 
         let cs_vp = CS1::VerifierParams::deserialize_with_mode(&mut reader, compress, validate)?;
@@ -535,14 +495,14 @@ where
             return Err(Error::CantBeZero("mu,nu".to_string()));
         }
 
-        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU>::empty(
+        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU>::empty(
             &prep_param.poseidon_config,
             prep_param.F.clone(),
             None,
         )?;
         let ccs = augmented_f_circuit.ccs.clone();
 
-        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, GC1, MU, NU>::empty();
+        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, MU, NU>::empty();
         let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
 
         // if cs params exist, use them, if not, generate new ones
@@ -587,14 +547,14 @@ where
 
         // prepare the HyperNova's AugmentedFCircuit and CycleFold's circuits and obtain its CCS
         // and R1CS respectively
-        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU>::empty(
+        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU>::empty(
             &pp.poseidon_config,
             F.clone(),
             pp.ccs.clone(),
         )?;
         let ccs = augmented_f_circuit.ccs.clone();
 
-        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, GC1, MU, NU>::empty();
+        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, MU, NU>::empty();
         let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
 
         // compute the public params hash
@@ -615,9 +575,6 @@ where
         // W_dummy=W_0 is a 'dummy witness', all zeroes, but with the size corresponding to the
         // R1CS that we're working with.
         Ok(Self {
-            _gc1: PhantomData,
-            _c2: PhantomData,
-            _gc2: PhantomData,
             ccs,
             cf_r1cs,
             poseidon_config: pp.poseidon_config.clone(),
@@ -698,7 +655,7 @@ where
             (vec![], vec![], vec![], vec![])
         };
 
-        let augmented_f_circuit: AugmentedFCircuit<C1, C2, GC2, FC, MU, NU>;
+        let augmented_f_circuit: AugmentedFCircuit<C1, C2, FC, MU, NU>;
 
         if self.z_i.len() != self.F.state_len() {
             return Err(Error::NotSameLength(
@@ -744,9 +701,7 @@ where
             W_i1.r_w = self.W_i.r_w;
             U_i1 = LCCCS::dummy(&self.ccs);
 
-            augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU> {
-                _c2: PhantomData,
-                _gc2: PhantomData,
+            augmented_f_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU> {
                 poseidon_config: self.poseidon_config.clone(),
                 ccs: self.ccs.clone(),
                 pp_hash: Some(self.pp_hash),
@@ -797,8 +752,7 @@ where
             let rho_bits = rho.into_bigint().to_bits_le()[..NOVA_N_BITS_RO].to_vec();
 
             // CycleFold part:
-            let cf_circuit = HyperNovaCycleFoldCircuit::<C1, GC1, MU, NU> {
-                _gc: PhantomData,
+            let cf_circuit = HyperNovaCycleFoldCircuit::<C1, MU, NU> {
                 r_bits: Some(rho_bits),
                 points: Some(
                     [
@@ -809,28 +763,19 @@ where
                 ),
             };
 
-            let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) = fold_cyclefold_circuit::<
-                HyperNovaCycleFoldConfig<C1, MU, NU>,
-                C1,
-                GC1,
-                C2,
-                GC2,
-                CS2,
-                H,
-            >(
-                &mut transcript_p,
-                self.cf_r1cs.clone(),
-                self.cf_cs_pp.clone(),
-                self.pp_hash,
-                self.cf_W_i.clone(), // CycleFold running instance witness
-                self.cf_U_i.clone(), // CycleFold running instance
-                cf_circuit,
-                &mut rng,
-            )?;
+            let (_cf_w_i, cf_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) =
+                fold_cyclefold_circuit::<HyperNovaCycleFoldConfig<C1, MU, NU>, C1, C2, CS2, H>(
+                    &mut transcript_p,
+                    self.cf_r1cs.clone(),
+                    self.cf_cs_pp.clone(),
+                    self.pp_hash,
+                    self.cf_W_i.clone(), // CycleFold running instance witness
+                    self.cf_U_i.clone(), // CycleFold running instance
+                    cf_circuit,
+                    &mut rng,
+                )?;
 
-            augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU> {
-                _c2: PhantomData,
-                _gc2: PhantomData,
+            augmented_f_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU> {
                 poseidon_config: self.poseidon_config.clone(),
                 ccs: self.ccs.clone(),
                 pp_hash: Some(self.pp_hash),
@@ -938,20 +883,17 @@ where
         let (pp, vp) = params;
 
         let f_circuit = FC::new(fcircuit_params)?;
-        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, GC2, FC, MU, NU>::empty(
+        let augmented_f_circuit = AugmentedFCircuit::<C1, C2, FC, MU, NU>::empty(
             &pp.poseidon_config,
             f_circuit.clone(),
             None,
         )?;
-        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, GC1, MU, NU>::empty();
+        let cf_circuit = HyperNovaCycleFoldCircuit::<C1, MU, NU>::empty();
 
         let ccs = augmented_f_circuit.ccs.clone();
         let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
 
         Ok(Self {
-            _gc1: PhantomData,
-            _c2: PhantomData,
-            _gc2: PhantomData,
             ccs,
             cf_r1cs,
             poseidon_config: pp.poseidon_config,
@@ -1028,8 +970,8 @@ where
 #[cfg(test)]
 mod tests {
     use crate::commitment::kzg::KZG;
-    use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as Projective};
-    use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_bn254::{Bn254, Fr, G1Projective as Projective};
+    use ark_grumpkin::Projective as Projective2;
     use ark_std::UniformRand;
 
     use super::*;
@@ -1077,7 +1019,7 @@ mod tests {
         const NU: usize = 3;
 
         type HN<CS1, CS2, const H: bool> =
-            HyperNova<Projective, GVar, Projective2, GVar2, CubicFCircuit<Fr>, CS1, CS2, MU, NU, H>;
+            HyperNova<Projective, Projective2, CubicFCircuit<Fr>, CS1, CS2, MU, NU, H>;
 
         let prep_param =
             PreprocessorParam::<Projective, Projective2, CubicFCircuit<Fr>, CS1, CS2, H>::new(

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -1,5 +1,3 @@
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
 use ark_ff::{BigInteger, Field, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{DenseUVPolynomial, Polynomial};
@@ -19,19 +17,19 @@ use crate::transcript::Transcript;
 use crate::utils::sum_check::structs::{IOPProof as SumCheckProof, IOPProverMessage};
 use crate::utils::sum_check::{IOPSumCheck, SumCheck};
 use crate::utils::virtual_polynomial::VPAuxInfo;
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// NIMFSProof defines a multifolding proof
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct NIMFSProof<C: CurveGroup> {
+pub struct NIMFSProof<C: SonobeCurve> {
     pub sc_proof: SumCheckProof<C::ScalarField>,
     pub sigmas_thetas: SigmasThetas<C::ScalarField>,
 }
 
-impl<C: CurveGroup> Dummy<(usize, usize, usize, usize)> for NIMFSProof<C> {
+impl<C: SonobeCurve> Dummy<(usize, usize, usize, usize)> for NIMFSProof<C> {
     fn dummy((s, t, mu, nu): (usize, usize, usize, usize)) -> Self {
         // use 'C::ScalarField::one()' instead of 'zero()' to enforce the NIMFSProof to have the
         // same in-circuit representation to match the number of constraints of an actual proof.
@@ -53,7 +51,7 @@ impl<C: CurveGroup> Dummy<(usize, usize, usize, usize)> for NIMFSProof<C> {
     }
 }
 
-impl<C: CurveGroup> Dummy<(&CCS<CF1<C>>, usize, usize)> for NIMFSProof<C> {
+impl<C: SonobeCurve> Dummy<(&CCS<CF1<C>>, usize, usize)> for NIMFSProof<C> {
     fn dummy((ccs, mu, nu): (&CCS<CF1<C>>, usize, usize)) -> Self {
         NIMFSProof::dummy((ccs.s, ccs.t, mu, nu))
     }
@@ -65,15 +63,12 @@ pub struct SigmasThetas<F: PrimeField>(pub Vec<Vec<F>>, pub Vec<Vec<F>>);
 #[derive(Debug)]
 /// Implements the Non-Interactive Multi Folding Scheme described in section 5 of
 /// [HyperNova](https://eprint.iacr.org/2023/573.pdf)
-pub struct NIMFS<C: CurveGroup, T: Transcript<C::ScalarField>> {
+pub struct NIMFS<C: SonobeCurve, T: Transcript<C::ScalarField>> {
     pub _c: PhantomData<C>,
     pub _t: PhantomData<T>,
 }
 
-impl<C: CurveGroup, T: Transcript<C::ScalarField>> NIMFS<C, T>
-where
-    C::ScalarField: Absorb,
-{
+impl<C: SonobeCurve, T: Transcript<C::ScalarField>> NIMFS<C, T> {
     pub fn fold(
         lcccs: &[LCCCS<C>],
         cccs: &[CCCS<C>],

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -17,19 +17,19 @@ use crate::transcript::Transcript;
 use crate::utils::sum_check::structs::{IOPProof as SumCheckProof, IOPProverMessage};
 use crate::utils::sum_check::{IOPSumCheck, SumCheck};
 use crate::utils::virtual_polynomial::VPAuxInfo;
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 use std::fmt::Debug;
 use std::marker::PhantomData;
 
 /// NIMFSProof defines a multifolding proof
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct NIMFSProof<C: SonobeCurve> {
+pub struct NIMFSProof<C: Curve> {
     pub sc_proof: SumCheckProof<C::ScalarField>,
     pub sigmas_thetas: SigmasThetas<C::ScalarField>,
 }
 
-impl<C: SonobeCurve> Dummy<(usize, usize, usize, usize)> for NIMFSProof<C> {
+impl<C: Curve> Dummy<(usize, usize, usize, usize)> for NIMFSProof<C> {
     fn dummy((s, t, mu, nu): (usize, usize, usize, usize)) -> Self {
         // use 'C::ScalarField::one()' instead of 'zero()' to enforce the NIMFSProof to have the
         // same in-circuit representation to match the number of constraints of an actual proof.
@@ -51,7 +51,7 @@ impl<C: SonobeCurve> Dummy<(usize, usize, usize, usize)> for NIMFSProof<C> {
     }
 }
 
-impl<C: SonobeCurve> Dummy<(&CCS<CF1<C>>, usize, usize)> for NIMFSProof<C> {
+impl<C: Curve> Dummy<(&CCS<CF1<C>>, usize, usize)> for NIMFSProof<C> {
     fn dummy((ccs, mu, nu): (&CCS<CF1<C>>, usize, usize)) -> Self {
         NIMFSProof::dummy((ccs.s, ccs.t, mu, nu))
     }
@@ -63,12 +63,12 @@ pub struct SigmasThetas<F: PrimeField>(pub Vec<Vec<F>>, pub Vec<Vec<F>>);
 #[derive(Debug)]
 /// Implements the Non-Interactive Multi Folding Scheme described in section 5 of
 /// [HyperNova](https://eprint.iacr.org/2023/573.pdf)
-pub struct NIMFS<C: SonobeCurve, T: Transcript<C::ScalarField>> {
+pub struct NIMFS<C: Curve, T: Transcript<C::ScalarField>> {
     pub _c: PhantomData<C>,
     pub _t: PhantomData<T>,
 }
 
-impl<C: SonobeCurve, T: Transcript<C::ScalarField>> NIMFS<C, T> {
+impl<C: Curve, T: Transcript<C::ScalarField>> NIMFS<C, T> {
     pub fn fold(
         lcccs: &[LCCCS<C>],
         cccs: &[CCCS<C>],

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -9,7 +9,7 @@ use crate::arith::ccs::CCS;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
 use crate::utils::virtual_polynomial::{build_eq_x_r_vec, eq_eval, VirtualPolynomial};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// Compute the arrays of sigma_i and theta_i from step 4 corresponding to the LCCCS and CCCS
 /// instances
@@ -96,7 +96,7 @@ pub fn compute_c<F: PrimeField>(
 }
 
 /// Compute g(x) polynomial for the given inputs.
-pub fn compute_g<C: SonobeCurve>(
+pub fn compute_g<C: Curve>(
     ccs: &CCS<C::ScalarField>,
     running_instances: &[LCCCS<C>],
     z_lcccs: &[Vec<C::ScalarField>],

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -1,4 +1,3 @@
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
 use ark_std::One;
@@ -10,7 +9,7 @@ use crate::arith::ccs::CCS;
 use crate::utils::mle::dense_vec_to_dense_mle;
 use crate::utils::vec::mat_vec_mul;
 use crate::utils::virtual_polynomial::{build_eq_x_r_vec, eq_eval, VirtualPolynomial};
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 /// Compute the arrays of sigma_i and theta_i from step 4 corresponding to the LCCCS and CCCS
 /// instances
@@ -97,17 +96,14 @@ pub fn compute_c<F: PrimeField>(
 }
 
 /// Compute g(x) polynomial for the given inputs.
-pub fn compute_g<C: CurveGroup>(
+pub fn compute_g<C: SonobeCurve>(
     ccs: &CCS<C::ScalarField>,
     running_instances: &[LCCCS<C>],
     z_lcccs: &[Vec<C::ScalarField>],
     z_cccs: &[Vec<C::ScalarField>],
     gamma: C::ScalarField,
     beta: &[C::ScalarField],
-) -> Result<VirtualPolynomial<C::ScalarField>, Error>
-where
-    C::ScalarField: PrimeField,
-{
+) -> Result<VirtualPolynomial<C::ScalarField>, Error> {
     assert_eq!(running_instances.len(), z_lcccs.len());
 
     let mut g = VirtualPolynomial::<C::ScalarField>::new(ccs.s);

--- a/folding-schemes/src/folding/mod.rs
+++ b/folding-schemes/src/folding/mod.rs
@@ -6,11 +6,10 @@ pub mod traits;
 
 #[cfg(test)]
 pub mod tests {
-    use ark_ec::CurveGroup;
-    use ark_ff::PrimeField;
-    use ark_pallas::{constraints::GVar as GVar1, Fr, Projective as G1};
+
+    use ark_pallas::{Fr, Projective as G1};
     use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-    use ark_vesta::{constraints::GVar as GVar2, Projective as G2};
+    use ark_vesta::Projective as G2;
     use std::io::Write;
 
     use crate::commitment::pedersen::Pedersen;
@@ -22,8 +21,8 @@ pub mod tests {
     use crate::frontend::utils::CubicFCircuit;
     use crate::frontend::FCircuit;
     use crate::transcript::poseidon::poseidon_canonical_config;
-    use crate::Error;
     use crate::FoldingScheme;
+    use crate::{Error, SonobeCurve};
 
     /// tests the IVC proofs and its serializers for the 3 implemented IVCs: Nova, HyperNova and
     /// ProtoGalaxy.
@@ -34,16 +33,14 @@ pub mod tests {
         let f_circuit = FC::new(())?;
 
         // test Nova
-        type N = Nova<G1, GVar1, G2, GVar2, FC, Pedersen<G1>, Pedersen<G2>, false>;
+        type N = Nova<G1, G2, FC, Pedersen<G1>, Pedersen<G2>, false>;
         let prep_param = NovaPreprocessorParam::new(poseidon_config.clone(), f_circuit);
         test_serialize_ivc_opt::<G1, G2, FC, N>("nova".to_string(), prep_param.clone())?;
 
         // test HyperNova
         type HN = HyperNova<
             G1,
-            GVar1,
             G2,
-            GVar2,
             FC,
             Pedersen<G1>,
             Pedersen<G2>,
@@ -54,26 +51,21 @@ pub mod tests {
         test_serialize_ivc_opt::<G1, G2, FC, HN>("hypernova".to_string(), prep_param)?;
 
         // test ProtoGalaxy
-        type P = ProtoGalaxy<G1, GVar1, G2, GVar2, FC, Pedersen<G1>, Pedersen<G2>>;
+        type P = ProtoGalaxy<G1, G2, FC, Pedersen<G1>, Pedersen<G2>>;
         let prep_param = (poseidon_config, f_circuit);
         test_serialize_ivc_opt::<G1, G2, FC, P>("protogalaxy".to_string(), prep_param)?;
         Ok(())
     }
 
     fn test_serialize_ivc_opt<
-        C1: CurveGroup,
-        C2: CurveGroup,
+        C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+        C2: SonobeCurve,
         FC: FCircuit<C1::ScalarField, Params = ()>,
         FS: FoldingScheme<C1, C2, FC>,
     >(
         name: String,
         prep_param: FS::PreprocessorParam,
-    ) -> Result<(), Error>
-    where
-        C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-        C2::BaseField: PrimeField,
-        FC: FCircuit<C1::ScalarField>,
-    {
+    ) -> Result<(), Error> {
         let mut rng = ark_std::test_rng();
         let F_circuit = FC::new(())?;
 

--- a/folding-schemes/src/folding/mod.rs
+++ b/folding-schemes/src/folding/mod.rs
@@ -22,7 +22,7 @@ pub mod tests {
     use crate::frontend::FCircuit;
     use crate::transcript::poseidon::poseidon_canonical_config;
     use crate::FoldingScheme;
-    use crate::{Error, SonobeCurve};
+    use crate::{Curve, Error};
 
     /// tests the IVC proofs and its serializers for the 3 implemented IVCs: Nova, HyperNova and
     /// ProtoGalaxy.
@@ -58,8 +58,8 @@ pub mod tests {
     }
 
     fn test_serialize_ivc_opt<
-        C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-        C2: SonobeCurve,
+        C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+        C2: Curve,
         FC: FCircuit<C1::ScalarField, Params = ()>,
         FS: FoldingScheme<C1, C2, FC>,
     >(

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -352,7 +352,9 @@ where
 pub mod tests {
     use super::*;
     use ark_bn254::{Fr, G1Projective as Projective};
-    use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
+    use ark_crypto_primitives::sponge::{
+        constraints::AbsorbGadget, poseidon::PoseidonSponge, CryptographicSponge,
+    };
     use ark_ff::BigInteger;
 
     use ark_relations::r1cs::ConstraintSystem;
@@ -406,18 +408,11 @@ pub mod tests {
         let mut transcriptVar = PoseidonSpongeVar::<Fr>::new(cs.clone(), &poseidon_config);
 
         // compute the challenge in-circuit
-        let U_iVar_vec = [
-            vec![U_iVar.u.clone()],
-            U_iVar.x.clone(),
-            U_iVar.cmE.to_native_sponge_field_elements()?,
-            U_iVar.cmW.to_native_sponge_field_elements()?,
-        ]
-        .concat();
         let r_bitsVar =
             ChallengeGadget::<Projective, CommittedInstance<Projective>>::get_challenge_gadget(
                 &mut transcriptVar,
                 pp_hashVar,
-                U_iVar_vec,
+                U_iVar.to_sponge_field_elements()?,
                 u_iVar,
                 Some(cmTVar),
             )?;

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -2,9 +2,7 @@
 use ark_crypto_primitives::sponge::{
     constraints::CryptographicSpongeVar,
     poseidon::{constraints::PoseidonSpongeVar, PoseidonConfig, PoseidonSponge},
-    Absorb,
 };
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_r1cs_std::{
     alloc::AllocVar,
@@ -16,7 +14,6 @@ use ark_r1cs_std::{
 };
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_std::{fmt::Debug, One, Zero};
-use core::marker::PhantomData;
 
 use super::{
     nifs::{
@@ -31,11 +28,12 @@ use crate::folding::circuits::{
         CycleFoldConfig, NIFSFullGadget,
     },
     nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
-    CF1, CF2,
+    CF1,
 };
 use crate::folding::traits::{CommittedInstanceVarOps, Dummy};
 use crate::frontend::FCircuit;
 use crate::transcript::AbsorbNonNativeGadget;
+use crate::SonobeCurve;
 
 /// `AugmentedFCircuit` enhances the original step function `F`, so that it can
 /// be used in recursive arguments such as IVC.
@@ -50,13 +48,7 @@ use crate::transcript::AbsorbNonNativeGadget;
 /// defined in [CycleFold](https://eprint.iacr.org/2023/1192.pdf). These extra
 /// constraints verify the correct folding of CycleFold instances.
 #[derive(Debug, Clone)]
-pub struct AugmentedFCircuit<
-    C1: CurveGroup,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
-    FC: FCircuit<CF1<C1>>,
-> {
-    pub(super) _gc2: PhantomData<GC2>,
+pub struct AugmentedFCircuit<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> {
     pub(super) poseidon_config: PoseidonConfig<CF1<C1>>,
     pub(super) pp_hash: Option<CF1<C1>>,
     pub(super) i: Option<CF1<C1>>,
@@ -81,12 +73,9 @@ pub struct AugmentedFCircuit<
     pub(super) cf2_cmT: Option<C2>,
 }
 
-impl<C1: CurveGroup, C2: CurveGroup, GC2: CurveVar<C2, CF2<C2>>, FC: FCircuit<CF1<C1>>>
-    AugmentedFCircuit<C1, C2, GC2, FC>
-{
+impl<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<C1, C2, FC> {
     pub fn empty(poseidon_config: &PoseidonConfig<CF1<C1>>, F_circuit: FC) -> Self {
         Self {
-            _gc2: PhantomData,
             poseidon_config: poseidon_config.clone(),
             pp_hash: None,
             i: None,
@@ -110,13 +99,11 @@ impl<C1: CurveGroup, C2: CurveGroup, GC2: CurveVar<C2, CF2<C2>>, FC: FCircuit<CF
     }
 }
 
-impl<C1, C2, GC2, FC> AugmentedFCircuit<C1, C2, GC2, FC>
+impl<C1, C2, FC> AugmentedFCircuit<C1, C2, FC>
 where
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: SonobeCurve,
     FC: FCircuit<CF1<C1>>,
-    C2::BaseField: PrimeField + Absorb,
 {
     pub fn compute_next_state(
         self,
@@ -159,11 +146,13 @@ where
             NonNativeAffineVar::new_witness(cs.clone(), || Ok(self.cmT.unwrap_or_else(C1::zero)))?;
 
         let cf_u_dummy = CycleFoldCommittedInstance::dummy(NovaCycleFoldConfig::<C1>::IO_LEN);
-        let cf_U_i = CycleFoldCommittedInstanceVar::<C2, GC2>::new_witness(cs.clone(), || {
+        let cf_U_i = CycleFoldCommittedInstanceVar::<C2>::new_witness(cs.clone(), || {
             Ok(self.cf_U_i.unwrap_or(cf_u_dummy.clone()))
         })?;
-        let cf1_cmT = GC2::new_witness(cs.clone(), || Ok(self.cf1_cmT.unwrap_or_else(C2::zero)))?;
-        let cf2_cmT = GC2::new_witness(cs.clone(), || Ok(self.cf2_cmT.unwrap_or_else(C2::zero)))?;
+        let cf1_cmT =
+            C2::Var::new_witness(cs.clone(), || Ok(self.cf1_cmT.unwrap_or_else(C2::zero)))?;
+        let cf2_cmT =
+            C2::Var::new_witness(cs.clone(), || Ok(self.cf2_cmT.unwrap_or_else(C2::zero)))?;
 
         // `sponge` is for digest computation.
         let sponge = PoseidonSpongeVar::<C1::ScalarField>::new(cs.clone(), &self.poseidon_config);
@@ -276,21 +265,21 @@ where
         // C.2. Construct `cf1_u_i` and `cf2_u_i`
         let cf1_u_i = CycleFoldCommittedInstanceVar {
             // cf1_u_i.cmE = 0
-            cmE: GC2::zero(),
+            cmE: C2::Var::zero(),
             // cf1_u_i.u = 1
             u: NonNativeUintVar::new_constant(cs.clone(), C1::BaseField::one())?,
             // cf1_u_i.cmW is provided by the prover as witness
-            cmW: GC2::new_witness(cs.clone(), || Ok(self.cf1_u_i_cmW.unwrap_or(C2::zero())))?,
+            cmW: C2::Var::new_witness(cs.clone(), || Ok(self.cf1_u_i_cmW.unwrap_or(C2::zero())))?,
             // cf1_u_i.x is computed in step 1
             x: cfW_x,
         };
         let cf2_u_i = CycleFoldCommittedInstanceVar {
             // cf2_u_i.cmE = 0
-            cmE: GC2::zero(),
+            cmE: C2::Var::zero(),
             // cf2_u_i.u = 1
             u: NonNativeUintVar::new_constant(cs.clone(), C1::BaseField::one())?,
             // cf2_u_i.cmW is provided by the prover as witness
-            cmW: GC2::new_witness(cs.clone(), || Ok(self.cf2_u_i_cmW.unwrap_or(C2::zero())))?,
+            cmW: C2::Var::new_witness(cs.clone(), || Ok(self.cf2_u_i_cmW.unwrap_or(C2::zero())))?,
             // cf2_u_i.x is computed in step 1
             x: cfE_x,
         };
@@ -300,7 +289,7 @@ where
 
         // compute cf1_r = H(cf1_u_i, cf_U_i, cf1_cmT)
         // cf_r_bits is denoted by rho* in the paper.
-        let cf1_r_bits = CycleFoldChallengeGadget::<C2, GC2>::get_challenge_gadget(
+        let cf1_r_bits = CycleFoldChallengeGadget::<C2>::get_challenge_gadget(
             &mut transcript,
             pp_hash.clone(),
             cf_U_i_vec,
@@ -308,19 +297,18 @@ where
             cf1_cmT.clone(),
         )?;
         // Fold cf1_u_i & cf_U_i into cf1_U_{i+1}
-        let cf1_U_i1 = NIFSFullGadget::<C2, GC2>::fold_committed_instance(
-            cf1_r_bits, cf1_cmT, cf_U_i, cf1_u_i,
-        )?;
+        let cf1_U_i1 =
+            NIFSFullGadget::<C2>::fold_committed_instance(cf1_r_bits, cf1_cmT, cf_U_i, cf1_u_i)?;
 
         // same for cf2_r:
-        let cf2_r_bits = CycleFoldChallengeGadget::<C2, GC2>::get_challenge_gadget(
+        let cf2_r_bits = CycleFoldChallengeGadget::<C2>::get_challenge_gadget(
             &mut transcript,
             pp_hash.clone(),
             cf1_U_i1.to_native_sponge_field_elements()?,
             cf2_u_i.clone(),
             cf2_cmT.clone(),
         )?;
-        let cf_U_i1 = NIFSFullGadget::<C2, GC2>::fold_committed_instance(
+        let cf_U_i1 = NIFSFullGadget::<C2>::fold_committed_instance(
             cf2_r_bits, cf2_cmT, cf1_U_i1, // the output from NIFS.V(cf1_r, cf_U, cfE_u)
             cf2_u_i,
         )?;
@@ -331,7 +319,7 @@ where
         // Non-base case: u_{i+1}.x[1] == H(cf_U_{i+1})
         let (cf_u_i1_x, _) = cf_U_i1.clone().hash(&sponge, pp_hash.clone())?;
         let (cf_u_i1_x_base, _) =
-            CycleFoldCommittedInstanceVar::<C2, GC2>::new_constant(cs.clone(), cf_u_dummy)?
+            CycleFoldCommittedInstanceVar::<C2>::new_constant(cs.clone(), cf_u_dummy)?
                 .hash(&sponge, pp_hash)?;
         let cf_x = is_basecase.select(&cf_u_i1_x_base, &cf_u_i1_x)?;
         // This line "converts" `cf_x` from a witness to a public input.
@@ -349,13 +337,11 @@ where
     }
 }
 
-impl<C1, C2, GC2, FC> ConstraintSynthesizer<CF1<C1>> for AugmentedFCircuit<C1, C2, GC2, FC>
+impl<C1, C2, FC> ConstraintSynthesizer<CF1<C1>> for AugmentedFCircuit<C1, C2, FC>
 where
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: SonobeCurve,
     FC: FCircuit<CF1<C1>>,
-    C2::BaseField: PrimeField + Absorb,
 {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {
         self.compute_next_state(cs).map(|_| ())
@@ -368,7 +354,7 @@ pub mod tests {
     use ark_bn254::{Fr, G1Projective as Projective};
     use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
     use ark_ff::BigInteger;
-    use ark_r1cs_std::convert::ToConstraintFieldGadget;
+
     use ark_relations::r1cs::ConstraintSystem;
     use ark_std::UniformRand;
 
@@ -423,8 +409,8 @@ pub mod tests {
         let U_iVar_vec = [
             vec![U_iVar.u.clone()],
             U_iVar.x.clone(),
-            U_iVar.cmE.to_constraint_field()?,
-            U_iVar.cmW.to_constraint_field()?,
+            U_iVar.cmE.to_native_sponge_field_elements()?,
+            U_iVar.cmW.to_native_sponge_field_elements()?,
         ]
         .concat();
         let r_bitsVar =

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -33,7 +33,7 @@ use crate::folding::circuits::{
 use crate::folding::traits::{CommittedInstanceVarOps, Dummy};
 use crate::frontend::FCircuit;
 use crate::transcript::AbsorbNonNativeGadget;
-use crate::SonobeCurve;
+use crate::Curve;
 
 /// `AugmentedFCircuit` enhances the original step function `F`, so that it can
 /// be used in recursive arguments such as IVC.
@@ -48,7 +48,7 @@ use crate::SonobeCurve;
 /// defined in [CycleFold](https://eprint.iacr.org/2023/1192.pdf). These extra
 /// constraints verify the correct folding of CycleFold instances.
 #[derive(Debug, Clone)]
-pub struct AugmentedFCircuit<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> {
+pub struct AugmentedFCircuit<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> {
     pub(super) poseidon_config: PoseidonConfig<CF1<C1>>,
     pub(super) pp_hash: Option<CF1<C1>>,
     pub(super) i: Option<CF1<C1>>,
@@ -73,7 +73,7 @@ pub struct AugmentedFCircuit<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<
     pub(super) cf2_cmT: Option<C2>,
 }
 
-impl<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<C1, C2, FC> {
+impl<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<C1, C2, FC> {
     pub fn empty(poseidon_config: &PoseidonConfig<CF1<C1>>, F_circuit: FC) -> Self {
         Self {
             poseidon_config: poseidon_config.clone(),
@@ -101,8 +101,8 @@ impl<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<
 
 impl<C1, C2, FC> AugmentedFCircuit<C1, C2, FC>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<CF1<C1>>,
 {
     pub fn compute_next_state(
@@ -339,8 +339,8 @@ where
 
 impl<C1, C2, FC> ConstraintSynthesizer<CF1<C1>> for AugmentedFCircuit<C1, C2, FC>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<CF1<C1>>,
 {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {

--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -17,14 +17,14 @@ use crate::folding::circuits::cyclefold::CycleFoldCommittedInstance;
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
 use crate::folding::traits::{CommittedInstanceOps, Inputize, InputizeNonNative, WitnessOps};
 use crate::frontend::FCircuit;
+use crate::{Curve, Error};
 use crate::{Decider as DeciderTrait, FoldingScheme};
-use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Proof<C1, C2, CS1, CS2, S1, S2>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     CS1: CommitmentScheme<C1>,
     CS2: CommitmentScheme<C2>,
     S1: SNARK<C1::ScalarField>,
@@ -63,7 +63,7 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierParam<C1, CS1_VerifyingKey, S1_VerifyingKey, CS2_VerifyingKey, S2_VerifyingKey>
 where
-    C1: SonobeCurve,
+    C1: Curve,
     CS1_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     S1_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     CS2_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
@@ -92,8 +92,8 @@ pub struct Decider<C1, C2, FC, CS1, CS2, S1, S2, FS> {
 impl<C1, C2, FC, CS1, CS2, S1, S2, FS> DeciderTrait<C1, C2, FC, FS>
     for Decider<C1, C2, FC, CS1, CS2, S1, S2, FS>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<
         C1,

--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -13,12 +13,9 @@ use super::decider_circuits::{DeciderCircuit1, DeciderCircuit2};
 use super::decider_eth_circuit::DeciderNovaGadget;
 use super::Nova;
 use crate::commitment::CommitmentScheme;
+use crate::folding::circuits::cyclefold::CycleFoldCommittedInstance;
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
-use crate::folding::circuits::{
-    cyclefold::{CycleFoldCommittedInstance, CycleFoldCommittedInstanceVar},
-    CF2,
-};
-use crate::folding::traits::{CommittedInstanceOps, Inputize, WitnessOps};
+use crate::folding::traits::{CommittedInstanceOps, Inputize, InputizeNonNative, WitnessOps};
 use crate::frontend::FCircuit;
 use crate::{Decider as DeciderTrait, FoldingScheme};
 use crate::{Error, SonobeCurve};
@@ -266,14 +263,11 @@ where
             &[vp.pp_hash, i][..],
             &z_0,
             &z_i,
-            &U_final_commitments
-                .iter()
-                .flat_map(|c| c.inputize())
-                .collect::<Vec<_>>(),
-            &Inputize::<CF2<C2>, CycleFoldCommittedInstanceVar<C2>>::inputize(&cf_U),
+            &U_final_commitments.inputize_nonnative(),
+            &cf_U.inputize_nonnative(),
             &proof.cs1_challenges,
             &proof.cs1_proofs.iter().map(|p| p.eval).collect::<Vec<_>>(),
-            &proof.cmT.inputize(),
+            &proof.cmT.inputize_nonnative(),
         ]
         .concat();
 

--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -2,10 +2,7 @@
 /// DeciderEth from decider_eth.rs file.
 /// More details can be found at the documentation page:
 /// https://privacy-scaling-explorations.github.io/sonobe-docs/design/nova-decider-offchain.html
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
 use ark_ff::{BigInteger, PrimeField};
-use ark_r1cs_std::{groups::GroupOpsBounds, prelude::CurveVar};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
 use ark_std::rand::{CryptoRng, RngCore};
@@ -23,14 +20,14 @@ use crate::folding::circuits::{
 };
 use crate::folding::traits::{CommittedInstanceOps, Inputize, WitnessOps};
 use crate::frontend::FCircuit;
-use crate::Error;
 use crate::{Decider as DeciderTrait, FoldingScheme};
+use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Proof<C1, C2, CS1, CS2, S1, S2>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     CS1: CommitmentScheme<C1>,
     CS2: CommitmentScheme<C2>,
     S1: SNARK<C1::ScalarField>,
@@ -69,7 +66,7 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierParam<C1, CS1_VerifyingKey, S1_VerifyingKey, CS2_VerifyingKey, S2_VerifyingKey>
 where
-    C1: CurveGroup,
+    C1: SonobeCurve,
     CS1_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     S1_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     CS2_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
@@ -84,11 +81,9 @@ where
 
 /// Onchain Decider, for ethereum use cases
 #[derive(Clone, Debug)]
-pub struct Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S1, S2, FS> {
+pub struct Decider<C1, C2, FC, CS1, CS2, S1, S2, FS> {
     _c1: PhantomData<C1>,
-    _gc1: PhantomData<GC1>,
     _c2: PhantomData<C2>,
-    _gc2: PhantomData<GC2>,
     _fc: PhantomData<FC>,
     _cs1: PhantomData<CS1>,
     _cs2: PhantomData<CS2>,
@@ -97,13 +92,11 @@ pub struct Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S1, S2, FS> {
     _fs: PhantomData<FS>,
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, S1, S2, FS> DeciderTrait<C1, C2, FC, FS>
-    for Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S1, S2, FS>
+impl<C1, C2, FC, CS1, CS2, S1, S2, FS> DeciderTrait<C1, C2, FC, FS>
+    for Decider<C1, C2, FC, CS1, CS2, S1, S2, FS>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     CS1: CommitmentScheme<
         C1,
@@ -120,15 +113,8 @@ where
     S1: SNARK<C1::ScalarField>,
     S2: SNARK<C2::ScalarField>,
     FS: FoldingScheme<C1, C2, FC>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    for<'b> &'b GC1: GroupOpsBounds<'b, C1, GC1>,
-    for<'b> &'b GC2: GroupOpsBounds<'b, C2, GC2>,
     // constrain FS into Nova, since this is a Decider specifically for Nova
-    Nova<C1, GC1, C2, GC2, FC, CS1, CS2, false>: From<FS>,
+    Nova<C1, C2, FC, CS1, CS2, false>: From<FS>,
     crate::folding::nova::ProverParams<C1, C2, CS1, CS2, false>:
         From<<FS as FoldingScheme<C1, C2, FC>>::ProverParam>,
     crate::folding::nova::VerifierParams<C1, C2, CS1, CS2, false>:
@@ -153,7 +139,7 @@ where
         prep_param: Self::PreprocessorParam,
         fs: FS,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
-        let circuit1 = DeciderCircuit1::<C1, C2, GC2>::try_from(Nova::from(fs.clone()))?;
+        let circuit1 = DeciderCircuit1::<C1, C2>::try_from(Nova::from(fs.clone()))?;
         let circuit2 = DeciderCircuit2::<C2>::try_from(Nova::from(fs))?;
 
         // get the Groth16 specific setup for the circuits
@@ -164,13 +150,13 @@ where
 
         // get the FoldingScheme prover & verifier params from Nova
         #[allow(clippy::type_complexity)]
-        let nova_pp: <Nova<C1, GC1, C2, GC2, FC, CS1, CS2, false> as FoldingScheme<
+        let nova_pp: <Nova<C1, C2, FC, CS1, CS2, false> as FoldingScheme<
             C1,
             C2,
             FC,
         >>::ProverParam = prep_param.0.clone().into();
         #[allow(clippy::type_complexity)]
-        let nova_vp: <Nova<C1, GC1, C2, GC2, FC, CS1, CS2, false> as FoldingScheme<
+        let nova_vp: <Nova<C1, C2, FC, CS1, CS2, false> as FoldingScheme<
             C1,
             C2,
             FC,
@@ -198,7 +184,7 @@ where
         pp: Self::ProverParam,
         fs: FS,
     ) -> Result<Self::Proof, Error> {
-        let circuit1 = DeciderCircuit1::<C1, C2, GC2>::try_from(Nova::from(fs.clone()))?;
+        let circuit1 = DeciderCircuit1::<C1, C2>::try_from(Nova::from(fs.clone()))?;
         let circuit2 = DeciderCircuit2::<C2>::try_from(Nova::from(fs))?;
 
         let cmT = circuit1.proof;
@@ -284,7 +270,7 @@ where
                 .iter()
                 .flat_map(|c| c.inputize())
                 .collect::<Vec<_>>(),
-            &Inputize::<CF2<C2>, CycleFoldCommittedInstanceVar<C2, GC2>>::inputize(&cf_U),
+            &Inputize::<CF2<C2>, CycleFoldCommittedInstanceVar<C2>>::inputize(&cf_U),
             &proof.cs1_challenges,
             &proof.cs1_proofs.iter().map(|p| p.eval).collect::<Vec<_>>(),
             &proof.cmT.inputize(),
@@ -344,12 +330,8 @@ pub mod tests {
 
     // Note: do not use the MNTx_298 curves in practice, these are just for tests. Use the MNTx_753
     // curves instead.
-    use ark_mnt4_298::{
-        constraints::G1Var as GVar, Fr, G1Projective as Projective, MNT4_298 as MNT4,
-    };
-    use ark_mnt6_298::{
-        constraints::G1Var as GVar2, G1Projective as Projective2, MNT6_298 as MNT6,
-    };
+    use ark_mnt4_298::{Fr, G1Projective as Projective, MNT4_298 as MNT4};
+    use ark_mnt6_298::{G1Projective as Projective2, MNT6_298 as MNT6};
     use std::time::Instant;
 
     use super::*;
@@ -363,9 +345,7 @@ pub mod tests {
         // use Nova as FoldingScheme
         type N = Nova<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, MNT4>,
             KZG<'static, MNT6>,
@@ -373,9 +353,7 @@ pub mod tests {
         >;
         type D = Decider<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, MNT4>,
             KZG<'static, MNT6>,

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -22,7 +22,7 @@ use crate::{
     },
 };
 use crate::{commitment::CommitmentScheme, transcript::poseidon::poseidon_canonical_config};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// Circuit that implements part of the in-circuit checks needed for the offchain verification over
 /// the Curve2's BaseField (=Curve1's ScalarField).
@@ -39,8 +39,8 @@ pub type DeciderCircuit1<C1, C2> = GenericOffchainDeciderCircuit1<
 >;
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve,
+        C1: Curve,
+        C2: Curve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         CS2: CommitmentScheme<C2, H>,
@@ -106,8 +106,8 @@ impl<
 pub type DeciderCircuit2<C2> = GenericOffchainDeciderCircuit2<C2>;
 
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve,
+        C1: Curve,
+        C2: Curve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         CS2: CommitmentScheme<C2, H>,

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -2,10 +2,9 @@
 /// DeciderEthCircuit.
 /// More details can be found at the documentation page:
 /// https://privacy-scaling-explorations.github.io/sonobe-docs/design/nova-decider-offchain.html
-use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, Absorb, CryptographicSponge};
-use ark_ec::CurveGroup;
+use ark_crypto_primitives::sponge::{poseidon::PoseidonSponge, CryptographicSponge};
 use ark_ff::{BigInteger, PrimeField};
-use ark_r1cs_std::{fields::fp::FpVar, prelude::CurveVar};
+use ark_r1cs_std::fields::fp::FpVar;
 use core::marker::PhantomData;
 
 use super::{
@@ -13,12 +12,8 @@ use super::{
     nifs::{nova::NIFS, NIFSTrait},
     CommittedInstance, Nova, Witness,
 };
-use crate::folding::{
-    circuits::{CF1, CF2},
-    traits::WitnessOps,
-};
+use crate::folding::{circuits::CF1, traits::WitnessOps};
 use crate::frontend::FCircuit;
-use crate::Error;
 use crate::{
     arith::r1cs::{circuits::R1CSMatricesVar, R1CS},
     folding::circuits::decider::{
@@ -27,14 +22,14 @@ use crate::{
     },
 };
 use crate::{commitment::CommitmentScheme, transcript::poseidon::poseidon_canonical_config};
+use crate::{Error, SonobeCurve};
 
 /// Circuit that implements part of the in-circuit checks needed for the offchain verification over
 /// the Curve2's BaseField (=Curve1's ScalarField).
 
-pub type DeciderCircuit1<C1, C2, GC2> = GenericOffchainDeciderCircuit1<
+pub type DeciderCircuit1<C1, C2> = GenericOffchainDeciderCircuit1<
     C1,
     C2,
-    GC2,
     CommittedInstance<C1>,
     CommittedInstance<C1>,
     Witness<C1>,
@@ -44,22 +39,17 @@ pub type DeciderCircuit1<C1, C2, GC2> = GenericOffchainDeciderCircuit1<
 >;
 
 impl<
-        C1: CurveGroup,
-        GC1: CurveVar<C1, CF2<C1>>,
-        C2: CurveGroup,
-        GC2: CurveVar<C2, CF2<C2>>,
+        C1: SonobeCurve,
+        C2: SonobeCurve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         CS2: CommitmentScheme<C2, H>,
         const H: bool,
-    > TryFrom<Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>> for DeciderCircuit1<C1, C2, GC2>
-where
-    CF1<C1>: Absorb,
-    <C1 as CurveGroup>::BaseField: PrimeField,
+    > TryFrom<Nova<C1, C2, FC, CS1, CS2, H>> for DeciderCircuit1<C1, C2>
 {
     type Error = Error;
 
-    fn try_from(nova: Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>) -> Result<Self, Error> {
+    fn try_from(nova: Nova<C1, C2, FC, CS1, CS2, H>) -> Result<Self, Error> {
         let mut transcript = PoseidonSponge::<C1::ScalarField>::new(&nova.poseidon_config);
         // pp_hash is absorbed to transcript at the NIFS::prove call
 
@@ -89,7 +79,6 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            _gc2: PhantomData,
             _avar: PhantomData,
             arith: nova.r1cs,
             poseidon_config: nova.poseidon_config,
@@ -117,21 +106,17 @@ where
 pub type DeciderCircuit2<C2> = GenericOffchainDeciderCircuit2<C2>;
 
 impl<
-        C1: CurveGroup,
-        GC1: CurveVar<C1, CF2<C1>>,
-        C2: CurveGroup,
-        GC2: CurveVar<C2, CF2<C2>>,
+        C1: SonobeCurve,
+        C2: SonobeCurve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         CS2: CommitmentScheme<C2, H>,
         const H: bool,
-    > TryFrom<Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>> for DeciderCircuit2<C2>
-where
-    CF1<C2>: Absorb,
+    > TryFrom<Nova<C1, C2, FC, CS1, CS2, H>> for DeciderCircuit2<C2>
 {
     type Error = Error;
 
-    fn try_from(nova: Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>) -> Result<Self, Error> {
+    fn try_from(nova: Nova<C1, C2, FC, CS1, CS2, H>) -> Result<Self, Error> {
         // compute the Commitment Scheme challenges of the CycleFold instance commitments, used as
         // inputs in the circuit
         let poseidon_config = poseidon_canonical_config::<C2::ScalarField>();
@@ -167,9 +152,9 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use ark_pallas::{constraints::GVar, Fq, Fr, Projective};
+    use ark_pallas::{Fq, Fr, Projective};
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
-    use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_vesta::Projective as Projective2;
 
     use super::*;
     use crate::commitment::pedersen::Pedersen;
@@ -188,9 +173,7 @@ pub mod tests {
 
         type N = Nova<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             Pedersen<Projective>,
             Pedersen<Projective2>,
@@ -215,8 +198,7 @@ pub mod tests {
         N::verify(nova_params.1, ivc_proof)?;
 
         // load the DeciderCircuit 1 & 2 from the Nova instance
-        let decider_circuit1 =
-            DeciderCircuit1::<Projective, Projective2, GVar2>::try_from(nova.clone())?;
+        let decider_circuit1 = DeciderCircuit1::<Projective, Projective2>::try_from(nova.clone())?;
         let decider_circuit2 = DeciderCircuit2::<Projective2>::try_from(nova)?;
 
         // generate the constraints of both circuits and check that are satisfied by the inputs

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -248,7 +248,7 @@ pub fn prepare_calldata(
     incoming_instance: &CommittedInstance<ark_bn254::G1Projective>,
     proof: Proof<ark_bn254::G1Projective, KZG<'static, Bn254>, Groth16<Bn254>>,
 ) -> Result<Vec<u8>, Error> {
-    Ok(vec![
+    Ok([
         function_signature_check.to_eth(),
         i.to_eth(),   // i
         z_0.to_eth(), // z_0

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -21,7 +21,7 @@ use crate::commitment::{
     CommitmentScheme,
 };
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
-use crate::folding::traits::{Inputize, WitnessOps};
+use crate::folding::traits::{InputizeNonNative, WitnessOps};
 use crate::frontend::FCircuit;
 use crate::utils::eth::ToEth;
 use crate::{Decider as DeciderTrait, FoldingScheme};
@@ -210,13 +210,10 @@ where
             &[pp_hash, i][..],
             &z_0,
             &z_i,
-            &U_final_commitments
-                .iter()
-                .flat_map(|c| c.inputize())
-                .collect::<Vec<_>>(),
+            &U_final_commitments.inputize_nonnative(),
             &proof.kzg_challenges,
             &proof.kzg_proofs.iter().map(|p| p.eval).collect::<Vec<_>>(),
-            &proof.cmT.inputize(),
+            &proof.cmT.inputize_nonnative(),
         ]
         .concat();
 

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -24,13 +24,13 @@ use crate::folding::circuits::decider::DeciderEnabledNIFS;
 use crate::folding::traits::{InputizeNonNative, WitnessOps};
 use crate::frontend::FCircuit;
 use crate::utils::eth::ToEth;
+use crate::{Curve, Error};
 use crate::{Decider as DeciderTrait, FoldingScheme};
-use crate::{Error, SonobeCurve};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C, CS, S>
 where
-    C: SonobeCurve,
+    C: Curve,
     CS: CommitmentScheme<C, ProverChallenge = C::ScalarField, Challenge = C::ScalarField>,
     S: SNARK<C::ScalarField>,
 {
@@ -48,7 +48,7 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierParam<C1, CS_VerifyingKey, S_VerifyingKey>
 where
-    C1: SonobeCurve,
+    C1: Curve,
     CS_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     S_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
 {
@@ -72,8 +72,8 @@ pub struct Decider<C1, C2, FC, CS1, CS2, S, FS> {
 impl<C1, C2, FC, CS1, CS2, S, FS> DeciderTrait<C1, C2, FC, FS>
     for Decider<C1, C2, FC, CS1, CS2, S, FS>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     // CS1 is a KZG commitment, where challenge is C1::Fr elem
     CS1: CommitmentScheme<

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -32,18 +32,18 @@ use crate::{
     arith::r1cs::{circuits::R1CSMatricesVar, R1CS},
     folding::circuits::decider::{DeciderEnabledNIFS, EvalGadget, KZGChallengesGadget},
 };
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// In-circuit representation of the Witness associated to the CommittedInstance.
 #[derive(Debug, Clone)]
-pub struct WitnessVar<C: SonobeCurve> {
+pub struct WitnessVar<C: Curve> {
     pub E: Vec<FpVar<C::ScalarField>>,
     pub rE: FpVar<C::ScalarField>,
     pub W: Vec<FpVar<C::ScalarField>>,
     pub rW: FpVar<C::ScalarField>,
 }
 
-impl<C: SonobeCurve> AllocVar<Witness<C>, CF1<C>> for WitnessVar<C> {
+impl<C: Curve> AllocVar<Witness<C>, CF1<C>> for WitnessVar<C> {
     fn new_variable<T: Borrow<Witness<C>>>(
         cs: impl Into<Namespace<CF1<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -67,7 +67,7 @@ impl<C: SonobeCurve> AllocVar<Witness<C>, CF1<C>> for WitnessVar<C> {
     }
 }
 
-impl<C: SonobeCurve> WitnessVarOps<C::ScalarField> for WitnessVar<C> {
+impl<C: Curve> WitnessVarOps<C::ScalarField> for WitnessVar<C> {
     fn get_openings(&self) -> Vec<(&[FpVar<C::ScalarField>], FpVar<C::ScalarField>)> {
         vec![(&self.W, self.rW.clone()), (&self.E, self.rE.clone())]
     }
@@ -86,8 +86,8 @@ pub type DeciderEthCircuit<C1, C2> = GenericOnchainDeciderCircuit<
 
 /// returns an instance of the DeciderEthCircuit from the given Nova struct
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve,
+        C1: Curve,
+        C2: Curve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         // enforce that the CS2 is Pedersen commitment scheme, since we're at Ethereum's EVM decider
@@ -153,7 +153,7 @@ impl<
 
 pub struct DeciderNovaGadget;
 
-impl<C: SonobeCurve>
+impl<C: Curve>
     DeciderEnabledNIFS<C, CommittedInstance<C>, CommittedInstance<C>, Witness<C>, R1CS<CF1<C>>>
     for DeciderNovaGadget
 {

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -5,14 +5,12 @@
 use ark_crypto_primitives::sponge::{
     constraints::CryptographicSpongeVar,
     poseidon::{constraints::PoseidonSpongeVar, PoseidonSponge},
-    Absorb, CryptographicSponge,
+    CryptographicSponge,
 };
-use ark_ec::CurveGroup;
 use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     fields::fp::FpVar,
-    prelude::CurveVar,
 };
 use ark_relations::r1cs::{Namespace, SynthesisError};
 use ark_std::{borrow::Borrow, marker::PhantomData};
@@ -25,31 +23,27 @@ use super::{
 use crate::commitment::{pedersen::Params as PedersenParams, CommitmentScheme};
 use crate::folding::{
     circuits::{
-        decider::on_chain::GenericOnchainDeciderCircuit, nonnative::affine::NonNativeAffineVar,
-        CF1, CF2,
+        decider::on_chain::GenericOnchainDeciderCircuit, nonnative::affine::NonNativeAffineVar, CF1,
     },
     traits::{WitnessOps, WitnessVarOps},
 };
 use crate::frontend::FCircuit;
-use crate::Error;
 use crate::{
     arith::r1cs::{circuits::R1CSMatricesVar, R1CS},
     folding::circuits::decider::{DeciderEnabledNIFS, EvalGadget, KZGChallengesGadget},
 };
+use crate::{Error, SonobeCurve};
 
 /// In-circuit representation of the Witness associated to the CommittedInstance.
 #[derive(Debug, Clone)]
-pub struct WitnessVar<C: CurveGroup> {
+pub struct WitnessVar<C: SonobeCurve> {
     pub E: Vec<FpVar<C::ScalarField>>,
     pub rE: FpVar<C::ScalarField>,
     pub W: Vec<FpVar<C::ScalarField>>,
     pub rW: FpVar<C::ScalarField>,
 }
 
-impl<C> AllocVar<Witness<C>, CF1<C>> for WitnessVar<C>
-where
-    C: CurveGroup,
-{
+impl<C: SonobeCurve> AllocVar<Witness<C>, CF1<C>> for WitnessVar<C> {
     fn new_variable<T: Borrow<Witness<C>>>(
         cs: impl Into<Namespace<CF1<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -73,16 +67,15 @@ where
     }
 }
 
-impl<C: CurveGroup> WitnessVarOps<C::ScalarField> for WitnessVar<C> {
+impl<C: SonobeCurve> WitnessVarOps<C::ScalarField> for WitnessVar<C> {
     fn get_openings(&self) -> Vec<(&[FpVar<C::ScalarField>], FpVar<C::ScalarField>)> {
         vec![(&self.W, self.rW.clone()), (&self.E, self.rE.clone())]
     }
 }
 
-pub type DeciderEthCircuit<C1, C2, GC2> = GenericOnchainDeciderCircuit<
+pub type DeciderEthCircuit<C1, C2> = GenericOnchainDeciderCircuit<
     C1,
     C2,
-    GC2,
     CommittedInstance<C1>,
     CommittedInstance<C1>,
     Witness<C1>,
@@ -93,23 +86,18 @@ pub type DeciderEthCircuit<C1, C2, GC2> = GenericOnchainDeciderCircuit<
 
 /// returns an instance of the DeciderEthCircuit from the given Nova struct
 impl<
-        C1: CurveGroup,
-        GC1: CurveVar<C1, CF2<C1>>,
-        C2: CurveGroup,
-        GC2: CurveVar<C2, CF2<C2>>,
+        C1: SonobeCurve,
+        C2: SonobeCurve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, H>,
         // enforce that the CS2 is Pedersen commitment scheme, since we're at Ethereum's EVM decider
         CS2: CommitmentScheme<C2, H, ProverParams = PedersenParams<C2>>,
         const H: bool,
-    > TryFrom<Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>> for DeciderEthCircuit<C1, C2, GC2>
-where
-    CF1<C1>: Absorb,
-    <C1 as CurveGroup>::BaseField: PrimeField,
+    > TryFrom<Nova<C1, C2, FC, CS1, CS2, H>> for DeciderEthCircuit<C1, C2>
 {
     type Error = Error;
 
-    fn try_from(nova: Nova<C1, GC1, C2, GC2, FC, CS1, CS2, H>) -> Result<Self, Error> {
+    fn try_from(nova: Nova<C1, C2, FC, CS1, CS2, H>) -> Result<Self, Error> {
         let mut transcript = PoseidonSponge::<C1::ScalarField>::new(&nova.poseidon_config);
 
         // compute the U_{i+1}, W_{i+1}
@@ -138,7 +126,6 @@ where
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
-            _gc2: PhantomData,
             _avar: PhantomData,
             arith: nova.r1cs,
             cf_arith: nova.cf_r1cs,
@@ -166,11 +153,9 @@ where
 
 pub struct DeciderNovaGadget;
 
-impl<C: CurveGroup>
+impl<C: SonobeCurve>
     DeciderEnabledNIFS<C, CommittedInstance<C>, CommittedInstance<C>, Witness<C>, R1CS<CF1<C>>>
     for DeciderNovaGadget
-where
-    CF1<C>: Absorb,
 {
     type ProofDummyCfg = ();
     type Proof = C;
@@ -215,9 +200,9 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use ark_pallas::{constraints::GVar, Fr, Projective};
+    use ark_pallas::{Fr, Projective};
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
-    use ark_vesta::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_vesta::Projective as Projective2;
 
     use super::*;
     use crate::commitment::pedersen::Pedersen;
@@ -236,9 +221,7 @@ pub mod tests {
 
         type N = Nova<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             Pedersen<Projective>,
             Pedersen<Projective2>,
@@ -262,7 +245,7 @@ pub mod tests {
         N::verify(nova_params.1, ivc_proof)?;
 
         // load the DeciderEthCircuit from the generated Nova instance
-        let decider_circuit = DeciderEthCircuit::<Projective, Projective2, GVar2>::try_from(nova)?;
+        let decider_circuit = DeciderEthCircuit::<Projective, Projective2>::try_from(nova)?;
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -746,7 +746,7 @@ where
             };
 
             // fold self.cf_U_i + cfW_U -> folded running with cfW
-            let (_cfW_w_i, cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT, _) = self.fold_cyclefold_circuit(
+            let (cfW_u_i, cfW_W_i1, cfW_U_i1, cfW_cmT) = self.fold_cyclefold_circuit(
                 &mut transcript,
                 self.cf_W_i.clone(), // CycleFold running instance witness
                 self.cf_U_i.clone(), // CycleFold running instance
@@ -754,7 +754,7 @@ where
                 &mut rng,
             )?;
             // fold [the output from folding self.cf_U_i + cfW_U] + cfE_U = folded_running_with_cfW + cfE
-            let (_cfE_w_i, cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT, _) = self.fold_cyclefold_circuit(
+            let (cfE_u_i, cf_W_i1, cf_U_i1, cf_cmT) = self.fold_cyclefold_circuit(
                 &mut transcript,
                 cfW_W_i1,
                 cfW_U_i1.clone(),
@@ -786,15 +786,6 @@ where
 
             self.cf_W_i = cf_W_i1;
             self.cf_U_i = cf_U_i1;
-
-            #[cfg(test)]
-            {
-                cfW_u_i.check_incoming()?;
-                cfE_u_i.check_incoming()?;
-                self.cf_r1cs.check_relation(&_cfW_w_i, &cfW_u_i)?;
-                self.cf_r1cs.check_relation(&_cfE_w_i, &cfE_u_i)?;
-                self.cf_r1cs.check_relation(&self.cf_W_i, &self.cf_U_i)?;
-            }
         }
 
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
@@ -981,16 +972,14 @@ where
         rng: &mut impl RngCore,
     ) -> Result<
         (
-            CycleFoldWitness<C2>,
             CycleFoldCommittedInstance<C2>, // u_i
             CycleFoldWitness<C2>,           // W_i1
             CycleFoldCommittedInstance<C2>, // U_i1
             C2,                             // cmT
-            C2::ScalarField,                // r_Fq
         ),
         Error,
     > {
-        fold_cyclefold_circuit::<NovaCycleFoldConfig<C1>, C1, C2, CS2, H>(
+        fold_cyclefold_circuit::<NovaCycleFoldConfig<C1>, C2, CS2, H>(
             transcript,
             self.cf_r1cs.clone(),
             self.cf_cs_pp.clone(),

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -122,13 +122,15 @@ impl<C: SonobeCurve> CommittedInstanceOps<C> for CommittedInstance<C> {
     }
 }
 
-impl<C: SonobeCurve> Inputize<C::ScalarField, CommittedInstanceVar<C>> for CommittedInstance<C> {
-    fn inputize(&self) -> Vec<C::ScalarField> {
+impl<C: SonobeCurve> Inputize<CF1<C>> for CommittedInstance<C> {
+    /// Returns the internal representation in the same order as how the value
+    /// is allocated in `CommittedInstanceVar::new_input`.
+    fn inputize(&self) -> Vec<CF1<C>> {
         [
             &[self.u][..],
             &self.x,
-            &self.cmE.inputize(),
-            &self.cmW.inputize(),
+            &self.cmE.inputize_nonnative(),
+            &self.cmW.inputize_nonnative(),
         ]
         .concat()
     }

--- a/folding-schemes/src/folding/nova/nifs/mod.rs
+++ b/folding-schemes/src/folding/nova/nifs/mod.rs
@@ -7,7 +7,6 @@
 /// - [Ova](https://hackmd.io/V4838nnlRKal9ZiTHiGYzw)
 /// - [Mova](https://eprint.iacr.org/2024/1220.pdf)
 use ark_crypto_primitives::sponge::{constraints::AbsorbGadget, Absorb, CryptographicSponge};
-use ark_ec::CurveGroup;
 use ark_r1cs_std::{alloc::AllocVar, boolean::Boolean, fields::fp::FpVar};
 use ark_relations::r1cs::SynthesisError;
 use ark_std::fmt::Debug;
@@ -18,7 +17,7 @@ use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::{CommittedInstanceOps, CommittedInstanceVarOps};
 use crate::transcript::{Transcript, TranscriptVar};
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 pub mod mova;
 pub mod nova;
@@ -33,7 +32,7 @@ pub mod pointvsline;
 /// [Mova](https://eprint.iacr.org/2024/1220.pdf).
 /// `H` specifies whether the NIFS will use a blinding factor.
 pub trait NIFSTrait<
-    C: CurveGroup,
+    C: SonobeCurve,
     CS: CommitmentScheme<C, H>,
     T: Transcript<C::ScalarField>,
     const H: bool = false,
@@ -99,7 +98,7 @@ pub trait NIFSTrait<
 /// logic of the NIFS.Verify defined in [Nova](https://eprint.iacr.org/2021/370.pdf) and it's
 /// variants [Ova](https://hackmd.io/V4838nnlRKal9ZiTHiGYzw) and
 /// [Mova](https://eprint.iacr.org/2024/1220.pdf).
-pub trait NIFSGadgetTrait<C: CurveGroup, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
+pub trait NIFSGadgetTrait<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
     type CommittedInstance: Debug + Clone + Absorb + CommittedInstanceOps<C>;
     type CommittedInstanceVar: Debug
         + Clone

--- a/folding-schemes/src/folding/nova/nifs/mod.rs
+++ b/folding-schemes/src/folding/nova/nifs/mod.rs
@@ -17,7 +17,7 @@ use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::{CommittedInstanceOps, CommittedInstanceVarOps};
 use crate::transcript::{Transcript, TranscriptVar};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 pub mod mova;
 pub mod nova;
@@ -32,7 +32,7 @@ pub mod pointvsline;
 /// [Mova](https://eprint.iacr.org/2024/1220.pdf).
 /// `H` specifies whether the NIFS will use a blinding factor.
 pub trait NIFSTrait<
-    C: SonobeCurve,
+    C: Curve,
     CS: CommitmentScheme<C, H>,
     T: Transcript<C::ScalarField>,
     const H: bool = false,
@@ -98,7 +98,7 @@ pub trait NIFSTrait<
 /// logic of the NIFS.Verify defined in [Nova](https://eprint.iacr.org/2021/370.pdf) and it's
 /// variants [Ova](https://hackmd.io/V4838nnlRKal9ZiTHiGYzw) and
 /// [Mova](https://eprint.iacr.org/2024/1220.pdf).
-pub trait NIFSGadgetTrait<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
+pub trait NIFSGadgetTrait<C: Curve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
     type CommittedInstance: Debug + Clone + Absorb + CommittedInstanceOps<C>;
     type CommittedInstanceVar: Debug
         + Clone

--- a/folding-schemes/src/folding/nova/nifs/nova.rs
+++ b/folding-schemes/src/folding/nova/nifs/nova.rs
@@ -20,15 +20,15 @@ use crate::folding::circuits::{
 use crate::folding::nova::{CommittedInstance, Witness};
 use crate::transcript::{Transcript, TranscriptVar};
 use crate::utils::vec::{hadamard, mat_vec_mul, vec_add, vec_scalar_mul, vec_sub};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// ChallengeGadget computes the RO challenge used for the Nova instances NIFS, it contains a
 /// rust-native and a in-circuit compatible versions.
-pub struct ChallengeGadget<C: SonobeCurve, CI: Absorb> {
+pub struct ChallengeGadget<C: Curve, CI: Absorb> {
     _c: PhantomData<C>,
     _ci: PhantomData<CI>,
 }
-impl<C: SonobeCurve, CI: Absorb> ChallengeGadget<C, CI> {
+impl<C: Curve, CI: Absorb> ChallengeGadget<C, CI> {
     pub fn get_challenge_native<T: Transcript<C::ScalarField>>(
         transcript: &mut T,
         pp_hash: C::ScalarField, // public params hash
@@ -73,7 +73,7 @@ impl<C: SonobeCurve, CI: Absorb> ChallengeGadget<C, CI> {
 /// [Nova](https://eprint.iacr.org/2021/370.pdf).
 /// `H` specifies whether the NIFS will use a blinding factor
 pub struct NIFS<
-    C: SonobeCurve,
+    C: Curve,
     CS: CommitmentScheme<C, H>,
     T: Transcript<C::ScalarField>,
     const H: bool = false,
@@ -83,7 +83,7 @@ pub struct NIFS<
     _t: PhantomData<T>,
 }
 
-impl<C: SonobeCurve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const H: bool>
+impl<C: Curve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const H: bool>
     NIFSTrait<C, CS, T, H> for NIFS<C, CS, T, H>
 {
     type CommittedInstance = CommittedInstance<C>;
@@ -194,7 +194,7 @@ impl<C: SonobeCurve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, 
     }
 }
 
-impl<C: SonobeCurve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const H: bool>
+impl<C: Curve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const H: bool>
     NIFS<C, CS, T, H>
 {
     /// compute_T: compute cross-terms T. We use the approach described in

--- a/folding-schemes/src/folding/nova/nifs/nova_circuits.rs
+++ b/folding-schemes/src/folding/nova/nifs/nova_circuits.rs
@@ -1,10 +1,8 @@
 /// contains [Nova](https://eprint.iacr.org/2021/370.pdf) NIFS related circuits
-use ark_crypto_primitives::sponge::{constraints::AbsorbGadget, Absorb, CryptographicSponge};
-use ark_ec::CurveGroup;
+use ark_crypto_primitives::sponge::{constraints::AbsorbGadget, CryptographicSponge};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     boolean::Boolean,
-    convert::ToConstraintFieldGadget,
     eq::EqGadget,
     fields::{fp::FpVar, FieldVar},
     uint8::UInt8,
@@ -14,13 +12,16 @@ use ark_std::{fmt::Debug, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
 
 use super::NIFSGadgetTrait;
-use crate::folding::circuits::{
-    nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
-    CF1, CF2,
-};
-use crate::folding::nova::CommittedInstance;
 use crate::folding::traits::CommittedInstanceVarOps;
 use crate::transcript::TranscriptVar;
+use crate::{
+    folding::circuits::{
+        nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
+        CF1, CF2,
+    },
+    SonobeCurve,
+};
+use crate::{folding::nova::CommittedInstance, transcript::AbsorbNonNativeGadget};
 
 use super::nova::ChallengeGadget;
 
@@ -28,17 +29,14 @@ use super::nova::ChallengeGadget;
 /// constraints field (E1::Fr, where E1 is the main curve). The peculiarity is that cmE and cmW are
 /// represented non-natively over the constraint field.
 #[derive(Debug, Clone)]
-pub struct CommittedInstanceVar<C: CurveGroup> {
+pub struct CommittedInstanceVar<C: SonobeCurve> {
     pub u: FpVar<C::ScalarField>,
     pub x: Vec<FpVar<C::ScalarField>>,
     pub cmE: NonNativeAffineVar<C>,
     pub cmW: NonNativeAffineVar<C>,
 }
 
-impl<C> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C>
-where
-    C: CurveGroup,
-{
+impl<C: SonobeCurve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C> {
     fn new_variable<T: Borrow<CommittedInstance<C>>>(
         cs: impl Into<Namespace<CF1<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -61,10 +59,7 @@ where
     }
 }
 
-impl<C> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C>
-where
-    C: CurveGroup,
-{
+impl<C: SonobeCurve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<C::ScalarField>>, SynthesisError> {
         FpVar::batch_to_sponge_bytes(&self.to_sponge_field_elements()?)
     }
@@ -73,14 +68,14 @@ where
         Ok([
             vec![self.u.clone()],
             self.x.clone(),
-            self.cmE.to_constraint_field()?,
-            self.cmW.to_constraint_field()?,
+            self.cmE.to_native_sponge_field_elements()?,
+            self.cmW.to_native_sponge_field_elements()?,
         ]
         .concat())
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
+impl<C: SonobeCurve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -107,7 +102,7 @@ impl<C: CurveGroup> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
 /// Implements the circuit that does the checks of the Non-Interactive Folding Scheme Verifier
 /// described in section 4 of [Nova](https://eprint.iacr.org/2021/370.pdf), where the cmE & cmW checks are
 /// delegated to the NIFSCycleFoldGadget.
-pub struct NIFSGadget<C: CurveGroup, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
+pub struct NIFSGadget<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
     _c: PhantomData<C>,
     _s: PhantomData<S>,
     _t: PhantomData<T>,
@@ -115,10 +110,9 @@ pub struct NIFSGadget<C: CurveGroup, S: CryptographicSponge, T: TranscriptVar<CF
 
 impl<C, S, T> NIFSGadgetTrait<C, S, T> for NIFSGadget<C, S, T>
 where
-    C: CurveGroup,
+    C: SonobeCurve,
     S: CryptographicSponge,
     T: TranscriptVar<CF1<C>, S>,
-    C::ScalarField: Absorb,
 {
     type CommittedInstance = CommittedInstance<C>;
     type CommittedInstanceVar = CommittedInstanceVar<C>;

--- a/folding-schemes/src/folding/nova/nifs/nova_circuits.rs
+++ b/folding-schemes/src/folding/nova/nifs/nova_circuits.rs
@@ -19,7 +19,7 @@ use crate::{
         nonnative::{affine::NonNativeAffineVar, uint::NonNativeUintVar},
         CF1, CF2,
     },
-    SonobeCurve,
+    Curve,
 };
 use crate::{folding::nova::CommittedInstance, transcript::AbsorbNonNativeGadget};
 
@@ -29,14 +29,14 @@ use super::nova::ChallengeGadget;
 /// constraints field (E1::Fr, where E1 is the main curve). The peculiarity is that cmE and cmW are
 /// represented non-natively over the constraint field.
 #[derive(Debug, Clone)]
-pub struct CommittedInstanceVar<C: SonobeCurve> {
+pub struct CommittedInstanceVar<C: Curve> {
     pub u: FpVar<C::ScalarField>,
     pub x: Vec<FpVar<C::ScalarField>>,
     pub cmE: NonNativeAffineVar<C>,
     pub cmW: NonNativeAffineVar<C>,
 }
 
-impl<C: SonobeCurve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C> {
+impl<C: Curve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C> {
     fn new_variable<T: Borrow<CommittedInstance<C>>>(
         cs: impl Into<Namespace<CF1<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -59,7 +59,7 @@ impl<C: SonobeCurve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanc
     }
 }
 
-impl<C: SonobeCurve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
+impl<C: Curve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<C::ScalarField>>, SynthesisError> {
         FpVar::batch_to_sponge_bytes(&self.to_sponge_field_elements()?)
     }
@@ -75,7 +75,7 @@ impl<C: SonobeCurve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
     }
 }
 
-impl<C: SonobeCurve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
+impl<C: Curve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -102,7 +102,7 @@ impl<C: SonobeCurve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
 /// Implements the circuit that does the checks of the Non-Interactive Folding Scheme Verifier
 /// described in section 4 of [Nova](https://eprint.iacr.org/2021/370.pdf), where the cmE & cmW checks are
 /// delegated to the NIFSCycleFoldGadget.
-pub struct NIFSGadget<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
+pub struct NIFSGadget<C: Curve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
     _c: PhantomData<C>,
     _s: PhantomData<S>,
     _t: PhantomData<T>,
@@ -110,7 +110,7 @@ pub struct NIFSGadget<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<C
 
 impl<C, S, T> NIFSGadgetTrait<C, S, T> for NIFSGadget<C, S, T>
 where
-    C: SonobeCurve,
+    C: Curve,
     S: CryptographicSponge,
     T: TranscriptVar<CF1<C>, S>,
 {

--- a/folding-schemes/src/folding/nova/nifs/ova.rs
+++ b/folding-schemes/src/folding/nova/nifs/ova.rs
@@ -55,9 +55,11 @@ impl<C: SonobeCurve> CommittedInstanceOps<C> for CommittedInstance<C> {
     }
 }
 
-impl<C: SonobeCurve> Inputize<C::ScalarField, CommittedInstanceVar<C>> for CommittedInstance<C> {
-    fn inputize(&self) -> Vec<C::ScalarField> {
-        [&[self.u][..], &self.x, &self.cmWE.inputize()].concat()
+impl<C: SonobeCurve> Inputize<CF1<C>> for CommittedInstance<C> {
+    /// Returns the internal representation in the same order as how the value
+    /// is allocated in `CommittedInstanceVar::new_input`.
+    fn inputize(&self) -> Vec<CF1<C>> {
+        [&[self.u][..], &self.x, &self.cmWE.inputize_nonnative()].concat()
     }
 }
 

--- a/folding-schemes/src/folding/nova/nifs/ova.rs
+++ b/folding-schemes/src/folding/nova/nifs/ova.rs
@@ -1,7 +1,6 @@
 /// This module contains the implementation the NIFSTrait for the
 /// [Ova](https://hackmd.io/V4838nnlRKal9ZiTHiGYzw) NIFS (Non-Interactive Folding Scheme).
 use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
 use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::fmt::Debug;
@@ -16,9 +15,9 @@ use crate::arith::r1cs::R1CS;
 use crate::commitment::CommitmentScheme;
 use crate::folding::traits::{CommittedInstanceOps, Inputize};
 use crate::folding::{circuits::CF1, traits::Dummy};
-use crate::transcript::{AbsorbNonNative, Transcript};
+use crate::transcript::Transcript;
 use crate::utils::vec::{hadamard, mat_vec_mul, vec_scalar_mul, vec_sub};
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 /// A CommittedInstance in [Ova](https://hackmd.io/V4838nnlRKal9ZiTHiGYzw) is represented by `W` or
 /// `W'`. It is the result of the commitment to a vector that contains the witness `w` concatenated
@@ -26,16 +25,13 @@ use crate::Error;
 /// document `u` is denoted as `mu`, in this implementation we use `u` so it follows the original
 /// Nova notation, so code is easier to follow).
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct CommittedInstance<C: CurveGroup> {
+pub struct CommittedInstance<C: SonobeCurve> {
     pub u: C::ScalarField, // in the Ova document is denoted as `mu`
     pub x: Vec<C::ScalarField>,
     pub cmWE: C,
 }
 
-impl<C: CurveGroup> Absorb for CommittedInstance<C>
-where
-    C::ScalarField: Absorb,
-{
+impl<C: SonobeCurve> Absorb for CommittedInstance<C> {
     fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
         C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
@@ -43,16 +39,11 @@ where
     fn to_sponge_field_elements<F: PrimeField>(&self, dest: &mut Vec<F>) {
         self.u.to_sponge_field_elements(dest);
         self.x.to_sponge_field_elements(dest);
-        // We cannot call `to_native_sponge_field_elements(dest)` directly, as
-        // `to_native_sponge_field_elements` needs `F` to be `C::ScalarField`,
-        // but here `F` is a generic `PrimeField`.
-        self.cmWE
-            .to_native_sponge_field_elements_as_vec()
-            .to_sponge_field_elements(dest);
+        self.cmWE.to_native_sponge_field_elements(dest);
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceOps<C> for CommittedInstance<C> {
+impl<C: SonobeCurve> CommittedInstanceOps<C> for CommittedInstance<C> {
     type Var = CommittedInstanceVar<C>;
 
     fn get_commitments(&self) -> Vec<C> {
@@ -64,7 +55,7 @@ impl<C: CurveGroup> CommittedInstanceOps<C> for CommittedInstance<C> {
     }
 }
 
-impl<C: CurveGroup> Inputize<C::ScalarField, CommittedInstanceVar<C>> for CommittedInstance<C> {
+impl<C: SonobeCurve> Inputize<C::ScalarField, CommittedInstanceVar<C>> for CommittedInstance<C> {
     fn inputize(&self) -> Vec<C::ScalarField> {
         [&[self.u][..], &self.x, &self.cmWE.inputize()].concat()
     }
@@ -73,12 +64,12 @@ impl<C: CurveGroup> Inputize<C::ScalarField, CommittedInstanceVar<C>> for Commit
 /// A Witness in Ova is represented by `w`. It also contains a blinder which can or not be used
 /// when committing to the witness itself.
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct Witness<C: CurveGroup> {
+pub struct Witness<C: SonobeCurve> {
     pub w: Vec<C::ScalarField>,
     pub rW: C::ScalarField,
 }
 
-impl<C: CurveGroup> Witness<C> {
+impl<C: SonobeCurve> Witness<C> {
     /// Generates a new `Witness` instance from a given witness vector.
     /// If `H = true`, then we assume we want to blind it at commitment time,
     /// hence sampling `rW` from the randomness passed.
@@ -111,7 +102,7 @@ impl<C: CurveGroup> Witness<C> {
     }
 }
 
-impl<C: CurveGroup> Dummy<&R1CS<CF1<C>>> for Witness<C> {
+impl<C: SonobeCurve> Dummy<&R1CS<CF1<C>>> for Witness<C> {
     fn dummy(r1cs: &R1CS<CF1<C>>) -> Self {
         Self {
             w: vec![C::ScalarField::zero(); r1cs.A.n_cols - 1 - r1cs.l],
@@ -122,7 +113,7 @@ impl<C: CurveGroup> Dummy<&R1CS<CF1<C>>> for Witness<C> {
 
 /// Implements the NIFS (Non-Interactive Folding Scheme) trait for Ova.
 pub struct NIFS<
-    C: CurveGroup,
+    C: SonobeCurve,
     CS: CommitmentScheme<C, H>,
     T: Transcript<C::ScalarField>,
     const H: bool = false,
@@ -132,11 +123,8 @@ pub struct NIFS<
     _t: PhantomData<T>,
 }
 
-impl<C: CurveGroup, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const H: bool>
+impl<C: SonobeCurve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const H: bool>
     NIFSTrait<C, CS, T, H> for NIFS<C, CS, T, H>
-where
-    C::ScalarField: Absorb,
-    <C as CurveGroup>::BaseField: PrimeField,
 {
     type CommittedInstance = CommittedInstance<C>;
     type Witness = Witness<C>;
@@ -241,7 +229,7 @@ where
 
 /// Computes the E parameter (error terms) for the given R1CS and the instance's z and u. This
 /// method is used by the verifier to obtain E in order to check the RelaxedR1CS relation.
-pub fn compute_E<C: CurveGroup>(
+pub fn compute_E<C: SonobeCurve>(
     r1cs: &R1CS<C::ScalarField>,
     z: &[C::ScalarField],
     u: C::ScalarField,
@@ -275,11 +263,11 @@ pub mod tests {
     // But since we don't hold `E` nor `e` within the NIFS, we create this structure to pass
     // `e` such that the check can be done.
     #[derive(Debug, Clone)]
-    pub(crate) struct TestingWitness<C: CurveGroup> {
+    pub(crate) struct TestingWitness<C: SonobeCurve> {
         pub(crate) w: Vec<C::ScalarField>,
         pub(crate) e: Vec<C::ScalarField>,
     }
-    impl<C: CurveGroup> Arith<TestingWitness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+    impl<C: SonobeCurve> Arith<TestingWitness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
         type Evaluation = Vec<CF1<C>>;
 
         fn eval_relation(

--- a/folding-schemes/src/folding/nova/nifs/ova_circuits.rs
+++ b/folding-schemes/src/folding/nova/nifs/ova_circuits.rs
@@ -1,11 +1,8 @@
 /// contains [Ova](https://hackmd.io/V4838nnlRKal9ZiTHiGYzw) NIFS related circuits
-use ark_crypto_primitives::sponge::{constraints::AbsorbGadget, Absorb, CryptographicSponge};
-use ark_ec::CurveGroup;
-use ark_ff::PrimeField;
+use ark_crypto_primitives::sponge::{constraints::AbsorbGadget, CryptographicSponge};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     boolean::Boolean,
-    convert::ToConstraintFieldGadget,
     eq::EqGadget,
     fields::{fp::FpVar, FieldVar},
     uint8::UInt8,
@@ -16,23 +13,24 @@ use core::{borrow::Borrow, marker::PhantomData};
 
 use super::ova::CommittedInstance;
 use super::NIFSGadgetTrait;
-use crate::folding::circuits::{nonnative::affine::NonNativeAffineVar, CF1};
 use crate::folding::traits::CommittedInstanceVarOps;
 use crate::transcript::TranscriptVar;
+use crate::{
+    folding::circuits::{nonnative::affine::NonNativeAffineVar, CF1},
+    transcript::AbsorbNonNativeGadget,
+};
 
 use crate::folding::nova::nifs::nova::ChallengeGadget;
+use crate::SonobeCurve;
 
 #[derive(Debug, Clone)]
-pub struct CommittedInstanceVar<C: CurveGroup> {
+pub struct CommittedInstanceVar<C: SonobeCurve> {
     pub u: FpVar<C::ScalarField>,
     pub x: Vec<FpVar<C::ScalarField>>,
     pub cmWE: NonNativeAffineVar<C>,
 }
 
-impl<C> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C>
-where
-    C: CurveGroup,
-{
+impl<C: SonobeCurve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C> {
     fn new_variable<T: Borrow<CommittedInstance<C>>>(
         cs: impl Into<Namespace<CF1<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -53,11 +51,7 @@ where
     }
 }
 
-impl<C> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C>
-where
-    C: CurveGroup,
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
-{
+impl<C: SonobeCurve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<C::ScalarField>>, SynthesisError> {
         FpVar::batch_to_sponge_bytes(&self.to_sponge_field_elements()?)
     }
@@ -66,13 +60,13 @@ where
         Ok([
             vec![self.u.clone()],
             self.x.clone(),
-            self.cmWE.to_constraint_field()?,
+            self.cmWE.to_native_sponge_field_elements()?,
         ]
         .concat())
     }
 }
 
-impl<C: CurveGroup> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
+impl<C: SonobeCurve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -95,7 +89,7 @@ impl<C: CurveGroup> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
 
 /// Implements the circuit that does the checks of the Non-Interactive Folding Scheme Verifier
 /// described of the Ova variant, where the cmWE check is delegated to the NIFSCycleFoldGadget.
-pub struct NIFSGadget<C: CurveGroup, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
+pub struct NIFSGadget<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
     _c: PhantomData<C>,
     _s: PhantomData<S>,
     _t: PhantomData<T>,
@@ -103,13 +97,9 @@ pub struct NIFSGadget<C: CurveGroup, S: CryptographicSponge, T: TranscriptVar<CF
 
 impl<C, S, T> NIFSGadgetTrait<C, S, T> for NIFSGadget<C, S, T>
 where
-    C: CurveGroup,
+    C: SonobeCurve,
     S: CryptographicSponge,
     T: TranscriptVar<CF1<C>, S>,
-    <C as ark_ec::CurveGroup>::BaseField: ark_ff::PrimeField,
-
-    C::ScalarField: Absorb,
-    <C as CurveGroup>::BaseField: PrimeField,
 {
     type CommittedInstance = CommittedInstance<C>;
     type CommittedInstanceVar = CommittedInstanceVar<C>;

--- a/folding-schemes/src/folding/nova/nifs/ova_circuits.rs
+++ b/folding-schemes/src/folding/nova/nifs/ova_circuits.rs
@@ -21,16 +21,16 @@ use crate::{
 };
 
 use crate::folding::nova::nifs::nova::ChallengeGadget;
-use crate::SonobeCurve;
+use crate::Curve;
 
 #[derive(Debug, Clone)]
-pub struct CommittedInstanceVar<C: SonobeCurve> {
+pub struct CommittedInstanceVar<C: Curve> {
     pub u: FpVar<C::ScalarField>,
     pub x: Vec<FpVar<C::ScalarField>>,
     pub cmWE: NonNativeAffineVar<C>,
 }
 
-impl<C: SonobeCurve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C> {
+impl<C: Curve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanceVar<C> {
     fn new_variable<T: Borrow<CommittedInstance<C>>>(
         cs: impl Into<Namespace<CF1<C>>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,
@@ -51,7 +51,7 @@ impl<C: SonobeCurve> AllocVar<CommittedInstance<C>, CF1<C>> for CommittedInstanc
     }
 }
 
-impl<C: SonobeCurve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
+impl<C: Curve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<C::ScalarField>>, SynthesisError> {
         FpVar::batch_to_sponge_bytes(&self.to_sponge_field_elements()?)
     }
@@ -66,7 +66,7 @@ impl<C: SonobeCurve> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C> {
     }
 }
 
-impl<C: SonobeCurve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
+impl<C: Curve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
     type PointVar = NonNativeAffineVar<C>;
 
     fn get_commitments(&self) -> Vec<Self::PointVar> {
@@ -89,7 +89,7 @@ impl<C: SonobeCurve> CommittedInstanceVarOps<C> for CommittedInstanceVar<C> {
 
 /// Implements the circuit that does the checks of the Non-Interactive Folding Scheme Verifier
 /// described of the Ova variant, where the cmWE check is delegated to the NIFSCycleFoldGadget.
-pub struct NIFSGadget<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
+pub struct NIFSGadget<C: Curve, S: CryptographicSponge, T: TranscriptVar<CF1<C>, S>> {
     _c: PhantomData<C>,
     _s: PhantomData<S>,
     _t: PhantomData<T>,
@@ -97,7 +97,7 @@ pub struct NIFSGadget<C: SonobeCurve, S: CryptographicSponge, T: TranscriptVar<C
 
 impl<C, S, T> NIFSGadgetTrait<C, S, T> for NIFSGadget<C, S, T>
 where
-    C: SonobeCurve,
+    C: Curve,
     S: CryptographicSponge,
     T: TranscriptVar<CF1<C>, S>,
 {

--- a/folding-schemes/src/folding/nova/nifs/pointvsline.rs
+++ b/folding-schemes/src/folding/nova/nifs/pointvsline.rs
@@ -7,32 +7,32 @@ use ark_std::{log2, Zero};
 use super::mova::{CommittedInstance, Witness};
 use crate::transcript::Transcript;
 use crate::utils::mle::dense_vec_to_dense_mle;
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// Implements the Points vs Line as described in
 /// [Mova](https://eprint.iacr.org/2024/1220.pdf) and Section 4.5.2 from Thaler’s book
 
 /// Claim from step 3 protocol 6
-pub struct PointvsLineEvaluationClaim<C: SonobeCurve> {
+pub struct PointvsLineEvaluationClaim<C: Curve> {
     pub mleE1_prime: C::ScalarField,
     pub mleE2_prime: C::ScalarField,
     pub rE_prime: Vec<C::ScalarField>,
 }
 /// Proof from step 1 protocol 6
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct PointVsLineProof<C: SonobeCurve> {
+pub struct PointVsLineProof<C: Curve> {
     pub h1: DensePolynomial<C::ScalarField>,
     pub h2: DensePolynomial<C::ScalarField>,
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct PointVsLine<C: SonobeCurve, T: Transcript<C::ScalarField>> {
+pub struct PointVsLine<C: Curve, T: Transcript<C::ScalarField>> {
     _phantom_C: std::marker::PhantomData<C>,
     _phantom_T: std::marker::PhantomData<T>,
 }
 
 /// Protocol 6 from Mova
-impl<C: SonobeCurve, T: Transcript<C::ScalarField>> PointVsLine<C, T> {
+impl<C: Curve, T: Transcript<C::ScalarField>> PointVsLine<C, T> {
     pub fn prove(
         transcript: &mut T,
         ci1: &CommittedInstance<C>,

--- a/folding-schemes/src/folding/nova/nifs/pointvsline.rs
+++ b/folding-schemes/src/folding/nova/nifs/pointvsline.rs
@@ -1,5 +1,3 @@
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
 use ark_ff::{One, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{DenseMultilinearExtension, DenseUVPolynomial, Polynomial};
@@ -9,35 +7,32 @@ use ark_std::{log2, Zero};
 use super::mova::{CommittedInstance, Witness};
 use crate::transcript::Transcript;
 use crate::utils::mle::dense_vec_to_dense_mle;
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 /// Implements the Points vs Line as described in
 /// [Mova](https://eprint.iacr.org/2024/1220.pdf) and Section 4.5.2 from Thaler’s book
 
 /// Claim from step 3 protocol 6
-pub struct PointvsLineEvaluationClaim<C: CurveGroup> {
+pub struct PointvsLineEvaluationClaim<C: SonobeCurve> {
     pub mleE1_prime: C::ScalarField,
     pub mleE2_prime: C::ScalarField,
     pub rE_prime: Vec<C::ScalarField>,
 }
 /// Proof from step 1 protocol 6
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
-pub struct PointVsLineProof<C: CurveGroup> {
+pub struct PointVsLineProof<C: SonobeCurve> {
     pub h1: DensePolynomial<C::ScalarField>,
     pub h2: DensePolynomial<C::ScalarField>,
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct PointVsLine<C: CurveGroup, T: Transcript<C::ScalarField>> {
+pub struct PointVsLine<C: SonobeCurve, T: Transcript<C::ScalarField>> {
     _phantom_C: std::marker::PhantomData<C>,
     _phantom_T: std::marker::PhantomData<T>,
 }
 
 /// Protocol 6 from Mova
-impl<C: CurveGroup, T: Transcript<C::ScalarField>> PointVsLine<C, T>
-where
-    C::ScalarField: Absorb,
-{
+impl<C: SonobeCurve, T: Transcript<C::ScalarField>> PointVsLine<C, T> {
     pub fn prove(
         transcript: &mut T,
         ci1: &CommittedInstance<C>,

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -12,7 +12,7 @@ use crate::arith::{
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::utils::gadgets::{EquivalenceGadget, VectorGadget};
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 /// Implements `Arith` for R1CS, where the witness is of type [`Witness`], and
 /// the committed instance is of type [`CommittedInstance`].
@@ -41,7 +41,7 @@ use crate::{Error, SonobeCurve};
 /// For R1CS, whether it is relaxed or not is now determined by the types of `W`
 /// and `U`: the satisfiability check is relaxed if `W` and `U` are defined by
 /// folding schemes, and plain if they are vectors of field elements.
-impl<C: SonobeCurve> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+impl<C: Curve> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     fn eval_relation(
@@ -61,7 +61,7 @@ impl<C: SonobeCurve> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     }
 }
 
-impl<C: SonobeCurve> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+impl<C: Curve> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     fn sample_witness_instance<CS: CommitmentScheme<C, true>>(
         &self,
         params: &CS::ProverParams,
@@ -102,7 +102,7 @@ impl<C: SonobeCurve> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<
     }
 }
 
-impl<C: SonobeCurve> ArithGadget<WitnessVar<C>, CommittedInstanceVar<C>>
+impl<C: Curve> ArithGadget<WitnessVar<C>, CommittedInstanceVar<C>>
     for R1CSMatricesVar<C::ScalarField, FpVar<C::ScalarField>>
 {
     type Evaluation = (Vec<FpVar<C::ScalarField>>, Vec<FpVar<C::ScalarField>>);

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -1,4 +1,3 @@
-use ark_ec::CurveGroup;
 use ark_r1cs_std::fields::fp::FpVar;
 use ark_relations::r1cs::SynthesisError;
 use ark_std::{rand::RngCore, UniformRand};
@@ -13,7 +12,7 @@ use crate::arith::{
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::utils::gadgets::{EquivalenceGadget, VectorGadget};
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 /// Implements `Arith` for R1CS, where the witness is of type [`Witness`], and
 /// the committed instance is of type [`CommittedInstance`].
@@ -42,7 +41,7 @@ use crate::Error;
 /// For R1CS, whether it is relaxed or not is now determined by the types of `W`
 /// and `U`: the satisfiability check is relaxed if `W` and `U` are defined by
 /// folding schemes, and plain if they are vectors of field elements.
-impl<C: CurveGroup> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+impl<C: SonobeCurve> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     fn eval_relation(
@@ -62,7 +61,7 @@ impl<C: CurveGroup> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     }
 }
 
-impl<C: CurveGroup> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+impl<C: SonobeCurve> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     fn sample_witness_instance<CS: CommitmentScheme<C, true>>(
         &self,
         params: &CS::ProverParams,
@@ -103,7 +102,7 @@ impl<C: CurveGroup> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<C
     }
 }
 
-impl<C: CurveGroup> ArithGadget<WitnessVar<C>, CommittedInstanceVar<C>>
+impl<C: SonobeCurve> ArithGadget<WitnessVar<C>, CommittedInstanceVar<C>>
     for R1CSMatricesVar<C::ScalarField, FpVar<C::ScalarField>>
 {
     type Evaluation = (Vec<FpVar<C::ScalarField>>, Vec<FpVar<C::ScalarField>>);

--- a/folding-schemes/src/folding/nova/zk.rs
+++ b/folding-schemes/src/folding/nova/zk.rs
@@ -45,10 +45,10 @@ use crate::{
     commitment::CommitmentScheme,
     folding::traits::CommittedInstanceOps,
     frontend::FCircuit,
-    Error, SonobeCurve,
+    Curve, Error,
 };
 
-pub struct RandomizedIVCProof<C1: SonobeCurve, C2: SonobeCurve> {
+pub struct RandomizedIVCProof<C1: Curve, C2: Curve> {
     pub U_i: CommittedInstance<C1>,
     pub u_i: CommittedInstance<C1>,
     pub U_r: CommittedInstance<C1>,
@@ -59,7 +59,7 @@ pub struct RandomizedIVCProof<C1: SonobeCurve, C2: SonobeCurve> {
     pub cf_W_i: Witness<C2>,
 }
 
-impl<C1: SonobeCurve, C2: SonobeCurve> RandomizedIVCProof<C1, C2> {
+impl<C1: Curve, C2: Curve> RandomizedIVCProof<C1, C2> {
     /// Compute a zero-knowledge proof of a Nova IVC proof
     /// It implements the prover of appendix D.4.in https://eprint.iacr.org/2023/573.pdf
     /// For further details on why folding is hiding, see lemma 9
@@ -130,7 +130,7 @@ impl<C1: SonobeCurve, C2: SonobeCurve> RandomizedIVCProof<C1, C2> {
         proof: &RandomizedIVCProof<C1, C2>,
     ) -> Result<(), Error>
     where
-        C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+        C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     {
         // Handles case where i=0
         if i == C1::ScalarField::zero() {

--- a/folding-schemes/src/folding/nova/zk.rs
+++ b/folding-schemes/src/folding/nova/zk.rs
@@ -30,29 +30,25 @@
 /// paper).
 /// And the Use-case-2 would require a modified version of the Decider circuits.
 ///
-use ark_ff::PrimeField;
-use ark_std::{One, Zero};
-
-use crate::{
-    arith::{r1cs::R1CS, Arith, ArithSampler},
-    folding::traits::CommittedInstanceOps,
-    RngCore,
-};
 use ark_crypto_primitives::sponge::{
     poseidon::{PoseidonConfig, PoseidonSponge},
-    Absorb, CryptographicSponge,
+    CryptographicSponge,
 };
-use ark_ec::CurveGroup;
-use ark_r1cs_std::groups::CurveVar;
-
-use crate::{commitment::CommitmentScheme, folding::circuits::CF2, frontend::FCircuit, Error};
+use ark_std::{rand::RngCore, One, Zero};
 
 use super::{
     nifs::{nova::NIFS, NIFSTrait},
     CommittedInstance, Nova, Witness,
 };
+use crate::{
+    arith::{r1cs::R1CS, Arith, ArithSampler},
+    commitment::CommitmentScheme,
+    folding::traits::CommittedInstanceOps,
+    frontend::FCircuit,
+    Error, SonobeCurve,
+};
 
-pub struct RandomizedIVCProof<C1: CurveGroup, C2: CurveGroup> {
+pub struct RandomizedIVCProof<C1: SonobeCurve, C2: SonobeCurve> {
     pub U_i: CommittedInstance<C1>,
     pub u_i: CommittedInstance<C1>,
     pub U_r: CommittedInstance<C1>,
@@ -63,32 +59,18 @@ pub struct RandomizedIVCProof<C1: CurveGroup, C2: CurveGroup> {
     pub cf_W_i: Witness<C2>,
 }
 
-impl<C1: CurveGroup, C2: CurveGroup> RandomizedIVCProof<C1, C2>
-where
-    C1::ScalarField: Absorb,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-{
+impl<C1: SonobeCurve, C2: SonobeCurve> RandomizedIVCProof<C1, C2> {
     /// Compute a zero-knowledge proof of a Nova IVC proof
     /// It implements the prover of appendix D.4.in https://eprint.iacr.org/2023/573.pdf
     /// For further details on why folding is hiding, see lemma 9
     pub fn new<
-        GC1: CurveVar<C1, CF2<C1>>,
-        GC2: CurveVar<C2, CF2<C2>>,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, true>,
         CS2: CommitmentScheme<C2, true>,
     >(
-        nova: &Nova<C1, GC1, C2, GC2, FC, CS1, CS2, true>,
+        nova: &Nova<C1, C2, FC, CS1, CS2, true>,
         mut rng: impl RngCore,
-    ) -> Result<RandomizedIVCProof<C1, C2>, Error>
-    where
-        C1::ScalarField: Absorb,
-        C2::ScalarField: Absorb,
-        C2::ScalarField: PrimeField,
-        <C2 as CurveGroup>::BaseField: PrimeField,
-        <C2 as CurveGroup>::BaseField: Absorb,
-        C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    {
+    ) -> Result<RandomizedIVCProof<C1, C2>, Error> {
         let mut transcript = PoseidonSponge::<C1::ScalarField>::new(&nova.poseidon_config);
 
         // I. Compute proof for 'regular' instances
@@ -137,11 +119,7 @@ where
     /// Verify a zero-knowledge proof of a Nova IVC proof
     /// It implements the verifier of appendix D.4. in https://eprint.iacr.org/2023/573.pdf
     #[allow(clippy::too_many_arguments)]
-    pub fn verify<
-        CS1: CommitmentScheme<C1, true>,
-        GC2: CurveVar<C2, CF2<C2>>,
-        CS2: CommitmentScheme<C2, true>,
-    >(
+    pub fn verify<CS1: CommitmentScheme<C1, true>, CS2: CommitmentScheme<C2, true>>(
         r1cs: &R1CS<C1::ScalarField>,
         cf_r1cs: &R1CS<C2::ScalarField>,
         pp_hash: C1::ScalarField,
@@ -152,11 +130,7 @@ where
         proof: &RandomizedIVCProof<C1, C2>,
     ) -> Result<(), Error>
     where
-        C1::ScalarField: Absorb,
-        C2::ScalarField: Absorb,
-        <C2 as CurveGroup>::BaseField: PrimeField,
-        <C2 as CurveGroup>::BaseField: Absorb,
-        C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+        C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     {
         // Handles case where i=0
         if i == C1::ScalarField::zero() {
@@ -227,7 +201,7 @@ pub mod tests {
     use crate::frontend::utils::CubicFCircuit;
     use crate::transcript::poseidon::poseidon_canonical_config;
     use ark_bn254::{Fr, G1Projective as Projective};
-    use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_grumpkin::Projective as Projective2;
     use rand::rngs::OsRng;
 
     // Tests zk proof generation and verification for a valid nova IVC proof
@@ -243,20 +217,17 @@ pub mod tests {
         >(poseidon_config.clone(), F_circuit, 3)?;
 
         let proof = RandomizedIVCProof::new(&nova, &mut rng)?;
-        let verify = RandomizedIVCProof::verify::<
-            Pedersen<Projective, true>,
-            GVar2,
-            Pedersen<Projective2, true>,
-        >(
-            &nova.r1cs,
-            &nova.cf_r1cs,
-            nova.pp_hash,
-            &nova.poseidon_config,
-            nova.i,
-            nova.z_0,
-            nova.z_i,
-            &proof,
-        );
+        let verify =
+            RandomizedIVCProof::verify::<Pedersen<Projective, true>, Pedersen<Projective2, true>>(
+                &nova.r1cs,
+                &nova.cf_r1cs,
+                nova.pp_hash,
+                &nova.poseidon_config,
+                nova.i,
+                nova.z_0,
+                nova.z_i,
+                &proof,
+            );
         assert!(verify.is_ok());
         Ok(())
     }
@@ -273,20 +244,17 @@ pub mod tests {
         >(poseidon_config.clone(), F_circuit, 0)?;
 
         let proof = RandomizedIVCProof::new(&nova, &mut rng)?;
-        let verify = RandomizedIVCProof::verify::<
-            Pedersen<Projective, true>,
-            GVar2,
-            Pedersen<Projective2, true>,
-        >(
-            &nova.r1cs,
-            &nova.cf_r1cs,
-            nova.pp_hash,
-            &nova.poseidon_config,
-            nova.i,
-            nova.z_0,
-            nova.z_i,
-            &proof,
-        );
+        let verify =
+            RandomizedIVCProof::verify::<Pedersen<Projective, true>, Pedersen<Projective2, true>>(
+                &nova.r1cs,
+                &nova.cf_r1cs,
+                nova.pp_hash,
+                &nova.poseidon_config,
+                nova.i,
+                nova.z_0,
+                nova.z_i,
+                &proof,
+            );
         assert!(verify.is_ok());
         Ok(())
     }
@@ -310,20 +278,17 @@ pub mod tests {
         nova_with_incorrect_running_instance.U_i = sampled_committed_instance;
         let incorrect_proof =
             RandomizedIVCProof::new(&nova_with_incorrect_running_instance, &mut rng)?;
-        let verify = RandomizedIVCProof::verify::<
-            Pedersen<Projective, true>,
-            GVar2,
-            Pedersen<Projective2, true>,
-        >(
-            &nova_with_incorrect_running_instance.r1cs,
-            &nova_with_incorrect_running_instance.cf_r1cs,
-            nova_with_incorrect_running_instance.pp_hash,
-            &nova_with_incorrect_running_instance.poseidon_config,
-            nova_with_incorrect_running_instance.i,
-            nova_with_incorrect_running_instance.z_0,
-            nova_with_incorrect_running_instance.z_i,
-            &incorrect_proof,
-        );
+        let verify =
+            RandomizedIVCProof::verify::<Pedersen<Projective, true>, Pedersen<Projective2, true>>(
+                &nova_with_incorrect_running_instance.r1cs,
+                &nova_with_incorrect_running_instance.cf_r1cs,
+                nova_with_incorrect_running_instance.pp_hash,
+                &nova_with_incorrect_running_instance.poseidon_config,
+                nova_with_incorrect_running_instance.i,
+                nova_with_incorrect_running_instance.z_0,
+                nova_with_incorrect_running_instance.z_i,
+                &incorrect_proof,
+            );
         assert!(verify.is_err());
         Ok(())
     }
@@ -347,20 +312,17 @@ pub mod tests {
         nova_with_incorrect_running_witness.W_i = sampled_committed_witness;
         let incorrect_proof =
             RandomizedIVCProof::new(&nova_with_incorrect_running_witness, &mut rng)?;
-        let verify = RandomizedIVCProof::verify::<
-            Pedersen<Projective, true>,
-            GVar2,
-            Pedersen<Projective2, true>,
-        >(
-            &nova_with_incorrect_running_witness.r1cs,
-            &nova_with_incorrect_running_witness.cf_r1cs,
-            nova_with_incorrect_running_witness.pp_hash,
-            &nova_with_incorrect_running_witness.poseidon_config,
-            nova_with_incorrect_running_witness.i,
-            nova_with_incorrect_running_witness.z_0,
-            nova_with_incorrect_running_witness.z_i,
-            &incorrect_proof,
-        );
+        let verify =
+            RandomizedIVCProof::verify::<Pedersen<Projective, true>, Pedersen<Projective2, true>>(
+                &nova_with_incorrect_running_witness.r1cs,
+                &nova_with_incorrect_running_witness.cf_r1cs,
+                nova_with_incorrect_running_witness.pp_hash,
+                &nova_with_incorrect_running_witness.poseidon_config,
+                nova_with_incorrect_running_witness.i,
+                nova_with_incorrect_running_witness.z_0,
+                nova_with_incorrect_running_witness.z_i,
+                &incorrect_proof,
+            );
         assert!(verify.is_err());
         Ok(())
     }

--- a/folding-schemes/src/folding/protogalaxy/circuits.rs
+++ b/folding-schemes/src/folding/protogalaxy/circuits.rs
@@ -38,14 +38,14 @@ use crate::{
     frontend::FCircuit,
     transcript::{AbsorbNonNativeGadget, TranscriptVar},
     utils::gadgets::VectorGadget,
-    SonobeCurve,
+    Curve,
 };
 
 pub struct FoldingGadget {}
 
 impl FoldingGadget {
     #[allow(clippy::type_complexity)]
-    pub fn fold_committed_instance<C: SonobeCurve, S: CryptographicSponge>(
+    pub fn fold_committed_instance<C: Curve, S: CryptographicSponge>(
         transcript: &mut impl TranscriptVar<C::ScalarField, S>,
         // running instance
         instance: &CommittedInstanceVar<C, true>,
@@ -135,7 +135,7 @@ pub struct AugmentationGadget;
 
 impl AugmentationGadget {
     #[allow(clippy::type_complexity)]
-    pub fn prepare_and_fold_primary<C: SonobeCurve, S: CryptographicSponge>(
+    pub fn prepare_and_fold_primary<C: Curve, S: CryptographicSponge>(
         transcript: &mut impl TranscriptVar<CF1<C>, S>,
         U: CommittedInstanceVar<C, true>,
         u_phis: Vec<NonNativeAffineVar<C>>,
@@ -171,8 +171,8 @@ impl AugmentationGadget {
     }
 
     pub fn prepare_and_fold_cyclefold<
-        C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-        C2: SonobeCurve,
+        C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+        C2: Curve,
         S: CryptographicSponge,
     >(
         transcript: &mut PoseidonSpongeVar<CF1<C1>>,
@@ -231,7 +231,7 @@ impl AugmentationGadget {
 /// defined in [CycleFold](https://eprint.iacr.org/2023/1192.pdf). These extra
 /// constraints verify the correct folding of CycleFold instances.
 #[derive(Debug, Clone)]
-pub struct AugmentedFCircuit<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> {
+pub struct AugmentedFCircuit<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> {
     pub(super) poseidon_config: PoseidonConfig<CF1<C1>>,
     pub(super) pp_hash: CF1<C1>,
     pub(super) i: CF1<C1>,
@@ -255,7 +255,7 @@ pub struct AugmentedFCircuit<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<
     pub(super) cf2_cmT: C2,
 }
 
-impl<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<C1, C2, FC> {
+impl<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<C1, C2, FC> {
     pub fn empty(
         poseidon_config: &PoseidonConfig<CF1<C1>>,
         F_circuit: FC,
@@ -294,8 +294,8 @@ impl<C1: SonobeCurve, C2: SonobeCurve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<
 
 impl<C1, C2, FC> AugmentedFCircuit<C1, C2, FC>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<CF1<C1>>,
 {
     pub fn compute_next_state(
@@ -473,8 +473,8 @@ where
 
 impl<C1, C2, FC> ConstraintSynthesizer<CF1<C1>> for AugmentedFCircuit<C1, C2, FC>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<CF1<C1>>,
 {
     fn generate_constraints(self, cs: ConstraintSystemRef<CF1<C1>>) -> Result<(), SynthesisError> {

--- a/folding-schemes/src/folding/protogalaxy/decider_eth.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth.rs
@@ -14,7 +14,7 @@ pub use super::decider_eth_circuit::DeciderEthCircuit;
 use super::decider_eth_circuit::DeciderProtoGalaxyGadget;
 use super::ProtoGalaxy;
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
-use crate::folding::traits::{Inputize, WitnessOps};
+use crate::folding::traits::{InputizeNonNative, WitnessOps};
 use crate::frontend::FCircuit;
 use crate::Error;
 use crate::{
@@ -209,10 +209,7 @@ where
             &[pp_hash, i][..],
             &z_0,
             &z_i,
-            &U_final_commitments
-                .iter()
-                .flat_map(|c| c.inputize())
-                .collect::<Vec<_>>(),
+            &U_final_commitments.inputize_nonnative(),
             &proof.kzg_challenges,
             &proof.kzg_proofs.iter().map(|p| p.eval).collect::<Vec<_>>(),
             &proof.L_X_evals,

--- a/folding-schemes/src/folding/protogalaxy/decider_eth.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth.rs
@@ -2,10 +2,6 @@
 /// the Decider from decider.rs file will be more efficient.
 /// More details can be found at the documentation page:
 /// https://privacy-scaling-explorations.github.io/sonobe-docs/design/nova-decider-onchain.html
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
-use ark_ff::PrimeField;
-use ark_r1cs_std::prelude::CurveVar;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
 use ark_std::{
@@ -17,20 +13,20 @@ use ark_std::{
 pub use super::decider_eth_circuit::DeciderEthCircuit;
 use super::decider_eth_circuit::DeciderProtoGalaxyGadget;
 use super::ProtoGalaxy;
-use crate::commitment::{
-    kzg::Proof as KZGProof, pedersen::Params as PedersenParams, CommitmentScheme,
-};
 use crate::folding::circuits::decider::DeciderEnabledNIFS;
-use crate::folding::circuits::CF2;
 use crate::folding::traits::{Inputize, WitnessOps};
 use crate::frontend::FCircuit;
 use crate::Error;
+use crate::{
+    commitment::{kzg::Proof as KZGProof, pedersen::Params as PedersenParams, CommitmentScheme},
+    SonobeCurve,
+};
 use crate::{Decider as DeciderTrait, FoldingScheme};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C, CS, S>
 where
-    C: CurveGroup,
+    C: SonobeCurve,
     CS: CommitmentScheme<C, ProverChallenge = C::ScalarField, Challenge = C::ScalarField>,
     S: SNARK<C::ScalarField>,
 {
@@ -45,7 +41,7 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierParam<C1, CS_VerifyingKey, S_VerifyingKey>
 where
-    C1: CurveGroup,
+    C1: SonobeCurve,
     CS_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     S_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
 {
@@ -56,11 +52,9 @@ where
 
 /// Onchain Decider, for ethereum use cases
 #[derive(Clone, Debug)]
-pub struct Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS> {
+pub struct Decider<C1, C2, FC, CS1, CS2, S, FS> {
     _c1: PhantomData<C1>,
-    _gc1: PhantomData<GC1>,
     _c2: PhantomData<C2>,
-    _gc2: PhantomData<GC2>,
     _fc: PhantomData<FC>,
     _cs1: PhantomData<CS1>,
     _cs2: PhantomData<CS2>,
@@ -68,13 +62,11 @@ pub struct Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS> {
     _fs: PhantomData<FS>,
 }
 
-impl<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS> DeciderTrait<C1, C2, FC, FS>
-    for Decider<C1, GC1, C2, GC2, FC, CS1, CS2, S, FS>
+impl<C1, C2, FC, CS1, CS2, S, FS> DeciderTrait<C1, C2, FC, FS>
+    for Decider<C1, C2, FC, CS1, CS2, S, FS>
 where
-    C1: CurveGroup,
-    GC1: CurveVar<C1, CF2<C1>>,
-    C2: CurveGroup,
-    GC2: CurveVar<C2, CF2<C2>>,
+    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: SonobeCurve,
     FC: FCircuit<C1::ScalarField>,
     // CS1 is a KZG commitment, where challenge is C1::Fr elem
     CS1: CommitmentScheme<
@@ -87,13 +79,8 @@ where
     CS2: CommitmentScheme<C2, ProverParams = PedersenParams<C2>>,
     S: SNARK<C1::ScalarField>,
     FS: FoldingScheme<C1, C2, FC>,
-    <C1 as CurveGroup>::BaseField: PrimeField,
-    <C2 as CurveGroup>::BaseField: PrimeField,
-    C1::ScalarField: Absorb,
-    C2::ScalarField: Absorb,
-    C1: CurveGroup<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
     // constrain FS into ProtoGalaxy, since this is a Decider specifically for ProtoGalaxy
-    ProtoGalaxy<C1, GC1, C2, GC2, FC, CS1, CS2>: From<FS>,
+    ProtoGalaxy<C1, C2, FC, CS1, CS2>: From<FS>,
     crate::folding::protogalaxy::ProverParams<C1, C2, CS1, CS2>:
         From<<FS as FoldingScheme<C1, C2, FC>>::ProverParam>,
     crate::folding::protogalaxy::VerifierParams<C1, C2, CS1, CS2>:
@@ -111,7 +98,7 @@ where
         prep_param: Self::PreprocessorParam,
         fs: FS,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
-        let circuit = DeciderEthCircuit::<C1, C2, GC2>::try_from(ProtoGalaxy::from(fs))?;
+        let circuit = DeciderEthCircuit::<C1, C2>::try_from(ProtoGalaxy::from(fs))?;
 
         // get the Groth16 specific setup for the circuit
         let (g16_pk, g16_vk) = S::circuit_specific_setup(circuit, &mut rng)
@@ -119,13 +106,13 @@ where
 
         // get the FoldingScheme prover & verifier params from ProtoGalaxy
         #[allow(clippy::type_complexity)]
-        let protogalaxy_pp: <ProtoGalaxy<C1, GC1, C2, GC2, FC, CS1, CS2> as FoldingScheme<
+        let protogalaxy_pp: <ProtoGalaxy<C1, C2, FC, CS1, CS2> as FoldingScheme<
             C1,
             C2,
             FC,
         >>::ProverParam = prep_param.0.clone().into();
         #[allow(clippy::type_complexity)]
-        let protogalaxy_vp: <ProtoGalaxy<C1, GC1, C2, GC2, FC, CS1, CS2> as FoldingScheme<
+        let protogalaxy_vp: <ProtoGalaxy<C1, C2, FC, CS1, CS2> as FoldingScheme<
             C1,
             C2,
             FC,
@@ -148,8 +135,7 @@ where
     ) -> Result<Self::Proof, Error> {
         let (snark_pk, cs_pk): (S::ProvingKey, CS1::ProverParams) = pp;
 
-        let circuit =
-            DeciderEthCircuit::<C1, C2, GC2>::try_from(ProtoGalaxy::from(folding_scheme))?;
+        let circuit = DeciderEthCircuit::<C1, C2>::try_from(ProtoGalaxy::from(folding_scheme))?;
 
         let L_X_evals = circuit.randomness.clone();
 
@@ -256,9 +242,9 @@ where
 #[cfg(test)]
 pub mod tests {
     use ark_bn254::Bn254;
-    use ark_bn254::{constraints::GVar, Fr, G1Projective as Projective};
+    use ark_bn254::{Fr, G1Projective as Projective};
     use ark_groth16::Groth16;
-    use ark_grumpkin::{constraints::GVar as GVar2, Projective as Projective2};
+    use ark_grumpkin::Projective as Projective2;
     use std::time::Instant;
 
     use super::*;
@@ -275,18 +261,14 @@ pub mod tests {
         // use ProtoGalaxy as FoldingScheme
         type PG = ProtoGalaxy<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
         >;
         type D = Decider<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
@@ -354,18 +336,14 @@ pub mod tests {
         // use ProtoGalaxy as FoldingScheme
         type PG = ProtoGalaxy<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,
         >;
         type D = Decider<
             Projective,
-            GVar,
             Projective2,
-            GVar2,
             CubicFCircuit<Fr>,
             KZG<'static, Bn254>,
             Pedersen<Projective2>,

--- a/folding-schemes/src/folding/protogalaxy/decider_eth.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth.rs
@@ -19,14 +19,14 @@ use crate::frontend::FCircuit;
 use crate::Error;
 use crate::{
     commitment::{kzg::Proof as KZGProof, pedersen::Params as PedersenParams, CommitmentScheme},
-    SonobeCurve,
+    Curve,
 };
 use crate::{Decider as DeciderTrait, FoldingScheme};
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct Proof<C, CS, S>
 where
-    C: SonobeCurve,
+    C: Curve,
     CS: CommitmentScheme<C, ProverChallenge = C::ScalarField, Challenge = C::ScalarField>,
     S: SNARK<C::ScalarField>,
 {
@@ -41,7 +41,7 @@ where
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct VerifierParam<C1, CS_VerifyingKey, S_VerifyingKey>
 where
-    C1: SonobeCurve,
+    C1: Curve,
     CS_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
     S_VerifyingKey: Clone + CanonicalSerialize + CanonicalDeserialize,
 {
@@ -65,8 +65,8 @@ pub struct Decider<C1, C2, FC, CS1, CS2, S, FS> {
 impl<C1, C2, FC, CS1, CS2, S, FS> DeciderTrait<C1, C2, FC, FS>
     for Decider<C1, C2, FC, CS1, CS2, S, FS>
 where
-    C1: SonobeCurve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-    C2: SonobeCurve,
+    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
+    C2: Curve,
     FC: FCircuit<C1::ScalarField>,
     // CS1 is a KZG commitment, where challenge is C1::Fr elem
     CS1: CommitmentScheme<

--- a/folding-schemes/src/folding/protogalaxy/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth_circuit.rs
@@ -28,7 +28,7 @@ use crate::{
         traits::{WitnessOps, WitnessVarOps},
     },
     frontend::FCircuit,
-    Error, SonobeCurve,
+    Curve, Error,
 };
 
 use super::{
@@ -81,8 +81,8 @@ pub type DeciderEthCircuit<C1, C2> = GenericOnchainDeciderCircuit<
 
 /// returns an instance of the DeciderEthCircuit from the given ProtoGalaxy struct
 impl<
-        C1: SonobeCurve,
-        C2: SonobeCurve,
+        C1: Curve,
+        C2: Curve,
         FC: FCircuit<C1::ScalarField>,
         CS1: CommitmentScheme<C1, false>,
         // enforce that the CS2 is Pedersen commitment scheme, since we're at Ethereum's EVM decider
@@ -142,7 +142,7 @@ impl<
 
 pub struct DeciderProtoGalaxyGadget;
 
-impl<C: SonobeCurve>
+impl<C: Curve>
     DeciderEnabledNIFS<
         C,
         CommittedInstance<C, RUNNING>,

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -16,7 +16,7 @@ use crate::folding::traits::Dummy;
 use crate::transcript::Transcript;
 use crate::utils::vec::*;
 use crate::Error;
-use crate::{arith::r1cs::R1CS, SonobeCurve};
+use crate::{arith::r1cs::R1CS, Curve};
 
 #[derive(Debug, Clone)]
 pub struct ProtoGalaxyProof<F: PrimeField> {
@@ -34,7 +34,7 @@ impl<F: PrimeField> Dummy<(usize, usize, usize)> for ProtoGalaxyProof<F> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ProtoGalaxyAux<C: SonobeCurve> {
+pub struct ProtoGalaxyAux<C: Curve> {
     pub L_X_evals: Vec<C::ScalarField>,
     pub phi_stars: Vec<C>,
 }
@@ -42,10 +42,10 @@ pub struct ProtoGalaxyAux<C: SonobeCurve> {
 #[derive(Clone, Debug)]
 /// Implements the protocol described in section 4 of
 /// [ProtoGalaxy](https://eprint.iacr.org/2023/1106.pdf)
-pub struct Folding<C: SonobeCurve> {
+pub struct Folding<C: Curve> {
     _phantom: PhantomData<C>,
 }
-impl<C: SonobeCurve> Folding<C> {
+impl<C: Curve> Folding<C> {
     #![allow(clippy::type_complexity)]
     /// implements the non-interactive Prover from the folding scheme described in section 4
     pub fn prove(
@@ -429,7 +429,7 @@ pub mod tests {
 
     // k represents the number of instances to be fold, apart from the running instance
     #[allow(clippy::type_complexity)]
-    pub fn prepare_inputs<C: SonobeCurve>(
+    pub fn prepare_inputs<C: Curve>(
         k: usize,
     ) -> Result<
         (

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -1,6 +1,4 @@
 /// Implements the scheme described in [ProtoGalaxy](https://eprint.iacr.org/2023/1106.pdf)
-use ark_crypto_primitives::sponge::Absorb;
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
 use ark_poly::{
     univariate::{DensePolynomial, SparsePolynomial},
@@ -14,11 +12,11 @@ use super::utils::{all_powers, betas_star, exponential_powers, pow_i};
 use super::ProtoGalaxyError;
 use super::{CommittedInstance, Witness};
 
-use crate::arith::r1cs::R1CS;
 use crate::folding::traits::Dummy;
 use crate::transcript::Transcript;
 use crate::utils::vec::*;
 use crate::Error;
+use crate::{arith::r1cs::R1CS, SonobeCurve};
 
 #[derive(Debug, Clone)]
 pub struct ProtoGalaxyProof<F: PrimeField> {
@@ -36,7 +34,7 @@ impl<F: PrimeField> Dummy<(usize, usize, usize)> for ProtoGalaxyProof<F> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ProtoGalaxyAux<C: CurveGroup> {
+pub struct ProtoGalaxyAux<C: SonobeCurve> {
     pub L_X_evals: Vec<C::ScalarField>,
     pub phi_stars: Vec<C>,
 }
@@ -44,13 +42,10 @@ pub struct ProtoGalaxyAux<C: CurveGroup> {
 #[derive(Clone, Debug)]
 /// Implements the protocol described in section 4 of
 /// [ProtoGalaxy](https://eprint.iacr.org/2023/1106.pdf)
-pub struct Folding<C: CurveGroup> {
+pub struct Folding<C: SonobeCurve> {
     _phantom: PhantomData<C>,
 }
-impl<C: CurveGroup> Folding<C>
-where
-    C::ScalarField: Absorb,
-{
+impl<C: SonobeCurve> Folding<C> {
     #![allow(clippy::type_complexity)]
     /// implements the non-interactive Prover from the folding scheme described in section 4
     pub fn prove(
@@ -434,7 +429,7 @@ pub mod tests {
 
     // k represents the number of instances to be fold, apart from the running instance
     #[allow(clippy::type_complexity)]
-    pub fn prepare_inputs<C: CurveGroup>(
+    pub fn prepare_inputs<C: SonobeCurve>(
         k: usize,
     ) -> Result<
         (

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -884,7 +884,7 @@ where
             };
 
             // fold self.cf_U_i + cf1_U -> folded running with cf1
-            let (_cf1_w_i, cf1_u_i, cf1_W_i1, cf1_U_i1, cf1_cmT, _) = self.fold_cyclefold_circuit(
+            let (cf1_u_i, cf1_W_i1, cf1_U_i1, cf1_cmT) = self.fold_cyclefold_circuit(
                 &mut transcript_prover,
                 self.cf_W_i.clone(), // CycleFold running instance witness
                 self.cf_U_i.clone(), // CycleFold running instance
@@ -892,7 +892,7 @@ where
                 &mut rng,
             )?;
             // fold [the output from folding self.cf_U_i + cf1_U] + cf2_U = folded_running_with_cf1 + cf2
-            let (_cf2_w_i, cf2_u_i, cf_W_i1, cf_U_i1, cf2_cmT, _) = self.fold_cyclefold_circuit(
+            let (cf2_u_i, cf_W_i1, cf_U_i1, cf2_cmT) = self.fold_cyclefold_circuit(
                 &mut transcript_prover,
                 cf1_W_i1,
                 cf1_U_i1.clone(),
@@ -935,11 +935,6 @@ where
                     )?,
                     U_i1
                 );
-                cf1_u_i.check_incoming()?;
-                cf2_u_i.check_incoming()?;
-                self.cf_r1cs.check_relation(&_cf1_w_i, &cf1_u_i)?;
-                self.cf_r1cs.check_relation(&_cf2_w_i, &cf2_u_i)?;
-                self.cf_r1cs.check_relation(&self.cf_W_i, &self.cf_U_i)?;
             }
 
             self.W_i = W_i1;
@@ -1106,16 +1101,14 @@ where
         rng: &mut impl RngCore,
     ) -> Result<
         (
-            CycleFoldWitness<C2>,
             CycleFoldCommittedInstance<C2>, // u_i
             CycleFoldWitness<C2>,           // W_i1
             CycleFoldCommittedInstance<C2>, // U_i1
             C2,                             // cmT
-            C2::ScalarField,                // r_Fq
         ),
         Error,
     > {
-        fold_cyclefold_circuit::<ProtoGalaxyCycleFoldConfig<C1>, C1, C2, CS2, false>(
+        fold_cyclefold_circuit::<ProtoGalaxyCycleFoldConfig<C1>, C2, CS2, false>(
             transcript,
             self.cf_r1cs.clone(),
             self.cf_cs_params.clone(),

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -120,11 +120,17 @@ impl<C: SonobeCurve, const TYPE: bool> CommittedInstanceOps<C> for CommittedInst
     }
 }
 
-impl<C: SonobeCurve, const TYPE: bool> Inputize<C::ScalarField, CommittedInstanceVar<C, TYPE>>
-    for CommittedInstance<C, TYPE>
-{
-    fn inputize(&self) -> Vec<C::ScalarField> {
-        [&self.phi.inputize(), &self.betas, &[self.e][..], &self.x].concat()
+impl<C: SonobeCurve, const TYPE: bool> Inputize<CF1<C>> for CommittedInstance<C, TYPE> {
+    /// Returns the internal representation in the same order as how the value
+    /// is allocated in `CommittedInstanceVar::new_input`.
+    fn inputize(&self) -> Vec<CF1<C>> {
+        [
+            &self.phi.inputize_nonnative(),
+            &self.betas,
+            &[self.e][..],
+            &self.x,
+        ]
+        .concat()
     }
 }
 

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -22,11 +22,11 @@ use crate::{
     folding::circuits::CF1,
     transcript::AbsorbNonNativeGadget,
     utils::vec::is_zero_vec,
-    Error, SonobeCurve,
+    Curve, Error,
 };
 
 // Implements the trait for absorbing ProtoGalaxy's CommittedInstance.
-impl<C: SonobeCurve, const TYPE: bool> Absorb for CommittedInstance<C, TYPE> {
+impl<C: Curve, const TYPE: bool> Absorb for CommittedInstance<C, TYPE> {
     fn to_sponge_bytes(&self, dest: &mut Vec<u8>) {
         C::ScalarField::batch_to_sponge_bytes(&self.to_sponge_field_elements_as_vec(), dest);
     }
@@ -40,9 +40,7 @@ impl<C: SonobeCurve, const TYPE: bool> Absorb for CommittedInstance<C, TYPE> {
 }
 
 // Implements the trait for absorbing ProtoGalaxy's CommittedInstanceVar in-circuit.
-impl<C: SonobeCurve, const TYPE: bool> AbsorbGadget<C::ScalarField>
-    for CommittedInstanceVar<C, TYPE>
-{
+impl<C: Curve, const TYPE: bool> AbsorbGadget<C::ScalarField> for CommittedInstanceVar<C, TYPE> {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<C::ScalarField>>, SynthesisError> {
         FpVar::batch_to_sponge_bytes(&self.to_sponge_field_elements()?)
     }
@@ -65,7 +63,7 @@ impl<C: SonobeCurve, const TYPE: bool> AbsorbGadget<C::ScalarField>
 /// relaxed R1CS.
 ///
 /// See `nova/traits.rs` for the rationale behind the design.
-impl<C: SonobeCurve, const TYPE: bool> Arith<Witness<CF1<C>>, CommittedInstance<C, TYPE>>
+impl<C: Curve, const TYPE: bool> Arith<Witness<CF1<C>>, CommittedInstance<C, TYPE>>
     for R1CS<CF1<C>>
 {
     type Evaluation = Vec<CF1<C>>;
@@ -106,7 +104,7 @@ impl<C: SonobeCurve, const TYPE: bool> Arith<Witness<CF1<C>>, CommittedInstance<
 
 /// Unlike its native counterpart, we only need to support running instances in
 /// circuit, as the decider circuit only checks running instance satisfiability.
-impl<C: SonobeCurve> ArithGadget<WitnessVar<CF1<C>>, CommittedInstanceVar<C, RUNNING>>
+impl<C: Curve> ArithGadget<WitnessVar<CF1<C>>, CommittedInstanceVar<C, RUNNING>>
     for R1CSMatricesVar<CF1<C>, FpVar<CF1<C>>>
 {
     type Evaluation = (Vec<FpVar<CF1<C>>>, Vec<FpVar<CF1<C>>>);

--- a/folding-schemes/src/folding/traits.rs
+++ b/folding-schemes/src/folding/traits.rs
@@ -155,7 +155,7 @@ pub trait Inputize<F> {
 /// the circuit.
 ///
 /// This is useful for the verifier to compute the public inputs.
-/// 
+///
 /// Note that we require this trait because we need to distinguish between some
 /// data types that are represented both natively and non-natively in-circuit
 /// (e.g., field elements can have type `FpVar` and `NonNativeUintVar`).

--- a/folding-schemes/src/folding/traits.rs
+++ b/folding-schemes/src/folding/traits.rs
@@ -9,12 +9,12 @@ use ark_relations::r1cs::SynthesisError;
 
 use crate::{
     transcript::{AbsorbNonNativeGadget, Transcript},
-    Error, SonobeCurve,
+    Curve, Error,
 };
 
 use super::circuits::CF1;
 
-pub trait CommittedInstanceOps<C: SonobeCurve>: Inputize<CF1<C>> {
+pub trait CommittedInstanceOps<C: Curve>: Inputize<CF1<C>> {
     /// The in-circuit representation of the committed instance.
     type Var: AllocVar<Self, CF1<C>> + CommittedInstanceVarOps<C>;
     /// `hash` implements the committed instance hash compatible with the
@@ -57,7 +57,7 @@ pub trait CommittedInstanceOps<C: SonobeCurve>: Inputize<CF1<C>> {
     }
 }
 
-pub trait CommittedInstanceVarOps<C: SonobeCurve> {
+pub trait CommittedInstanceVarOps<C: Curve> {
     type PointVar: AbsorbNonNativeGadget<CF1<C>>;
     /// `hash` implements the in-circuit committed instance hash compatible with
     /// the native implementation from `CommittedInstanceOps::hash`.

--- a/folding-schemes/src/folding/traits.rs
+++ b/folding-schemes/src/folding/traits.rs
@@ -3,16 +3,18 @@ use ark_crypto_primitives::sponge::{
     poseidon::constraints::PoseidonSpongeVar,
     Absorb,
 };
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
-use ark_r1cs_std::{alloc::AllocVar, convert::ToConstraintFieldGadget, fields::fp::FpVar};
+use ark_r1cs_std::{alloc::AllocVar, fields::fp::FpVar};
 use ark_relations::r1cs::SynthesisError;
 
-use crate::{transcript::Transcript, Error};
+use crate::{
+    transcript::{AbsorbNonNativeGadget, Transcript},
+    Error, SonobeCurve,
+};
 
 use super::circuits::CF1;
 
-pub trait CommittedInstanceOps<C: CurveGroup>: Inputize<CF1<C>, Self::Var> {
+pub trait CommittedInstanceOps<C: SonobeCurve>: Inputize<CF1<C>, Self::Var> {
     /// The in-circuit representation of the committed instance.
     type Var: AllocVar<Self, CF1<C>> + CommittedInstanceVarOps<C>;
     /// `hash` implements the committed instance hash compatible with the
@@ -29,7 +31,6 @@ pub trait CommittedInstanceOps<C: CurveGroup>: Inputize<CF1<C>, Self::Var> {
         z_i: &[CF1<C>],
     ) -> CF1<C>
     where
-        CF1<C>: Absorb,
         Self: Sized + Absorb,
     {
         let mut sponge = sponge.clone();
@@ -56,8 +57,8 @@ pub trait CommittedInstanceOps<C: CurveGroup>: Inputize<CF1<C>, Self::Var> {
     }
 }
 
-pub trait CommittedInstanceVarOps<C: CurveGroup> {
-    type PointVar: ToConstraintFieldGadget<CF1<C>>;
+pub trait CommittedInstanceVarOps<C: SonobeCurve> {
+    type PointVar: AbsorbNonNativeGadget<CF1<C>>;
     /// `hash` implements the in-circuit committed instance hash compatible with
     /// the native implementation from `CommittedInstanceOps::hash`.
     /// Returns `H(i, z_0, z_i, U_i)`, where `i` can be `i` but also `i+1`, and

--- a/folding-schemes/src/frontend/utils.rs
+++ b/folding-schemes/src/frontend/utils.rs
@@ -3,7 +3,7 @@ use ark_r1cs_std::{
     alloc::AllocVar,
     fields::{fp::FpVar, FieldVar},
 };
-use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_std::marker::PhantomData;
 use ark_std::{fmt::Debug, Zero};
 
@@ -147,11 +147,7 @@ pub struct WrapperCircuit<F: PrimeField, FC: FCircuit<F>> {
     pub z_i1: Option<Vec<F>>,
 }
 
-impl<F, FC> ark_relations::r1cs::ConstraintSynthesizer<F> for WrapperCircuit<F, FC>
-where
-    F: PrimeField,
-    FC: FCircuit<F>,
-{
+impl<F: PrimeField, FC: FCircuit<F>> ConstraintSynthesizer<F> for WrapperCircuit<F, FC> {
     fn generate_constraints(self, cs: ConstraintSystemRef<F>) -> Result<(), SynthesisError> {
         let z_i =
             Vec::<FpVar<F>>::new_witness(cs.clone(), || Ok(self.z_i.unwrap_or(vec![F::zero()])))?;

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -20,6 +20,7 @@ use ark_std::{
 };
 use thiserror::Error;
 
+use crate::folding::traits::{Inputize, InputizeNonNative};
 use crate::frontend::FCircuit;
 use crate::transcript::AbsorbNonNative;
 
@@ -307,7 +308,9 @@ pub trait DeciderOnchain<
     ) -> Result<Vec<u8>, Error>;
 }
 
-pub trait SonobeField: PrimeField<BasePrimeField = Self> + Absorb + AbsorbNonNative {
+pub trait SonobeField:
+    PrimeField<BasePrimeField = Self> + Absorb + AbsorbNonNative + Inputize<Self>
+{
     type Var: FieldVar<Self, Self>;
 }
 
@@ -316,7 +319,10 @@ impl<P: FpConfig<N>, const N: usize> SonobeField for Fp<P, N> {
 }
 
 pub trait SonobeCurve:
-    CurveGroup<ScalarField: SonobeField, BaseField: SonobeField> + AbsorbNonNative
+    CurveGroup<ScalarField: SonobeField, BaseField: SonobeField>
+    + AbsorbNonNative
+    + Inputize<Self::BaseField>
+    + InputizeNonNative<Self::ScalarField>
 {
     type Var: CurveVar<Self, Self::BaseField>;
 }

--- a/folding-schemes/src/transcript/mod.rs
+++ b/folding-schemes/src/transcript/mod.rs
@@ -40,6 +40,12 @@ impl<T: AbsorbNonNative> AbsorbNonNative for [T] {
     }
 }
 
+impl<F: PrimeField, T: AbsorbNonNativeGadget<F>> AbsorbNonNativeGadget<F> for &T {
+    fn to_native_sponge_field_elements(&self) -> Result<Vec<FpVar<F>>, SynthesisError> {
+        T::to_native_sponge_field_elements(self)
+    }
+}
+
 impl<F: PrimeField, T: AbsorbNonNativeGadget<F>> AbsorbNonNativeGadget<F> for [T] {
     fn to_native_sponge_field_elements(&self) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let mut result = Vec::new();

--- a/folding-schemes/src/transcript/poseidon.rs
+++ b/folding-schemes/src/transcript/poseidon.rs
@@ -17,8 +17,8 @@ impl<F: PrimeField + Absorb> Transcript<F> for PoseidonSponge<F> {
         self.absorb(&x);
         self.absorb(&y);
     }
-    fn absorb_nonnative<V: AbsorbNonNative<F>>(&mut self, v: &V) {
-        self.absorb(&v.to_native_sponge_field_elements_as_vec());
+    fn absorb_nonnative<V: AbsorbNonNative>(&mut self, v: &V) {
+        self.absorb(&v.to_native_sponge_field_elements_as_vec::<F>());
     }
     fn get_challenge(&mut self) -> F {
         let c = self.squeeze_field_elements(1);

--- a/folding-schemes/src/utils/espresso/sum_check/mod.rs
+++ b/folding-schemes/src/utils/espresso/sum_check/mod.rs
@@ -59,10 +59,7 @@ pub trait SumCheck<F: PrimeField> {
 }
 
 /// Trait for sum check protocol prover side APIs.
-pub trait SumCheckProver<F: PrimeField>
-where
-    Self: Sized,
-{
+pub trait SumCheckProver<F: PrimeField>: Sized {
     type VirtualPolynomial;
     type ProverMessage;
 

--- a/folding-schemes/src/utils/eth.rs
+++ b/folding-schemes/src/utils/eth.rs
@@ -1,0 +1,58 @@
+//! This module provides a trait and implementations for converting Rust types
+//! to EVM calldata.
+use ark_ec::{
+    pairing::Pairing,
+    short_weierstrass::{Affine, Projective, SWCurveConfig},
+    AffineRepr, CurveGroup,
+};
+use ark_ff::{BigInteger, Fp, Fp2, Fp2Config, FpConfig, PrimeField};
+use ark_groth16::Proof;
+
+pub trait ToEth {
+    fn to_eth(&self) -> Vec<u8>;
+}
+
+impl<T: ToEth> ToEth for [T] {
+    fn to_eth(&self) -> Vec<u8> {
+        self.iter().flat_map(ToEth::to_eth).collect()
+    }
+}
+
+impl ToEth for u8 {
+    fn to_eth(&self) -> Vec<u8> {
+        vec![*self]
+    }
+}
+
+impl<P: FpConfig<N>, const N: usize> ToEth for Fp<P, N> {
+    fn to_eth(&self) -> Vec<u8> {
+        self.into_bigint().to_bytes_be()
+    }
+}
+
+impl<P: Fp2Config<Fp: ToEth>> ToEth for Fp2<P> {
+    fn to_eth(&self) -> Vec<u8> {
+        [self.c1.to_eth(), self.c0.to_eth()].concat()
+    }
+}
+
+impl<P: SWCurveConfig<BaseField: ToEth>> ToEth for Affine<P> {
+    fn to_eth(&self) -> Vec<u8> {
+        // the encoding of the additive identity is [0, 0] on the EVM
+        let (x, y) = self.xy().unwrap_or_default();
+
+        [x.to_eth(), y.to_eth()].concat()
+    }
+}
+
+impl<P: SWCurveConfig<BaseField: ToEth>> ToEth for Projective<P> {
+    fn to_eth(&self) -> Vec<u8> {
+        self.into_affine().to_eth()
+    }
+}
+
+impl<E: Pairing<G1Affine: ToEth, G2Affine: ToEth>> ToEth for Proof<E> {
+    fn to_eth(&self) -> Vec<u8> {
+        [self.a.to_eth(), self.b.to_eth(), self.c.to_eth()].concat()
+    }
+}

--- a/folding-schemes/src/utils/gadgets.rs
+++ b/folding-schemes/src/utils/gadgets.rs
@@ -71,11 +71,8 @@ pub struct SparseMatrixVar<FV> {
     pub coeffs: Vec<Vec<(FV, usize)>>,
 }
 
-impl<F, CF, FV> AllocVar<SparseMatrix<F>, CF> for SparseMatrixVar<FV>
-where
-    F: PrimeField,
-    CF: PrimeField,
-    FV: AllocVar<F, CF>,
+impl<F: PrimeField, CF: PrimeField, FV: AllocVar<F, CF>> AllocVar<SparseMatrix<F>, CF>
+    for SparseMatrixVar<FV>
 {
     fn new_variable<T: Borrow<SparseMatrix<F>>>(
         cs: impl Into<Namespace<CF>>,

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -11,6 +11,7 @@ use crate::arith::ArithSerializer;
 use crate::commitment::CommitmentScheme;
 use crate::{Error, SonobeCurve};
 
+pub mod eth;
 pub mod gadgets;
 pub mod hypercube;
 pub mod lagrange_poly;

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
-use ark_ec::{AffineRepr, CurveGroup};
+use ark_ec::AffineRepr;
 use ark_ff::PrimeField;
 use ark_serialize::CanonicalSerialize;
 use sha3::{Digest, Sha3_256};
 
 use crate::arith::ArithSerializer;
 use crate::commitment::CommitmentScheme;
-use crate::Error;
+use crate::{Error, SonobeCurve};
 
 pub mod gadgets;
 pub mod hypercube;
@@ -35,7 +35,7 @@ pub fn powers_of<F: PrimeField>(x: F, n: usize) -> Vec<F> {
 
 /// returns the coordinates of a commitment point. This is compatible with the arkworks
 /// GC.to_constraint_field()[..2]
-pub fn get_cm_coordinates<C: CurveGroup>(cm: &C) -> Vec<C::BaseField> {
+pub fn get_cm_coordinates<C: SonobeCurve>(cm: &C) -> Vec<C::BaseField> {
     let (cm_x, cm_y) = cm.into_affine().xy().unwrap_or_default();
     vec![cm_x, cm_y]
 }
@@ -49,8 +49,8 @@ pub fn pp_hash<C1, C2, CS1, CS2, const H: bool>(
     poseidon_config: &PoseidonConfig<C1::ScalarField>,
 ) -> Result<C1::ScalarField, Error>
 where
-    C1: CurveGroup,
-    C2: CurveGroup,
+    C1: SonobeCurve,
+    C2: SonobeCurve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {

--- a/folding-schemes/src/utils/mod.rs
+++ b/folding-schemes/src/utils/mod.rs
@@ -9,7 +9,7 @@ use sha3::{Digest, Sha3_256};
 
 use crate::arith::ArithSerializer;
 use crate::commitment::CommitmentScheme;
-use crate::{Error, SonobeCurve};
+use crate::{Curve, Error};
 
 pub mod eth;
 pub mod gadgets;
@@ -36,7 +36,7 @@ pub fn powers_of<F: PrimeField>(x: F, n: usize) -> Vec<F> {
 
 /// returns the coordinates of a commitment point. This is compatible with the arkworks
 /// GC.to_constraint_field()[..2]
-pub fn get_cm_coordinates<C: SonobeCurve>(cm: &C) -> Vec<C::BaseField> {
+pub fn get_cm_coordinates<C: Curve>(cm: &C) -> Vec<C::BaseField> {
     let (cm_x, cm_y) = cm.into_affine().xy().unwrap_or_default();
     vec![cm_x, cm_y]
 }
@@ -50,8 +50,8 @@ pub fn pp_hash<C1, C2, CS1, CS2, const H: bool>(
     poseidon_config: &PoseidonConfig<C1::ScalarField>,
 ) -> Result<C1::ScalarField, Error>
 where
-    C1: SonobeCurve,
-    C2: SonobeCurve,
+    C1: Curve,
+    C2: Curve,
     CS1: CommitmentScheme<C1, H>,
     CS2: CommitmentScheme<C2, H>,
 {

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -139,10 +139,10 @@ impl NovaCycleFoldVerifierKey {
 
 #[cfg(test)]
 mod tests {
-    use ark_bn254::{constraints::GVar, Bn254, Fr, G1Projective as G1};
+    use ark_bn254::{Bn254, Fr, G1Projective as G1};
     use ark_ff::PrimeField;
     use ark_groth16::Groth16;
-    use ark_grumpkin::{constraints::GVar as GVar2, Projective as G2};
+    use ark_grumpkin::Projective as G2;
     use ark_r1cs_std::alloc::AllocVar;
     use ark_r1cs_std::fields::fp::FpVar;
     use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
@@ -174,18 +174,9 @@ mod tests {
         NovaCycleFoldVerifierKey, ProtocolVerifierKey,
     };
 
-    type NOVA<FC> = Nova<G1, GVar, G2, GVar2, FC, KZG<'static, Bn254>, Pedersen<G2>, false>;
-    type DECIDER<FC> = DeciderEth<
-        G1,
-        GVar,
-        G2,
-        GVar2,
-        FC,
-        KZG<'static, Bn254>,
-        Pedersen<G2>,
-        Groth16<Bn254>,
-        NOVA<FC>,
-    >;
+    type NOVA<FC> = Nova<G1, G2, FC, KZG<'static, Bn254>, Pedersen<G2>, false>;
+    type DECIDER<FC> =
+        DeciderEth<G1, G2, FC, KZG<'static, Bn254>, Pedersen<G2>, Groth16<Bn254>, NOVA<FC>>;
 
     type FS_PP<FC> = <NOVA<FC> as FoldingScheme<G1, G2, FC>>::ProverParam;
     type FS_VP<FC> = <NOVA<FC> as FoldingScheme<G1, G2, FC>>::VerifierParam;


### PR DESCRIPTION
The current codebase has pretty complicated trait bounds / type parameters, and this is mostly due to the requirement of types that are more specific / powerful than the ones provided by arkworks.

For example, when using `CurveGroup`, we often need its `BaseField` to be a `PrimeField`, its `ScalarField` and `BaseField` to be `Absorb`able, and an in-circuit type `CurveVar` to be associated with the curve.

This PR aims to simplify the interfaces of complex traits, thereby improving the DX of sonobe before the incoming release. Specifically:
- Two new traits, `SonobeField` and `SonobeCurve`, are introduced, in order to remove type parameters like `GC{1, 2}: CurveVar` and trait bounds like `Absorb` and `PrimeField`.
- Traits and implementations related to sponges / transcripts are redesigned.
  - Type parameters for `AbsorbNonNative` are adjusted in order to fix #170.
  - Instead of implementing and calling `to_constraint_field` to obtain the hash preimage that corresponds to an in-circuit variable, `to_{native_}sponge_field_elements` is now preferred because it is semantically more meaningful.
    (Note that we cannot eliminate `to_constraint_field` calls for `CurveGroup` because arkworks does not implement `to_sponge_field_elements` for it, and it is also impossible for us to do the implementation as both traits are foreign.)
- The `Inputize` trait was originally added to replace arkworks' `ToConstraintField::to_field_elements`, since we have too many methods similar to the latter, whose naming is also less clearer than the former.
  Now, this PR separates the "inputization" of non-native variables from native variables, resulting in a new trait `InputizeNonNative`. The benefit is that. we can now simultaneously handle types with two representations in-circuit (e.g., `CurveGroup` whose in-circuit version can be either `CurveVar` or `NonNativeAffineVar`).
  Furthermore, `Inputize` for a type `T` is now *guaranteed* to return underlying field elements in the same order as how `T::Var` is allocated in-circuit. In comparison, arkworks' implementation of `ToConstraintField::to_field_elements` for EC group elements (which essentially returns `x`, `y`, `infinity` of the affine form) in fact does not match the allocation of in-circuit EC variables (which is handled in the order of `x`, `y`, `z` of the projective form).
- To allow easy conversion to EVM calldata, this PR implements the `ToEth` trait for arkworks types, so that we can avoid verbosity when implementing `prepare_calldata` for on-chain deciders for HyperNova, ProtoGalaxy, etc. in the future.
- The CycleFold-related code is also refactored. I think this is more related to #158 which I am still working on (sorry for the long delay!), but let me keep it as is in this PR.

Thanks in advance for reviewing this (yet another) huge PR. It would be great to hear your feedback!