### PR TITLE
Fix spelling

### DIFF
--- a/folding-schemes/src/commitment/kzg.rs
+++ b/folding-schemes/src/commitment/kzg.rs
@@ -98,7 +98,7 @@ impl<'a, E: Pairing<G1: Curve>, const H: bool> CommitmentScheme<E::G1, H> for KZ
     }
 
     /// setup returns the tuple (ProverKey, VerifierKey). For real world deployments the setup must
-    /// be computed in the most trustless way possible, usually through a MPC ceremony.
+    /// be computed in the most trustless way possible, usually through an MPC ceremony.
     fn setup(
         mut rng: impl RngCore,
         len: usize,

--- a/folding-schemes/src/utils/espresso/virtual_polynomial.rs
+++ b/folding-schemes/src/utils/espresso/virtual_polynomial.rs
@@ -125,7 +125,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
         }
     }
 
-    /// Creates an new virtual polynomial from a MLE and its coefficient.
+    /// Creates a new virtual polynomial from a MLE and its coefficient.
     pub fn new_from_mle(mle: &Arc<DenseMultilinearExtension<F>>, coefficient: F) -> Self {
         let mle_ptr: *const DenseMultilinearExtension<F> = Arc::as_ptr(mle);
         let mut hm = HashMap::new();

--- a/folding-schemes/src/utils/gadgets.rs
+++ b/folding-schemes/src/utils/gadgets.rs
@@ -12,7 +12,7 @@ use crate::utils::vec::SparseMatrix;
 
 /// `EquivalenceGadget` enforces that two in-circuit variables are equivalent,
 /// where the equivalence relation is parameterized by `M`:
-/// - For `FpVar`, it is simply a equality relation, and `M` is unused.
+/// - For `FpVar`, it is simply an equality relation, and `M` is unused.
 /// - For `NonNativeUintVar`, we consider equivalence as a congruence relation,
 ///   in terms of modular arithmetic, so `M` specifies the modulus.
 pub trait EquivalenceGadget<M> {


### PR DESCRIPTION
- Fixed "an MPC ceremony" → "a MPC ceremony" in `kzg.rs`.
- Corrected "an new virtual polynomial" → "a new virtual polynomial" in `virtual_polynomial.rs`.
- Fixed redundant "a equality relation" → "an equality relation" in `gadgets.rs`.
