### PR TITLE
fix: typos in documentation files

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,4 @@
-use ::clap::Parser;
+use clap::Parser;
 use ark_serialize::Write;
 use settings::Cli;
 use std::path::Path;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
-use clap::Parser;
 use ark_serialize::Write;
+use clap::Parser;
 use settings::Cli;
 use std::path::Path;
 use std::{fs, io};


### PR DESCRIPTION
Corrected `use ::clap::Parser` to `use clap::Parser`