### PR TITLE
Remove `fs` from the parameters of `Decider::preprocess`

### DIFF
--- a/examples/circom_full_flow.rs
+++ b/examples/circom_full_flow.rs
@@ -87,11 +87,12 @@ fn main() -> Result<(), Error> {
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config, f_circuit.clone());
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params)?;
 
+    // prepare the Decider prover & verifier params
+    let (decider_pp, decider_vp) =
+        D::preprocess(&mut rng, (nova_params.clone(), f_circuit.state_len()))?;
+
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit.clone(), z_0)?;
-
-    // prepare the Decider prover & verifier params
-    let (decider_pp, decider_vp) = D::preprocess(&mut rng, nova_params.clone(), nova.clone())?;
 
     // run n steps of the folding iteration
     for (i, external_inputs_at_step) in external_inputs.iter().enumerate() {

--- a/examples/full_flow.rs
+++ b/examples/full_flow.rs
@@ -87,11 +87,12 @@ fn main() -> Result<(), Error> {
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config.clone(), f_circuit);
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params)?;
 
+    // prepare the Decider prover & verifier params
+    let (decider_pp, decider_vp) =
+        D::preprocess(&mut rng, (nova_params.clone(), f_circuit.state_len()))?;
+
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit, z_0)?;
-
-    // prepare the Decider prover & verifier params
-    let (decider_pp, decider_vp) = D::preprocess(&mut rng, nova_params, nova.clone())?;
 
     // run n steps of the folding iteration
     for i in 0..n_steps {

--- a/examples/noir_full_flow.rs
+++ b/examples/noir_full_flow.rs
@@ -67,11 +67,12 @@ fn main() -> Result<(), Error> {
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config, f_circuit.clone());
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params)?;
 
+    // prepare the Decider prover & verifier params
+    let (decider_pp, decider_vp) =
+        D::preprocess(&mut rng, (nova_params.clone(), f_circuit.state_len()))?;
+
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit.clone(), z_0)?;
-
-    // prepare the Decider prover & verifier params
-    let (decider_pp, decider_vp) = D::preprocess(&mut rng, nova_params.clone(), nova.clone())?;
 
     // run n steps of the folding iteration
     for i in 0..5 {

--- a/examples/noname_full_flow.rs
+++ b/examples/noname_full_flow.rs
@@ -86,11 +86,12 @@ fn main() -> Result<(), Error> {
     let nova_preprocess_params = PreprocessorParam::new(poseidon_config, f_circuit.clone());
     let nova_params = N::preprocess(&mut rng, &nova_preprocess_params)?;
 
+    // prepare the Decider prover & verifier params
+    let (decider_pp, decider_vp) =
+        D::preprocess(&mut rng, (nova_params.clone(), f_circuit.state_len()))?;
+
     // initialize the folding scheme engine, in our case we use Nova
     let mut nova = N::init(&nova_params, f_circuit.clone(), z_0)?;
-
-    // prepare the Decider prover & verifier params
-    let (decider_pp, decider_vp) = D::preprocess(&mut rng, nova_params.clone(), nova.clone())?;
 
     // run n steps of the folding iteration
     for (i, external_inputs_at_step) in external_inputs.iter().enumerate() {

--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -388,7 +388,8 @@ pub mod tests {
 
         // prepare the Decider prover & verifier params
         let start = Instant::now();
-        let (decider_pp, decider_vp) = D::preprocess(&mut rng, (nova_params, F_circuit.state_len()))?;
+        let (decider_pp, decider_vp) =
+            D::preprocess(&mut rng, (nova_params, F_circuit.state_len()))?;
         println!("Decider preprocess, {:?}", start.elapsed());
 
         // decider proof generation

--- a/folding-schemes/src/folding/nova/decider_eth.rs
+++ b/folding-schemes/src/folding/nova/decider_eth.rs
@@ -323,7 +323,8 @@ pub mod tests {
         println!("Nova initialized, {:?}", start.elapsed());
 
         // prepare the Decider prover & verifier params
-        let (decider_pp, decider_vp) = D::preprocess(&mut rng, (nova_params, F_circuit.state_len()))?;
+        let (decider_pp, decider_vp) =
+            D::preprocess(&mut rng, (nova_params, F_circuit.state_len()))?;
 
         let start = Instant::now();
         nova.prove_step(&mut rng, (), None)?;
@@ -397,7 +398,8 @@ pub mod tests {
         let nova_params = N::preprocess(&mut rng, &preprocessor_param)?;
 
         // prepare the Decider prover & verifier params
-        let (decider_pp, decider_vp) = D::preprocess(&mut rng, (nova_params.clone(), F_circuit.state_len()))?;
+        let (decider_pp, decider_vp) =
+            D::preprocess(&mut rng, (nova_params.clone(), F_circuit.state_len()))?;
 
         // serialize the Nova params. These params are the trusted setup of the commitment schemes used
         // (ie. KZG & Pedersen in this case)

--- a/folding-schemes/src/lib.rs
+++ b/folding-schemes/src/lib.rs
@@ -266,7 +266,6 @@ pub trait Decider<
     fn preprocess(
         rng: impl RngCore + CryptoRng,
         prep_param: Self::PreprocessorParam,
-        fs: FS,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error>;
 
     fn prove(

--- a/solidity-verifiers/src/verifiers/nova_cyclefold.rs
+++ b/solidity-verifiers/src/verifiers/nova_cyclefold.rs
@@ -146,7 +146,6 @@ mod tests {
     use ark_r1cs_std::alloc::AllocVar;
     use ark_r1cs_std::fields::fp::FpVar;
     use ark_relations::r1cs::{ConstraintSystemRef, SynthesisError};
-    use ark_std::Zero;
     use askama::Template;
     use std::marker::PhantomData;
     use std::time::Instant;
@@ -305,14 +304,9 @@ mod tests {
                 f_circuit.clone(),
             );
         let nova_params = NOVA::preprocess(&mut rng, &prep_param).unwrap();
-        let nova = NOVA::init(
-            &nova_params,
-            f_circuit.clone(),
-            vec![Fr::zero(); f_circuit.state_len()].clone(),
-        )
-        .unwrap();
         let decider_params =
-            DECIDER::preprocess(&mut rng, nova_params.clone(), nova.clone()).unwrap();
+            DECIDER::<FC>::preprocess(&mut rng, (nova_params.clone(), f_circuit.state_len()))
+                .unwrap();
 
         (nova_params, decider_params)
     }


### PR DESCRIPTION
In the current `Decider` trait, the `preprocess` method takes `fs`, an instance of the `FoldingScheme` trait, as input.

However, note that `fs` is created by the prover by running `FoldingScheme::init` with the initial state `z_0`. On the other hand, `Decider::preprocess` is usually invoked by a trusted party at the beginning (before provers and verifiers are involved), when `z_0` is still unknown.

Thus, it makes more sense to remove the `fs` parameter from `Decider::preprocess`. The implementations of `Decider` are updated correspondingly, so that the preprocessing can be done without a concrete `fs`. Instead, we simply build a dummy decider circuit, during which we only need to provide some parameters that are known before the creation of `fs`.