### PR TITLE
Fix typographical errors in documentation and comments

### DIFF
--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -98,7 +98,7 @@ impl<'a, E: Pairing<G1: Curve>, const H: bool> CommitmentScheme<E::G1, H> for KZ
     }
 
     /// setup returns the tuple (ProverKey, VerifierKey). For real world deployments the setup must
-    /// be computed in the most trustless way possible, usually through a MPC ceremony.
+    /// be computed in the most trustless way possible, usually through an MPC ceremony.
     fn setup(
         mut rng: impl RngCore,
         len: usize,

--- a/folding-schemes/src/folding/nova/nifs/nova.rs
+++ b/folding-schemes/src/folding/nova/nifs/nova.rs
@@ -23,7 +23,7 @@ use crate::utils::vec::{hadamard, mat_vec_mul, vec_add, vec_scalar_mul, vec_sub}
 use crate::{Curve, Error};
 
 /// ChallengeGadget computes the RO challenge used for the Nova instances NIFS, it contains a
-/// rust-native and a in-circuit compatible versions.
+/// rust-native and an in-circuit compatible versions.
 pub struct ChallengeGadget<C: Curve, CI: Absorb> {
     _c: PhantomData<C>,
     _ci: PhantomData<CI>,

--- a/folding-schemes/src/utils/espresso/virtual_polynomial.rs
+++ b/folding-schemes/src/utils/espresso/virtual_polynomial.rs
@@ -125,7 +125,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
         }
     }
 
-    /// Creates an new virtual polynomial from a MLE and its coefficient.
+    /// Creates a new virtual polynomial from a MLE and its coefficient.
     pub fn new_from_mle(mle: &Arc<DenseMultilinearExtension<F>>, coefficient: F) -> Self {
         let mle_ptr: *const DenseMultilinearExtension<F> = Arc::as_ptr(mle);
         let mut hm = HashMap::new();

--- a/folding-schemes/src/utils/gadgets.rs
+++ b/folding-schemes/src/utils/gadgets.rs
@@ -12,7 +12,7 @@ use crate::utils::vec::SparseMatrix;
 
 /// `EquivalenceGadget` enforces that two in-circuit variables are equivalent,
 /// where the equivalence relation is parameterized by `M`:
-/// - For `FpVar`, it is simply a equality relation, and `M` is unused.
+/// - For `FpVar`, it is simply an equality relation, and `M` is unused.
 /// - For `NonNativeUintVar`, we consider equivalence as a congruence relation,
 ///   in terms of modular arithmetic, so `M` specifies the modulus.
 pub trait EquivalenceGadget<M> {


### PR DESCRIPTION
This PR addresses several typographical errors in documentation and inline comments across multiple files. These changes ensure grammatical accuracy and improve clarity for developers reading the code.

#### **Files Changed:**

1. **`kzg.rs`**  
   - Corrected "a MPC ceremony" to "an MPC ceremony."

2. **`nova.rs`**  
   - Corrected "a in-circuit compatible versions" to "an in-circuit compatible versions."

3. **`virtual_polynomial.rs`**  
   - Corrected "an new virtual polynomial" to "a new virtual polynomial."

4. **`gadgets.rs`**  
   - Corrected "a equality relation" to "an equality relation."

---

### **Additional Notes**  

These updates are limited to documentation and comments. They do not affect the functionality of the codebase.

---

### **Checklist**  

- [x] Targeted the correct branch.  
- [x] Verified all changes are grammatical improvements.  
- [x] No changes to functionality or logic were made.  

---
