### PR TITLE
Update the FCircuit trait, so that it supports custom data structures for the external inputs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,12 @@
 Cargo.lock
 
 # Circom generated files
-frontends/src/circom/test_folder/*_js/
+experimental-frontends/src/circom/test_folder/*_js/
 *.r1cs
 *.sym
 
 # Noir generated files
-frontends/src/noir/test_folder/*/target/*
+experimental-frontends/src/noir/test_folder/*/target/*
 
 # generated contracts data
 solidity-verifiers/generated

--- a/benches/common.rs
+++ b/benches/common.rs
@@ -29,7 +29,7 @@ pub(crate) fn bench_ivc_opt<
 
     // warmup steps
     for _ in 0..5 {
-        fs.prove_step(rng, vec![], None)?;
+        fs.prove_step(rng, (), None)?;
     }
 
     let mut group = c.benchmark_group(format!(
@@ -38,7 +38,7 @@ pub(crate) fn bench_ivc_opt<
     ));
     group.significance_level(0.1).sample_size(10);
     group.bench_function("prove_step", |b| {
-        b.iter(|| -> Result<_, _> { black_box(fs.clone()).prove_step(rng, vec![], None) })
+        b.iter(|| -> Result<_, _> { black_box(fs.clone()).prove_step(rng, (), None) })
     });
 
     // verify the IVCProof

--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -17,7 +17,7 @@ use ark_grumpkin::Projective as G2;
 use std::path::PathBuf;
 use std::time::Instant;
 
-use experimental_frontends::circom::CircomFCircuit;
+use experimental_frontends::{circom::CircomFCircuit, utils::VecF};
 use folding_schemes::{
     commitment::{kzg::KZG, pedersen::Pedersen},
     folding::{
@@ -64,14 +64,16 @@ fn main() -> Result<(), Error> {
         "./experimental-frontends/src/circom/test_folder/with_external_inputs_js/with_external_inputs.wasm",
     );
 
-    let f_circuit_params = (r1cs_path.into(), wasm_path.into(), 1, 2);
-    let f_circuit = CircomFCircuit::<Fr>::new(f_circuit_params)?;
+    let f_circuit_params = (r1cs_path.into(), wasm_path.into(), 1); // state len = 1
+    const EXT_INP_LEN: usize = 2; // external inputs len = 2
+    let f_circuit = CircomFCircuit::<Fr, EXT_INP_LEN>::new(f_circuit_params)?;
 
-    pub type N = Nova<G1, G2, CircomFCircuit<Fr>, KZG<'static, Bn254>, Pedersen<G2>, false>;
+    pub type N =
+        Nova<G1, G2, CircomFCircuit<Fr, EXT_INP_LEN>, KZG<'static, Bn254>, Pedersen<G2>, false>;
     pub type D = DeciderEth<
         G1,
         G2,
-        CircomFCircuit<Fr>,
+        CircomFCircuit<Fr, EXT_INP_LEN>,
         KZG<'static, Bn254>,
         Pedersen<G2>,
         Groth16<Bn254>,
@@ -94,7 +96,7 @@ fn main() -> Result<(), Error> {
     // run n steps of the folding iteration
     for (i, external_inputs_at_step) in external_inputs.iter().enumerate() {
         let start = Instant::now();
-        nova.prove_step(rng, external_inputs_at_step.clone(), None)?;
+        nova.prove_step(rng, VecF(external_inputs_at_step.clone()), None)?;
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/external_inputs.rs
+++ b/examples/external_inputs.rs
@@ -74,8 +74,8 @@ where
     F: Absorb,
 {
     type Params = PoseidonConfig<F>;
-    type ExternalInputs = VecF<F>;
-    type ExternalInputsVar = VecFpVar<F>;
+    type ExternalInputs = [F; 1];
+    type ExternalInputsVar = [FpVar<F>; 1];
 
     fn new(params: Self::Params) -> Result<Self, Error> {
         Ok(Self {
@@ -95,46 +95,11 @@ where
         z_i: Vec<FpVar<F>>,
         external_inputs: Self::ExternalInputsVar,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
-        let ei: VecFpVar<F> = external_inputs.into();
         let crh_params =
             CRHParametersVar::<F>::new_constant(cs.clone(), self.poseidon_config.clone())?;
-        let hash_input: [FpVar<F>; 2] = [z_i[0].clone(), ei.0[0].clone()];
+        let hash_input: [FpVar<F>; 2] = [z_i[0].clone(), external_inputs[0].clone()];
         let h = CRHGadget::<F>::evaluate(&crh_params, &hash_input)?;
         Ok(vec![h])
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct VecF<F: PrimeField>(Vec<F>);
-impl<F: PrimeField> Default for VecF<F> {
-    fn default() -> Self {
-        VecF(vec![F::zero()])
-    }
-}
-
-use ark_r1cs_std::alloc::AllocationMode;
-use ark_relations::r1cs::Namespace;
-use core::borrow::Borrow;
-#[derive(Clone, Debug)]
-pub struct VecFpVar<F: PrimeField>(Vec<FpVar<F>>);
-impl<F: PrimeField> AllocVar<VecF<F>, F> for VecFpVar<F> {
-    fn new_variable<T: Borrow<VecF<F>>>(
-        cs: impl Into<Namespace<F>>,
-        f: impl FnOnce() -> Result<T, SynthesisError>,
-        mode: AllocationMode,
-    ) -> Result<Self, SynthesisError> {
-        f().and_then(|val| {
-            let cs = cs.into();
-
-            let v = Vec::<FpVar<F>>::new_variable(cs.clone(), || Ok(val.borrow().0.clone()), mode)?;
-
-            Ok(VecFpVar(v))
-        })
-    }
-}
-impl<F: PrimeField> Default for VecFpVar<F> {
-    fn default() -> Self {
-        VecFpVar(vec![FpVar::<F>::Constant(F::zero())])
     }
 }
 
@@ -171,14 +136,13 @@ pub mod tests {
             external_inputs_step_native(z_i.clone(), external_inputs.clone(), &poseidon_config);
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
-        let external_inputsVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(external_inputs))?;
+        let external_inputsVar: [FpVar<Fr>; 1] =
+            Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(external_inputs))?
+                .try_into()
+                .unwrap();
 
-        let computed_z_i1Var = circuit.generate_step_constraints(
-            cs.clone(),
-            0,
-            z_iVar,
-            VecFpVar(external_inputsVar),
-        )?;
+        let computed_z_i1Var =
+            circuit.generate_step_constraints(cs.clone(), 0, z_iVar, external_inputsVar)?;
         assert_eq!(computed_z_i1Var.value()?, z_i1);
         Ok(())
     }
@@ -191,11 +155,11 @@ fn main() -> Result<(), Error> {
 
     // prepare the external inputs to be used at each folding step
     let external_inputs = vec![
-        VecF(vec![Fr::from(3_u32)]),
-        VecF(vec![Fr::from(33_u32)]),
-        VecF(vec![Fr::from(73_u32)]),
-        VecF(vec![Fr::from(103_u32)]),
-        VecF(vec![Fr::from(125_u32)]),
+        [Fr::from(3_u32)],
+        [Fr::from(33_u32)],
+        [Fr::from(73_u32)],
+        [Fr::from(103_u32)],
+        [Fr::from(125_u32)],
     ];
     assert_eq!(external_inputs.len(), num_steps);
 

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -46,21 +46,21 @@ pub struct CubicFCircuit<F: PrimeField> {
 }
 impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
     type Params = ();
+    type ExternalInputs = ();
+    type ExternalInputsVar = ();
+
     fn new(_params: Self::Params) -> Result<Self, Error> {
         Ok(Self { _f: PhantomData })
     }
     fn state_len(&self) -> usize {
         1
     }
-    fn external_inputs_len(&self) -> usize {
-        0
-    }
     fn generate_step_constraints(
         &self,
         cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
-        _external_inputs: Vec<FpVar<F>>,
+        _external_inputs: Self::ExternalInputsVar,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let five = FpVar::<F>::new_constant(cs.clone(), F::from(5u32))?;
         let z_i = z_i[0].clone();
@@ -96,7 +96,7 @@ fn main() -> Result<(), Error> {
     // run n steps of the folding iteration
     for i in 0..n_steps {
         let start = Instant::now();
-        nova.prove_step(rng, vec![], None)?;
+        nova.prove_step(rng, (), None)?;
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/multi_inputs.rs
+++ b/examples/multi_inputs.rs
@@ -30,6 +30,8 @@ pub struct MultiInputsFCircuit<F: PrimeField> {
 }
 impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
     type Params = ();
+    type ExternalInputs = ();
+    type ExternalInputsVar = ();
 
     fn new(_params: Self::Params) -> Result<Self, Error> {
         Ok(Self { _f: PhantomData })
@@ -37,16 +39,13 @@ impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
     fn state_len(&self) -> usize {
         5
     }
-    fn external_inputs_len(&self) -> usize {
-        0
-    }
     /// generates the constraints for the step of F for the given z_i
     fn generate_step_constraints(
         &self,
         cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
-        _external_inputs: Vec<FpVar<F>>,
+        _external_inputs: Self::ExternalInputsVar,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let four = FpVar::<F>::new_constant(cs.clone(), F::from(4u32))?;
         let forty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
@@ -96,7 +95,7 @@ pub mod tests {
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let computed_z_i1Var =
-            circuit.generate_step_constraints(cs.clone(), 0, z_iVar.clone(), vec![])?;
+            circuit.generate_step_constraints(cs.clone(), 0, z_iVar.clone(), ())?;
         assert_eq!(computed_z_i1Var.value()?, z_i1);
         Ok(())
     }
@@ -140,7 +139,7 @@ fn main() -> Result<(), Error> {
     // compute a step of the IVC
     for i in 0..num_steps {
         let start = Instant::now();
-        folding_scheme.prove_step(rng, vec![], None)?;
+        folding_scheme.prove_step(rng, (), None)?;
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/examples/sha256.rs
+++ b/examples/sha256.rs
@@ -36,6 +36,8 @@ pub struct Sha256FCircuit<F: PrimeField> {
 }
 impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
     type Params = ();
+    type ExternalInputs = ();
+    type ExternalInputsVar = ();
 
     fn new(_params: Self::Params) -> Result<Self, Error> {
         Ok(Self { _f: PhantomData })
@@ -43,16 +45,13 @@ impl<F: PrimeField> FCircuit<F> for Sha256FCircuit<F> {
     fn state_len(&self) -> usize {
         1
     }
-    fn external_inputs_len(&self) -> usize {
-        0
-    }
     /// generates the constraints for the step of F for the given z_i
     fn generate_step_constraints(
         &self,
         _cs: ConstraintSystemRef<F>,
         _i: usize,
         z_i: Vec<FpVar<F>>,
-        _external_inputs: Vec<FpVar<F>>,
+        _external_inputs: Self::ExternalInputsVar,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let unit_var = UnitVar::default();
         let out_bytes = Sha256Gadget::evaluate(&unit_var, &z_i[0].to_bytes_le()?)?;
@@ -89,7 +88,7 @@ pub mod tests {
 
         let z_iVar = Vec::<FpVar<Fr>>::new_witness(cs.clone(), || Ok(z_i))?;
         let computed_z_i1Var =
-            circuit.generate_step_constraints(cs.clone(), 0, z_iVar.clone(), vec![])?;
+            circuit.generate_step_constraints(cs.clone(), 0, z_iVar.clone(), ())?;
         assert_eq!(computed_z_i1Var.value()?, z_i1);
         Ok(())
     }
@@ -126,7 +125,7 @@ fn main() -> Result<(), Error> {
     // compute a step of the IVC
     for i in 0..num_steps {
         let start = Instant::now();
-        folding_scheme.prove_step(rng, vec![], None)?;
+        folding_scheme.prove_step(rng, (), None)?;
         println!("Nova::prove_step {}: {:?}", i, start.elapsed());
     }
 

--- a/experimental-frontends/src/lib.rs
+++ b/experimental-frontends/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod circom;
 pub mod noir;
 pub mod noname;
+pub mod utils;

--- a/experimental-frontends/src/utils.rs
+++ b/experimental-frontends/src/utils.rs
@@ -1,0 +1,38 @@
+use ark_ff::PrimeField;
+use ark_r1cs_std::{
+    alloc::{AllocVar, AllocationMode},
+    fields::fp::FpVar,
+};
+use ark_relations::r1cs::{Namespace, SynthesisError};
+use ark_std::fmt::Debug;
+use core::borrow::Borrow;
+
+#[derive(Clone, Debug)]
+pub struct VecF<F: PrimeField, const L: usize>(pub Vec<F>);
+impl<F: PrimeField, const L: usize> Default for VecF<F, L> {
+    fn default() -> Self {
+        VecF(vec![F::zero(); L])
+    }
+}
+#[derive(Clone, Debug)]
+pub struct VecFpVar<F: PrimeField, const L: usize>(pub Vec<FpVar<F>>);
+impl<F: PrimeField, const L: usize> AllocVar<VecF<F, L>, F> for VecFpVar<F, L> {
+    fn new_variable<T: Borrow<VecF<F, L>>>(
+        cs: impl Into<Namespace<F>>,
+        f: impl FnOnce() -> Result<T, SynthesisError>,
+        mode: AllocationMode,
+    ) -> Result<Self, SynthesisError> {
+        f().and_then(|val| {
+            let cs = cs.into();
+
+            let v = Vec::<FpVar<F>>::new_variable(cs.clone(), || Ok(val.borrow().0.clone()), mode)?;
+
+            Ok(VecFpVar(v))
+        })
+    }
+}
+impl<F: PrimeField, const L: usize> Default for VecFpVar<F, L> {
+    fn default() -> Self {
+        VecFpVar(vec![FpVar::<F>::Constant(F::zero()); L])
+    }
+}

--- a/folding-schemes/src/folding/circuits/nonnative/uint.rs
+++ b/folding-schemes/src/folding/circuits/nonnative/uint.rs
@@ -203,8 +203,8 @@ impl<F: PrimeField> NonNativeUintVar<F> {
         // Thus, 55 allows us to compute `Az∘Bz` without the expensive alignment
         // operation.
         //
-        // TODO (@winderica): either make it a global const, or compute an
-        // optimal value based on the modulus size
+        // TODO: either make it a global const, or compute an optimal value
+        // based on the modulus size.
         55
     }
 }

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -479,7 +479,7 @@ pub struct AugmentedFCircuit<
     pub(super) i_usize: Option<usize>,
     pub(super) z_0: Option<Vec<C1::ScalarField>>,
     pub(super) z_i: Option<Vec<C1::ScalarField>>,
-    pub(super) external_inputs: Option<Vec<C1::ScalarField>>,
+    pub(super) external_inputs: Option<FC::ExternalInputs>,
     pub(super) U_i: Option<LCCCS<C1>>,
     pub(super) Us: Option<Vec<LCCCS<C1>>>, // other U_i's to be folded that are not the main running instance
     pub(super) u_i_C: Option<C1>,          // u_i.C
@@ -602,7 +602,7 @@ where
                 i_usize: Some(0),
                 z_0: Some(z_0.clone()),
                 z_i: Some(z_0.clone()),
-                external_inputs: Some(vec![C1::ScalarField::zero(); self.F.external_inputs_len()]),
+                external_inputs: Some(FC::ExternalInputs::default()),
                 U_i: Some(U_i.clone()),
                 Us: Some(Us),
                 u_i_C: Some(u_i.C),
@@ -681,10 +681,8 @@ where
                 .z_i
                 .unwrap_or(vec![CF1::<C1>::zero(); self.F.state_len()]))
         })?;
-        let external_inputs = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || {
-            Ok(self
-                .external_inputs
-                .unwrap_or(vec![CF1::<C1>::zero(); self.F.external_inputs_len()]))
+        let external_inputs = FC::ExternalInputsVar::new_witness(cs.clone(), || {
+            Ok(self.external_inputs.unwrap_or_default())
         })?;
 
         let U_dummy = LCCCS::<C1>::dummy(&self.ccs);
@@ -1278,7 +1276,7 @@ mod tests {
                         i_usize: Some(0),
                         z_0: Some(z_0.clone()),
                         z_i: Some(z_i.clone()),
-                        external_inputs: Some(vec![]),
+                        external_inputs: Some(()),
                         U_i: Some(U_i.clone()),
                         Us: Some(Us.clone()),
                         u_i_C: Some(u_i.C),
@@ -1362,7 +1360,7 @@ mod tests {
                         i_usize: Some(i),
                         z_0: Some(z_0.clone()),
                         z_i: Some(z_i.clone()),
-                        external_inputs: Some(vec![]),
+                        external_inputs: Some(()),
                         U_i: Some(U_i.clone()),
                         Us: Some(Us.clone()),
                         u_i_C: Some(u_i.C),

--- a/folding-schemes/src/folding/hypernova/decider_eth.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth.rs
@@ -260,8 +260,8 @@ pub mod tests {
         let hypernova_params = HN::preprocess(&mut rng, &prep_param)?;
 
         let mut hypernova = HN::init(&hypernova_params, F_circuit, z_0.clone())?;
-        hypernova.prove_step(&mut rng, vec![], Some((vec![], vec![])))?;
-        hypernova.prove_step(&mut rng, vec![], Some((vec![], vec![])))?; // do a 2nd step
+        hypernova.prove_step(&mut rng, (), Some((vec![], vec![])))?;
+        hypernova.prove_step(&mut rng, (), Some((vec![], vec![])))?; // do a 2nd step
 
         // prepare the Decider prover & verifier params
         let (decider_pp, decider_vp) =
@@ -356,8 +356,8 @@ pub mod tests {
         let hypernova_params = (hypernova_pp_deserialized, hypernova_vp_deserialized);
         let mut hypernova = HN::init(&hypernova_params, F_circuit, z_0.clone())?;
 
-        hypernova.prove_step(&mut rng, vec![], Some((vec![], vec![])))?;
-        hypernova.prove_step(&mut rng, vec![], Some((vec![], vec![])))?;
+        hypernova.prove_step(&mut rng, (), Some((vec![], vec![])))?;
+        hypernova.prove_step(&mut rng, (), Some((vec![], vec![])))?;
 
         // decider proof generation
         let proof = D::prove(rng, decider_pp, hypernova.clone())?;

--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -301,7 +301,7 @@ pub mod tests {
 
         // generate a Nova instance and do a step of it
         let mut hypernova = HN::init(&hn_params, F_circuit, z_0.clone())?;
-        hypernova.prove_step(&mut rng, vec![], None)?;
+        hypernova.prove_step(&mut rng, (), None)?;
 
         let ivc_proof = hypernova.ivc_proof();
         HN::verify(hn_params.1, ivc_proof)?;

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -279,7 +279,7 @@ where
         &self,
         mut rng: impl RngCore,
         state: Vec<C1::ScalarField>,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
     ) -> Result<Self::RunningInstance, Error> {
         let r1cs_z = self.new_instance_generic(state, external_inputs)?;
         // compute committed instances, w_{i+1}, u_{i+1}, which will be used as w_i, u_i, so we
@@ -301,7 +301,7 @@ where
         &self,
         mut rng: impl RngCore,
         state: Vec<C1::ScalarField>,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
     ) -> Result<Self::IncomingInstance, Error> {
         let r1cs_z = self.new_instance_generic(state, external_inputs)?;
         // compute committed instances, w_{i+1}, u_{i+1}, which will be used as w_i, u_i, so we
@@ -332,7 +332,7 @@ where
     fn new_instance_generic(
         &self,
         state: Vec<C1::ScalarField>,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
     ) -> Result<Vec<C1::ScalarField>, Error> {
         // prepare the initial dummy instances
         let U_i = LCCCS::<C1>::dummy(&self.ccs);
@@ -599,7 +599,7 @@ where
     fn prove_step(
         &mut self,
         mut rng: impl RngCore,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
         other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error> {
         // ensure that commitments are blinding if user has specified so.
@@ -663,14 +663,6 @@ where
                 self.z_i.len(),
                 "F.state_len()".to_string(),
                 self.F.state_len(),
-            ));
-        }
-        if external_inputs.len() != self.F.external_inputs_len() {
-            return Err(Error::NotSameLength(
-                "F.external_inputs_len()".to_string(),
-                self.F.external_inputs_len(),
-                "external_inputs.len()".to_string(),
-                external_inputs.len(),
             ));
         }
 
@@ -1045,17 +1037,17 @@ mod tests {
             let mut lcccs = vec![];
             for j in 0..MU - 1 {
                 let instance_state = vec![Fr::from(j as u32 + 85_u32)];
-                let (U, W) = hypernova.new_running_instance(&mut rng, instance_state, vec![])?;
+                let (U, W) = hypernova.new_running_instance(&mut rng, instance_state, ())?;
                 lcccs.push((U, W));
             }
             let mut cccs = vec![];
             for j in 0..NU - 1 {
                 let instance_state = vec![Fr::from(j as u32 + 15_u32)];
-                let (u, w) = hypernova.new_incoming_instance(&mut rng, instance_state, vec![])?;
+                let (u, w) = hypernova.new_incoming_instance(&mut rng, instance_state, ())?;
                 cccs.push((u, w));
             }
 
-            hypernova.prove_step(&mut rng, vec![], Some((lcccs, cccs)))?;
+            hypernova.prove_step(&mut rng, (), Some((lcccs, cccs)))?;
         }
         assert_eq!(Fr::from(num_steps as u32), hypernova.i);
 

--- a/folding-schemes/src/folding/mod.rs
+++ b/folding-schemes/src/folding/mod.rs
@@ -77,7 +77,7 @@ pub mod tests {
         // perform multiple IVC steps (internally folding)
         let num_steps: usize = 3;
         for _ in 0..num_steps {
-            fs.prove_step(&mut rng, vec![], None)?;
+            fs.prove_step(&mut rng, FC::ExternalInputs::default(), None)?;
         }
 
         // verify the IVCProof
@@ -121,8 +121,8 @@ pub mod tests {
         // serialization new FS instance
         let num_steps: usize = 3;
         for _ in 0..num_steps {
-            new_fs.prove_step(&mut rng, vec![], None)?;
-            fs.prove_step(&mut rng, vec![], None)?;
+            new_fs.prove_step(&mut rng, FC::ExternalInputs::default(), None)?;
+            fs.prove_step(&mut rng, FC::ExternalInputs::default(), None)?;
         }
 
         // check that the IVCProofs from both FS instances are equal

--- a/folding-schemes/src/folding/nova/circuits.rs
+++ b/folding-schemes/src/folding/nova/circuits.rs
@@ -55,7 +55,7 @@ pub struct AugmentedFCircuit<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> {
     pub(super) i_usize: Option<usize>,
     pub(super) z_0: Option<Vec<C1::ScalarField>>,
     pub(super) z_i: Option<Vec<C1::ScalarField>>,
-    pub(super) external_inputs: Option<Vec<C1::ScalarField>>,
+    pub(super) external_inputs: Option<FC::ExternalInputs>,
     pub(super) u_i_cmW: Option<C1>,
     pub(super) U_i: Option<CommittedInstance<C1>>,
     pub(super) U_i1_cmE: Option<C1>,
@@ -125,10 +125,8 @@ where
                 .z_i
                 .unwrap_or(vec![CF1::<C1>::zero(); self.F.state_len()]))
         })?;
-        let external_inputs = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || {
-            Ok(self
-                .external_inputs
-                .unwrap_or(vec![CF1::<C1>::zero(); self.F.external_inputs_len()]))
+        let external_inputs = FC::ExternalInputsVar::new_witness(cs.clone(), || {
+            Ok(self.external_inputs.unwrap_or_default())
         })?;
 
         let u_dummy = CommittedInstance::dummy(2);

--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -371,9 +371,9 @@ pub mod tests {
         let mut nova = N::init(&nova_params, F_circuit, z_0.clone())?;
         println!("Nova initialized, {:?}", start.elapsed());
         let start = Instant::now();
-        nova.prove_step(&mut rng, vec![], None)?;
+        nova.prove_step(&mut rng, (), None)?;
         println!("prove_step, {:?}", start.elapsed());
-        nova.prove_step(&mut rng, vec![], None)?; // do a 2nd step
+        nova.prove_step(&mut rng, (), None)?; // do a 2nd step
 
         let mut rng = rand::rngs::OsRng;
 

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -192,7 +192,7 @@ pub mod tests {
 
         // generate a Nova instance and do a step of it
         let mut nova = N::init(&nova_params, F_circuit, z_0.clone())?;
-        nova.prove_step(&mut rng, vec![], None)?;
+        nova.prove_step(&mut rng, (), None)?;
         // verify the IVC
         let ivc_proof = nova.ivc_proof();
         N::verify(nova_params.1, ivc_proof)?;

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -319,9 +319,9 @@ pub mod tests {
         let (decider_pp, decider_vp) = D::preprocess(&mut rng, nova_params, nova.clone())?;
 
         let start = Instant::now();
-        nova.prove_step(&mut rng, vec![], None)?;
+        nova.prove_step(&mut rng, (), None)?;
         println!("prove_step, {:?}", start.elapsed());
-        nova.prove_step(&mut rng, vec![], None)?; // do a 2nd step
+        nova.prove_step(&mut rng, (), None)?; // do a 2nd step
 
         // decider proof generation
         let start = Instant::now();
@@ -431,9 +431,9 @@ pub mod tests {
         let mut nova = N::init(&nova_params, F_circuit, z_0)?;
 
         let start = Instant::now();
-        nova.prove_step(&mut rng, vec![], None)?;
+        nova.prove_step(&mut rng, (), None)?;
         println!("prove_step, {:?}", start.elapsed());
-        nova.prove_step(&mut rng, vec![], None)?; // do a 2nd step
+        nova.prove_step(&mut rng, (), None)?; // do a 2nd step
 
         // decider proof generation
         let start = Instant::now();

--- a/folding-schemes/src/folding/nova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/nova/decider_eth_circuit.rs
@@ -240,7 +240,7 @@ pub mod tests {
 
         // generate a Nova instance and do a step of it
         let mut nova = N::init(&nova_params, F_circuit, z_0.clone())?;
-        nova.prove_step(&mut rng, vec![], None)?;
+        nova.prove_step(&mut rng, (), None)?;
         let ivc_proof = nova.ivc_proof();
         N::verify(nova_params.1, ivc_proof)?;
 

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -620,8 +620,8 @@ where
     fn prove_step(
         &mut self,
         mut rng: impl RngCore,
-        external_inputs: Vec<C1::ScalarField>,
-        // Nova does not support multi-instances folding
+        external_inputs: FC::ExternalInputs,
+        // Nova does not support multi-instances folding (by design)
         _other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error> {
         // ensure that commitments are blinding if user has specified so.
@@ -657,14 +657,6 @@ where
                 self.z_i.len(),
                 "F.state_len()".to_string(),
                 self.F.state_len(),
-            ));
-        }
-        if external_inputs.len() != self.F.external_inputs_len() {
-            return Err(Error::NotSameLength(
-                "F.external_inputs_len()".to_string(),
-                self.F.external_inputs_len(),
-                "external_inputs.len()".to_string(),
-                external_inputs.len(),
             ));
         }
 
@@ -1123,7 +1115,7 @@ pub mod tests {
         )?;
 
         for _ in 0..num_steps {
-            nova.prove_step(&mut rng, vec![], None)?;
+            nova.prove_step(&mut rng, (), None)?;
         }
         assert_eq!(Fr::from(num_steps as u32), nova.i);
 

--- a/folding-schemes/src/folding/protogalaxy/circuits.rs
+++ b/folding-schemes/src/folding/protogalaxy/circuits.rs
@@ -238,7 +238,7 @@ pub struct AugmentedFCircuit<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> {
     pub(super) i_usize: usize,
     pub(super) z_0: Vec<CF1<C1>>,
     pub(super) z_i: Vec<CF1<C1>>,
-    pub(super) external_inputs: Vec<CF1<C1>>,
+    pub(super) external_inputs: FC::ExternalInputs,
     pub(super) F: FC, // F circuit
     pub(super) u_i_phi: C1,
     pub(super) U_i: CommittedInstance<C1, true>,
@@ -274,7 +274,7 @@ impl<C1: Curve, C2: Curve, FC: FCircuit<CF1<C1>>> AugmentedFCircuit<C1, C2, FC> 
             i_usize: 0,
             z_0: vec![CF1::<C1>::zero(); F_circuit.state_len()],
             z_i: vec![CF1::<C1>::zero(); F_circuit.state_len()],
-            external_inputs: vec![CF1::<C1>::zero(); F_circuit.external_inputs_len()],
+            external_inputs: FC::ExternalInputs::default(),
             u_i_phi: C1::zero(),
             U_i: u_dummy,
             U_i1_phi: C1::zero(),
@@ -307,7 +307,7 @@ where
         let z_0 = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || Ok(self.z_0))?;
         let z_i = Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || Ok(self.z_i))?;
         let external_inputs =
-            Vec::<FpVar<CF1<C1>>>::new_witness(cs.clone(), || Ok(self.external_inputs))?;
+            FC::ExternalInputsVar::new_witness(cs.clone(), || Ok(self.external_inputs))?;
 
         let u_dummy = CommittedInstance::<C1, true>::dummy((2, self.U_i.betas.len()));
         let U_i = CommittedInstanceVar::<C1, true>::new_witness(cs.clone(), || Ok(self.U_i))?;

--- a/folding-schemes/src/folding/protogalaxy/decider_eth.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth.rs
@@ -285,8 +285,8 @@ pub mod tests {
         let start = Instant::now();
         let mut protogalaxy = PG::init(&protogalaxy_params, F_circuit, z_0.clone())?;
         println!("ProtoGalaxy initialized, {:?}", start.elapsed());
-        protogalaxy.prove_step(&mut rng, vec![], None)?;
-        protogalaxy.prove_step(&mut rng, vec![], None)?; // do a 2nd step
+        protogalaxy.prove_step(&mut rng, (), None)?;
+        protogalaxy.prove_step(&mut rng, (), None)?; // do a 2nd step
 
         // prepare the Decider prover & verifier params
         let (decider_pp, decider_vp) =
@@ -360,8 +360,8 @@ pub mod tests {
         let start = Instant::now();
         let mut protogalaxy = PG::init(&protogalaxy_params, F_circuit, z_0.clone())?;
         println!("ProtoGalaxy initialized, {:?}", start.elapsed());
-        protogalaxy.prove_step(&mut rng, vec![], None)?;
-        protogalaxy.prove_step(&mut rng, vec![], None)?; // do a 2nd step
+        protogalaxy.prove_step(&mut rng, (), None)?;
+        protogalaxy.prove_step(&mut rng, (), None)?; // do a 2nd step
 
         // prepare the Decider prover & verifier params
         let (decider_pp, decider_vp) =
@@ -402,9 +402,9 @@ pub mod tests {
         let mut protogalaxy = PG::init(&protogalaxy_params, F_circuit, z_0)?;
 
         let start = Instant::now();
-        protogalaxy.prove_step(&mut rng, vec![], None)?;
+        protogalaxy.prove_step(&mut rng, (), None)?;
         println!("prove_step, {:?}", start.elapsed());
-        protogalaxy.prove_step(&mut rng, vec![], None)?; // do a 2nd step
+        protogalaxy.prove_step(&mut rng, (), None)?; // do a 2nd step
 
         // decider proof generation
         let start = Instant::now();

--- a/folding-schemes/src/folding/protogalaxy/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth_circuit.rs
@@ -222,7 +222,7 @@ pub mod tests {
 
         // generate a Nova instance and do a step of it
         let mut protogalaxy = PG::init(&pg_params, F_circuit, z_0.clone())?;
-        protogalaxy.prove_step(&mut rng, vec![], None)?;
+        protogalaxy.prove_step(&mut rng, (), None)?;
 
         let ivc_proof = protogalaxy.ivc_proof();
         PG::verify(pg_params.1, ivc_proof)?;

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -567,7 +567,7 @@ where
             cs.clone(),
             0,
             Vec::new_witness(cs.clone(), || Ok(vec![Zero::zero(); state_len]))?,
-            FC::ExternalInputsVar::default(),
+            FC::ExternalInputsVar::new_witness(cs.clone(), || Ok(FC::ExternalInputs::default()))?,
         )?;
         let step_constraints = cs.num_constraints();
 

--- a/folding-schemes/src/frontend/mod.rs
+++ b/folding-schemes/src/frontend/mod.rs
@@ -12,12 +12,12 @@ pub mod utils;
 /// the step.
 /// Note that the external inputs for the specific circuit are defined at the implementation of
 /// both `FCircuit::ExternalInputs` and `FCircuit::ExternalInputsVar`, where the `Default` trait
-/// implementation. For example if the external inputs are just an array of field elements, their
-/// `Default` trait implementation must return an array of the expected size.
+/// implementation for the `ExternalInputs` returns the initialized data structure (ie. if the type
+/// contains a vector, it is initialized at the expected length).
 pub trait FCircuit<F: PrimeField>: Clone + Debug {
     type Params: Debug;
     type ExternalInputs: Clone + Default + Debug;
-    type ExternalInputsVar: Clone + Default + Debug + AllocVar<Self::ExternalInputs, F>;
+    type ExternalInputsVar: Clone + Debug + AllocVar<Self::ExternalInputs, F>;
 
     /// returns a new FCircuit instance
     fn new(params: Self::Params) -> Result<Self, Error>;

--- a/folding-schemes/src/frontend/utils.rs
+++ b/folding-schemes/src/frontend/utils.rs
@@ -146,12 +146,11 @@ impl<F: PrimeField, FC: FCircuit<F>> ConstraintSynthesizer<F> for WrapperCircuit
             Vec::<FpVar<F>>::new_witness(cs.clone(), || Ok(self.z_i.unwrap_or(vec![F::zero()])))?;
         let z_i1 =
             Vec::<FpVar<F>>::new_input(cs.clone(), || Ok(self.z_i1.unwrap_or(vec![F::zero()])))?;
-        let computed_z_i1 = self.FC.generate_step_constraints(
-            cs.clone(),
-            0,
-            z_i.clone(),
-            FC::ExternalInputsVar::default(),
-        )?;
+        let external_inputs =
+            FC::ExternalInputsVar::new_input(cs.clone(), || Ok(FC::ExternalInputs::default()))?;
+        let computed_z_i1 =
+            self.FC
+                .generate_step_constraints(cs.clone(), 0, z_i.clone(), external_inputs)?;
 
         use ark_r1cs_std::eq::EqGadget;
         computed_z_i1.enforce_equal(&z_i1)?;

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -197,7 +197,7 @@ pub trait FoldingScheme<
     fn prove_step(
         &mut self,
         rng: impl RngCore,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
         other_instances: Option<Self::MultiCommittedInstanceWithWitness>,
     ) -> Result<(), Error>;
 
@@ -237,7 +237,7 @@ pub trait MultiFolding<
         &self,
         rng: impl RngCore,
         state: Vec<C1::ScalarField>,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
     ) -> Result<Self::RunningInstance, Error>;
 
     /// Creates a new IncomingInstance for the given state, to be folded in the multi-folding step.
@@ -245,7 +245,7 @@ pub trait MultiFolding<
         &self,
         rng: impl RngCore,
         state: Vec<C1::ScalarField>,
-        external_inputs: Vec<C1::ScalarField>,
+        external_inputs: FC::ExternalInputs,
     ) -> Result<Self::IncomingInstance, Error>;
 }
 

--- a/solidity-verifiers/Cargo.toml
+++ b/solidity-verifiers/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 ark-groth16 = "^0.5.0"
-ark-bn254 = "^0.5.0"
+ark-bn254 = { version = "^0.5.0", default-features = false, features = ["r1cs"] }
 ark-poly-commit = "^0.5.0"
 ark-serialize = "^0.5.0"
 askama = { version = "0.12.0", features = ["config"], default-features = false }
@@ -22,7 +22,7 @@ ark-crypto-primitives = { version = "^0.5.0", default-features = false, features
 ark-snark = { version = "^0.5.0", default-features = false }
 ark-relations = { version = "^0.5.0", default-features = false }
 ark-r1cs-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-grumpkin = { version = "^0.5.0", default-features = false }
+ark-grumpkin = { version = "^0.5.0", default-features = false, features = ["r1cs"] }
 folding-schemes = { path = "../folding-schemes/", features=["light-test"]}
 experimental-frontends = { path = "../experimental-frontends/"}
 noname = { git = "https://github.com/dmpierre/noname" }

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -190,21 +190,20 @@ mod tests {
     }
     impl<F: PrimeField> FCircuit<F> for CubicFCircuit<F> {
         type Params = ();
+        type ExternalInputs = ();
+        type ExternalInputsVar = ();
         fn new(_params: Self::Params) -> Result<Self, Error> {
             Ok(Self { _f: PhantomData })
         }
         fn state_len(&self) -> usize {
             1
         }
-        fn external_inputs_len(&self) -> usize {
-            0
-        }
         fn generate_step_constraints(
             &self,
             cs: ConstraintSystemRef<F>,
             _i: usize,
             z_i: Vec<FpVar<F>>,
-            _external_inputs: Vec<FpVar<F>>,
+            _external_inputs: Self::ExternalInputsVar,
         ) -> Result<Vec<FpVar<F>>, SynthesisError> {
             let five = FpVar::<F>::new_constant(cs.clone(), F::from(5u32))?;
             let z_i = z_i[0].clone();
@@ -224,6 +223,8 @@ mod tests {
     }
     impl<F: PrimeField> FCircuit<F> for MultiInputsFCircuit<F> {
         type Params = ();
+        type ExternalInputs = ();
+        type ExternalInputsVar = ();
 
         fn new(_params: Self::Params) -> Result<Self, Error> {
             Ok(Self { _f: PhantomData })
@@ -231,16 +232,13 @@ mod tests {
         fn state_len(&self) -> usize {
             5
         }
-        fn external_inputs_len(&self) -> usize {
-            0
-        }
         /// generates the constraints for the step of F for the given z_i
         fn generate_step_constraints(
             &self,
             cs: ConstraintSystemRef<F>,
             _i: usize,
             z_i: Vec<FpVar<F>>,
-            _external_inputs: Vec<FpVar<F>>,
+            _external_inputs: Self::ExternalInputsVar,
         ) -> Result<Vec<FpVar<F>>, SynthesisError> {
             let four = FpVar::<F>::new_constant(cs.clone(), F::from(4u32))?;
             let forty = FpVar::<F>::new_constant(cs.clone(), F::from(40u32))?;
@@ -344,7 +342,8 @@ mod tests {
 
         let mut nova = NOVA::<FC>::init(&fs_params, f_circuit, z_0).unwrap();
         for _ in 0..n_steps {
-            nova.prove_step(&mut rng, vec![], None).unwrap();
+            nova.prove_step(&mut rng, FC::ExternalInputs::default(), None)
+                .unwrap();
         }
 
         let start = Instant::now();


### PR DESCRIPTION
Update the FCircuit trait, so that it supports custom data structures for the external inputs.

This also eliminates the need of having the `external_inputs_len` method in the `FCircuit`.

The motivation for this change is that in most practical use cases, the external inputs have a not-naive structure, and the old interface required that to convert the external inputs structure into a vector of finite field elements, which inside the FCircuit would be converted back into a custom data structure. This is specially tedious when dealing with curve points, which converting them from point to field elements and back to the point (both outside (rust native) and inside the circuit (constraints)) is a bit cumbersome.  With this update, it's much more straight forward to define the FCircuit with custom external inputs data structures.

For the experimental-frontends, the external inputs keep being an array of field elements.

> When reviewing this PR: the main change is in the file [folding-schemes/src/frontend/mod.rs](https://github.com/privacy-scaling-explorations/sonobe/pull/191/files#diff-b36294c106971af264dff9fa104e0e4602d6d3a540bc44cc9b7f130e4c3b06fe), most of the rest of the git diff is just updating the code to the new `FCircuit` interface.

### Context/motivation
When doing more 'real world' use cases, it is convenient to don't have the limitation to just arrays of field elements for the external inputs on the FCircuit. For example, when dealing with elliptic curve points, it required to convert the points to affine to get their coordinates as field elements, then concatenate the various field elements (coordinates) from various points to pass it as `Vec<FpVar<F>>` as the `external_inputs` to the FCircuit, which then inside the FCircuit that vector gets decomposed back into separated coordinates to rebuild the elliptic curve points (which in order to do so, need to break some of the abstractions to be able to build the specific curve points).
This grows in complexity as the data structures needed are more rich.

As an example, suppose we want to have as external inputs the following structure `ExtInpVar`:
```rust
pub struct ExtInpVar<C: CurveGroup, GC: CurveVar<C, CF<C>>> {
    msg: FpVar<CF<C>>,
    pk: GC,
    sig_r: GC,
    sig_s: Vec<Boolean<CF<C>>>,
}
```

with this PR, in the `FCircuit` we just need to set the trait parameters:
```rust
type ExternalInputs = ExtInp<C>;
type ExternalInputsVar = ExtInpVar<C, GC>;
```
And then we can just directly use that type for the `external_inputs`:
```rust
    fn generate_step_constraints(
        &self,
        cs: ConstraintSystemRef<F>,
        _i: usize,
        z_i: Vec<FpVar<F>>,
        external_inputs: Self::ExternalInputsVar,
    ) -> Result<Vec<FpVar<F>>, SynthesisError> {
        let mut count = z_i[0].clone();
        let res = verify::<C, GC>(
            cs.clone(),
            self.config.clone(),
            external_inputs.pk,
            (external_inputs.sig_r, external_inputs.sig_s),
            external_inputs.msg,
        )?;
        res.enforce_equal(&Boolean::<F>::TRUE)?;
        count = count.clone() + FpVar::<F>::one();

        Ok(vec![count])
    }
}
```

The same use case before this PR, would have required much more code, and furthermore it would have needed to remove some of the curve abstractions in order to be able to reconstruct the `GC` points from their coordinates inside the `FCircuit`.

Full use case example code available at: [https://github.com/arnaucube/fold-babyjubjubs/blob/main/src/fcircuit.rs#L53](https://github.com/arnaucube/fold-babyjubjubs/blob/4dfb2781421f3e98fc0556a13f0f4bac5d9c3eaa/src/fcircuit.rs#L53)