### PR TITLE
Introduce getter methods for information related to constraint systems

### DIFF
--- a/folding-schemes/src/arith/ccs/mod.rs
+++ b/folding-schemes/src/arith/ccs/mod.rs
@@ -6,8 +6,8 @@ use crate::utils::vec::{
 };
 use crate::Error;
 
-use super::ArithSerializer;
 use super::{r1cs::R1CS, ArithRelation};
+use super::{Arith, ArithSerializer};
 
 pub mod circuits;
 
@@ -71,6 +71,13 @@ impl<F: PrimeField> CCS<F> {
     }
 }
 
+impl<F: PrimeField> Arith for CCS<F> {
+    #[inline]
+    fn degree(&self) -> usize {
+        self.d
+    }
+}
+
 impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> ArithRelation<W, U> for CCS<F> {
     type Evaluation = Vec<F>;
 
@@ -109,7 +116,7 @@ impl<F: PrimeField> From<R1CS<F>> for CCS<F> {
             s_prime: log2(n) as usize,
             t: 3,
             q: 2,
-            d: 2,
+            d: r1cs.degree(),
 
             S: vec![vec![0, 1], vec![2]],
             c: vec![F::one(), F::one().neg()],

--- a/folding-schemes/src/arith/ccs/mod.rs
+++ b/folding-schemes/src/arith/ccs/mod.rs
@@ -7,7 +7,7 @@ use crate::utils::vec::{
 use crate::Error;
 
 use super::ArithSerializer;
-use super::{r1cs::R1CS, Arith};
+use super::{r1cs::R1CS, ArithRelation};
 
 pub mod circuits;
 
@@ -71,7 +71,7 @@ impl<F: PrimeField> CCS<F> {
     }
 }
 
-impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> Arith<W, U> for CCS<F> {
+impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> ArithRelation<W, U> for CCS<F> {
     type Evaluation = Vec<F>;
 
     fn eval_relation(&self, w: &W, u: &U) -> Result<Self::Evaluation, Error> {

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -1,3 +1,4 @@
+use ark_ff::PrimeField;
 use ark_relations::r1cs::SynthesisError;
 use ark_std::rand::RngCore;
 
@@ -6,14 +7,32 @@ use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Curve, Error};
 pub mod ccs;
 pub mod r1cs;
 
+/// [`Arith`] is a trait about constraint systems (R1CS, CCS, etc.), where we
+/// define methods for getting information about the constraint system.
 pub trait Arith: Clone {
+    /// Returns the degree of the constraint system
     fn degree(&self) -> usize;
+
+    /// Returns the number of constraints in the constraint system
+    fn n_constraints(&self) -> usize;
+
+    /// Returns the number of variables in the constraint system
+    fn n_variables(&self) -> usize;
+
+    /// Returns the number of public inputs / public IO / instances / statements
+    /// in the constraint system
+    fn n_public_inputs(&self) -> usize;
+
+    /// Returns the number of witnesses / secret inputs in the constraint system
+    fn n_witnesses(&self) -> usize;
+
+    /// Returns a tuple containing (w, x) (witness and public inputs respectively)
+    fn split_z<F: PrimeField>(&self, z: &[F]) -> (Vec<F>, Vec<F>);
 }
 
-/// `ArithRelation` treats a constraint system (R1CS, CCS, etc.) as a relation
-/// between a witness of type `W` and a statement / public input / public IO /
-/// instance of type `U`, and in this trait, we define the necessary operations
-/// on the relation.
+/// `ArithRelation` *treats a constraint system as a relation* between a witness
+/// of type `W` and a statement / public input / public IO / instance of type
+/// `U`, and in this trait, we define the necessary operations on the relation.
 ///
 /// Note that the same constraint system may support different types of `W` and
 /// `U`, and the satisfiability check may vary.

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -6,11 +6,11 @@ use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Curve, Error};
 pub mod ccs;
 pub mod r1cs;
 
-/// `Arith` defines the operations that a constraint system (e.g., R1CS, CCS,
-/// etc.) should support.
+/// `ArithRelation` treats a constraint system (R1CS, CCS, etc.) as a relation
+/// between a witness of type `W` and a statement / public input / public IO /
+/// instance of type `U`, and in this trait, we define the necessary operations
+/// on the relation.
 ///
-/// Here, `W` is the type of witness, and `U` is the type of statement / public
-/// input / public IO / instance.
 /// Note that the same constraint system may support different types of `W` and
 /// `U`, and the satisfiability check may vary.
 ///
@@ -40,7 +40,7 @@ pub mod r1cs;
 /// This is also the case of CCS, where `W` and `U` may be vectors of field
 /// elements, [`crate::folding::hypernova::Witness`] and [`crate::folding::hypernova::lcccs::LCCCS`],
 /// or [`crate::folding::hypernova::Witness`] and [`crate::folding::hypernova::cccs::CCCS`].
-pub trait Arith<W, U>: Clone {
+pub trait ArithRelation<W, U>: Clone {
     type Evaluation;
 
     /// Returns a dummy witness and instance
@@ -122,7 +122,7 @@ pub trait ArithSerializer {
 /// in a plain R1CS.
 ///
 /// [HyperNova]: https://eprint.iacr.org/2023/573.pdf
-pub trait ArithSampler<C: Curve, W, U>: Arith<W, U> {
+pub trait ArithSampler<C: Curve, W, U>: ArithRelation<W, U> {
     /// Samples a random witness and instance that satisfy the constraint system.
     fn sample_witness_instance<CS: CommitmentScheme<C, true>>(
         &self,
@@ -131,9 +131,9 @@ pub trait ArithSampler<C: Curve, W, U>: Arith<W, U> {
     ) -> Result<(W, U), Error>;
 }
 
-/// `ArithGadget` defines the in-circuit counterparts of operations specified in
-/// `Arith` on constraint systems.
-pub trait ArithGadget<WVar, UVar> {
+/// `ArithRelationGadget` defines the in-circuit counterparts of operations
+/// specified in `ArithRelation` on constraint systems.
+pub trait ArithRelationGadget<WVar, UVar> {
     type Evaluation;
 
     /// Evaluates the constraint system `self` at witness `w` and instance `u`.

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -6,6 +6,10 @@ use crate::{commitment::CommitmentScheme, folding::traits::Dummy, Curve, Error};
 pub mod ccs;
 pub mod r1cs;
 
+pub trait Arith: Clone {
+    fn degree(&self) -> usize;
+}
+
 /// `ArithRelation` treats a constraint system (R1CS, CCS, etc.) as a relation
 /// between a witness of type `W` and a statement / public input / public IO /
 /// instance of type `U`, and in this trait, we define the necessary operations
@@ -40,7 +44,7 @@ pub mod r1cs;
 /// This is also the case of CCS, where `W` and `U` may be vectors of field
 /// elements, [`crate::folding::hypernova::Witness`] and [`crate::folding::hypernova::lcccs::LCCCS`],
 /// or [`crate::folding::hypernova::Witness`] and [`crate::folding::hypernova::cccs::CCCS`].
-pub trait ArithRelation<W, U>: Clone {
+pub trait ArithRelation<W, U>: Arith {
     type Evaluation;
 
     /// Returns a dummy witness and instance

--- a/folding-schemes/src/arith/r1cs/circuits.rs
+++ b/folding-schemes/src/arith/r1cs/circuits.rs
@@ -86,8 +86,6 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use std::cmp::max;
-
     use ark_crypto_primitives::crh::{
         sha256::{
             constraints::{Sha256Gadget, UnitVar},
@@ -101,6 +99,7 @@ pub mod tests {
     use ark_r1cs_std::{eq::EqGadget, fields::fp::FpVar, uint8::UInt8};
     use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef};
     use ark_std::{
+        cmp::max,
         rand::{thread_rng, Rng},
         One, UniformRand,
     };
@@ -112,7 +111,7 @@ pub mod tests {
             extract_r1cs, extract_w_x,
             tests::{get_test_r1cs, get_test_z},
         },
-        ArithRelation,
+        Arith, ArithRelation,
     };
     use crate::commitment::{pedersen::Pedersen, CommitmentScheme};
     use crate::folding::{

--- a/folding-schemes/src/arith/r1cs/circuits.rs
+++ b/folding-schemes/src/arith/r1cs/circuits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    arith::ArithGadget,
+    arith::ArithRelationGadget,
     utils::gadgets::{EquivalenceGadget, MatrixGadget, SparseMatrixVar, VectorGadget},
 };
 use ark_ff::PrimeField;
@@ -59,7 +59,7 @@ where
     }
 }
 
-impl<M, FVar, WVar: AsRef<[FVar]>, UVar: AsRef<[FVar]>> ArithGadget<WVar, UVar>
+impl<M, FVar, WVar: AsRef<[FVar]>, UVar: AsRef<[FVar]>> ArithRelationGadget<WVar, UVar>
     for R1CSMatricesVar<M, FVar>
 where
     SparseMatrixVar<FVar>: MatrixGadget<FVar>,
@@ -112,7 +112,7 @@ pub mod tests {
             extract_r1cs, extract_w_x,
             tests::{get_test_r1cs, get_test_z},
         },
-        Arith,
+        ArithRelation,
     };
     use crate::commitment::{pedersen::Pedersen, CommitmentScheme};
     use crate::folding::{

--- a/folding-schemes/src/arith/r1cs/mod.rs
+++ b/folding-schemes/src/arith/r1cs/mod.rs
@@ -4,7 +4,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::Rng;
 
 use super::ccs::CCS;
-use super::{Arith, ArithSerializer};
+use super::{ArithRelation, ArithSerializer};
 use crate::utils::vec::{
     hadamard, is_zero_vec, mat_vec_mul, vec_scalar_mul, vec_sub, SparseMatrix,
 };
@@ -43,7 +43,7 @@ impl<F: PrimeField> R1CS<F> {
     }
 }
 
-impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> Arith<W, U> for R1CS<F> {
+impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> ArithRelation<W, U> for R1CS<F> {
     type Evaluation = Vec<F>;
 
     fn eval_relation(&self, w: &W, u: &U) -> Result<Self::Evaluation, Error> {

--- a/folding-schemes/src/arith/r1cs/mod.rs
+++ b/folding-schemes/src/arith/r1cs/mod.rs
@@ -4,7 +4,7 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::rand::Rng;
 
 use super::ccs::CCS;
-use super::{ArithRelation, ArithSerializer};
+use super::{Arith, ArithRelation, ArithSerializer};
 use crate::utils::vec::{
     hadamard, is_zero_vec, mat_vec_mul, vec_scalar_mul, vec_sub, SparseMatrix,
 };
@@ -40,6 +40,13 @@ impl<F: PrimeField> R1CS<F> {
         let uCz = vec_scalar_mul(&Cz, &z[0]);
         let AzBz = hadamard(&Az, &Bz)?;
         vec_sub(&AzBz, &uCz)
+    }
+}
+
+impl<F: PrimeField> Arith for R1CS<F> {
+    #[inline]
+    fn degree(&self) -> usize {
+        2
     }
 }
 

--- a/folding-schemes/src/arith/r1cs/mod.rs
+++ b/folding-schemes/src/arith/r1cs/mod.rs
@@ -5,6 +5,7 @@ use ark_std::rand::Rng;
 
 use super::ccs::CCS;
 use super::{Arith, ArithRelation, ArithSerializer};
+use crate::folding::traits::Dummy;
 use crate::utils::vec::{
     hadamard, is_zero_vec, mat_vec_mul, vec_scalar_mul, vec_sub, SparseMatrix,
 };
@@ -14,14 +15,14 @@ pub mod circuits;
 
 #[derive(Debug, Clone, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct R1CS<F: PrimeField> {
-    pub l: usize, // io len
+    l: usize, // io len
     pub A: SparseMatrix<F>,
     pub B: SparseMatrix<F>,
     pub C: SparseMatrix<F>,
 }
 
 impl<F: PrimeField> R1CS<F> {
-    /// Evaluates the CCS relation at a given vector of variables `z`
+    /// Evaluates the R1CS relation at a given vector of variables `z`
     pub fn eval_at_z(&self, z: &[F]) -> Result<Vec<F>, Error> {
         if z.len() != self.A.n_cols {
             return Err(Error::NotSameLength(
@@ -48,6 +49,30 @@ impl<F: PrimeField> Arith for R1CS<F> {
     fn degree(&self) -> usize {
         2
     }
+
+    #[inline]
+    fn n_constraints(&self) -> usize {
+        self.A.n_rows
+    }
+
+    #[inline]
+    fn n_variables(&self) -> usize {
+        self.A.n_cols
+    }
+
+    #[inline]
+    fn n_public_inputs(&self) -> usize {
+        self.l
+    }
+
+    #[inline]
+    fn n_witnesses(&self) -> usize {
+        self.n_variables() - self.n_public_inputs() - 1
+    }
+
+    fn split_z<P: PrimeField>(&self, z: &[P]) -> (Vec<P>, Vec<P>) {
+        (z[self.l + 1..].to_vec(), z[1..self.l + 1].to_vec())
+    }
 }
 
 impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> ArithRelation<W, U> for R1CS<F> {
@@ -73,14 +98,20 @@ impl<F: PrimeField> ArithSerializer for R1CS<F> {
     }
 }
 
+impl<F: PrimeField> Dummy<(usize, usize, usize)> for R1CS<F> {
+    fn dummy((n_constraints, n_variables, n_public_inputs): (usize, usize, usize)) -> Self {
+        Self {
+            l: n_public_inputs,
+            A: SparseMatrix::dummy((n_constraints, n_variables)),
+            B: SparseMatrix::dummy((n_constraints, n_variables)),
+            C: SparseMatrix::dummy((n_constraints, n_variables)),
+        }
+    }
+}
+
 impl<F: PrimeField> R1CS<F> {
     pub fn empty() -> Self {
-        R1CS {
-            l: 0,
-            A: SparseMatrix::empty(),
-            B: SparseMatrix::empty(),
-            C: SparseMatrix::empty(),
-        }
+        Self::dummy((0, 0, 0))
     }
     pub fn rand<R: Rng>(rng: &mut R, n_rows: usize, n_cols: usize) -> Self {
         Self {
@@ -90,37 +121,12 @@ impl<F: PrimeField> R1CS<F> {
             C: SparseMatrix::rand(rng, n_rows, n_cols),
         }
     }
-
-    #[inline]
-    pub fn num_constraints(&self) -> usize {
-        self.A.n_rows
-    }
-
-    #[inline]
-    pub fn num_public_inputs(&self) -> usize {
-        self.l
-    }
-
-    #[inline]
-    pub fn num_variables(&self) -> usize {
-        self.A.n_cols
-    }
-
-    #[inline]
-    pub fn num_witnesses(&self) -> usize {
-        self.num_variables() - self.num_public_inputs() - 1
-    }
-
-    /// returns a tuple containing (w, x) (witness and public inputs respectively)
-    pub fn split_z(&self, z: &[F]) -> (Vec<F>, Vec<F>) {
-        (z[self.l + 1..].to_vec(), z[1..self.l + 1].to_vec())
-    }
 }
 
 impl<F: PrimeField> From<CCS<F>> for R1CS<F> {
     fn from(ccs: CCS<F>) -> Self {
         R1CS::<F> {
-            l: ccs.l,
+            l: ccs.n_public_inputs(),
             A: ccs.M[0].clone(),
             B: ccs.M[1].clone(),
             C: ccs.M[2].clone(),

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -30,7 +30,7 @@ use crate::Error;
 use crate::{
     arith::{
         r1cs::{circuits::R1CSMatricesVar, extract_w_x, R1CS},
-        ArithGadget,
+        ArithRelationGadget,
     },
     folding::traits::InputizeNonNative,
     Curve,
@@ -261,7 +261,7 @@ impl<C: Curve> NIFSFullGadget<C> {
     }
 }
 
-impl<C: Curve> ArithGadget<CycleFoldWitnessVar<C>, CycleFoldCommittedInstanceVar<C>>
+impl<C: Curve> ArithRelationGadget<CycleFoldWitnessVar<C>, CycleFoldCommittedInstanceVar<C>>
     for R1CSMatricesVar<CF1<C>, NonNativeUintVar<CF2<C>>>
 {
     type Evaluation = (Vec<NonNativeUintVar<CF2<C>>>, Vec<NonNativeUintVar<CF2<C>>>);
@@ -557,7 +557,7 @@ where
 
     #[cfg(test)]
     {
-        use crate::{arith::Arith, folding::traits::CommittedInstanceOps};
+        use crate::{arith::ArithRelation, folding::traits::CommittedInstanceOps};
         cf_u_i.check_incoming()?;
         cf_r1cs.check_relation(&cf_w_i, &cf_u_i)?;
         cf_r1cs.check_relation(&cf_W_i1, &cf_U_i1)?;

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -21,20 +21,19 @@ use ark_std::Zero;
 use core::{borrow::Borrow, marker::PhantomData};
 
 use super::{nonnative::uint::NonNativeUintVar, CF1, CF2};
+use crate::arith::{
+    r1cs::{circuits::R1CSMatricesVar, extract_w_x, R1CS},
+    Arith, ArithRelationGadget,
+};
 use crate::commitment::CommitmentScheme;
 use crate::constants::NOVA_N_BITS_RO;
-use crate::folding::nova::nifs::{nova::NIFS, NIFSTrait};
+use crate::folding::{
+    nova::nifs::{nova::NIFS, NIFSTrait},
+    traits::InputizeNonNative,
+};
 use crate::transcript::{AbsorbNonNative, AbsorbNonNativeGadget, Transcript, TranscriptVar};
 use crate::utils::gadgets::{EquivalenceGadget, VectorGadget};
-use crate::Error;
-use crate::{
-    arith::{
-        r1cs::{circuits::R1CSMatricesVar, extract_w_x, R1CS},
-        ArithRelationGadget,
-    },
-    folding::traits::InputizeNonNative,
-    Curve,
-};
+use crate::{Curve, Error};
 
 /// Re-export the Nova committed instance as `CycleFoldCommittedInstance` and
 /// witness as `CycleFoldWitness`, for clarity and consistency
@@ -528,7 +527,8 @@ where
     assert_eq!(cf_x_i.len(), CFG::IO_LEN);
 
     // fold cyclefold instances
-    let cf_w_i = CycleFoldWitness::<C2>::new::<H>(cf_w_i.clone(), cf_r1cs.A.n_rows, &mut rng);
+    let cf_w_i =
+        CycleFoldWitness::<C2>::new::<H>(cf_w_i.clone(), cf_r1cs.n_constraints(), &mut rng);
     let cf_u_i = cf_w_i.commit::<CS2, H>(&cf_cs_params, cf_x_i.clone())?;
 
     // compute T* and cmT* for CycleFoldCircuit

--- a/folding-schemes/src/folding/circuits/decider/mod.rs
+++ b/folding-schemes/src/folding/circuits/decider/mod.rs
@@ -13,7 +13,7 @@ use ark_std::log2;
 use crate::folding::traits::{CommittedInstanceOps, CommittedInstanceVarOps, Dummy, WitnessOps};
 use crate::transcript::{Transcript, TranscriptVar};
 use crate::utils::vec::poly_from_vec;
-use crate::{arith::Arith, folding::circuits::CF1};
+use crate::{arith::ArithRelation, folding::circuits::CF1};
 use crate::{Curve, Error};
 
 pub mod off_chain;
@@ -99,7 +99,7 @@ pub trait DeciderEnabledNIFS<
     RU: CommittedInstanceOps<C>, // Running instance
     IU: CommittedInstanceOps<C>, // Incoming instance
     W: WitnessOps<CF1<C>>,
-    A: Arith<W, RU>,
+    A: ArithRelation<W, RU>,
 >
 {
     type ProofDummyCfg;

--- a/folding-schemes/src/folding/circuits/decider/off_chain.rs
+++ b/folding-schemes/src/folding/circuits/decider/off_chain.rs
@@ -13,7 +13,7 @@ use ark_std::{marker::PhantomData, Zero};
 use crate::{
     arith::{
         r1cs::{circuits::R1CSMatricesVar, R1CS},
-        Arith, ArithGadget,
+        ArithRelation, ArithRelationGadget,
     },
     folding::{
         circuits::{
@@ -37,11 +37,11 @@ use super::DeciderEnabledNIFS;
 pub struct GenericOffchainDeciderCircuit1<
     C1: Curve,
     C2: Curve,
-    RU: CommittedInstanceOps<C1>,       // Running instance
-    IU: CommittedInstanceOps<C1>,       // Incoming instance
-    W: WitnessOps<CF1<C1>>,             // Witness
-    A: Arith<W, RU>,                    // Constraint system
-    AVar: ArithGadget<W::Var, RU::Var>, // In-circuit representation of `A`
+    RU: CommittedInstanceOps<C1>,               // Running instance
+    IU: CommittedInstanceOps<C1>,               // Incoming instance
+    W: WitnessOps<CF1<C1>>,                     // Witness
+    A: ArithRelation<W, RU>,                    // Constraint system
+    AVar: ArithRelationGadget<W::Var, RU::Var>, // In-circuit representation of `A`
     D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
 > {
     pub _avar: PhantomData<AVar>,
@@ -81,8 +81,8 @@ impl<
         RU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         IU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         W: WitnessOps<CF1<C1>> + for<'a> Dummy<&'a A>,
-        A: Arith<W, RU>,
-        AVar: ArithGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
+        A: ArithRelation<W, RU>,
+        AVar: ArithRelationGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
         D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
     >
     Dummy<(
@@ -143,8 +143,8 @@ impl<
         RU: CommittedInstanceOps<C1>,
         IU: CommittedInstanceOps<C1>,
         W: WitnessOps<CF1<C1>>,
-        A: Arith<W, RU>,
-        AVar: ArithGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
+        A: ArithRelation<W, RU>,
+        AVar: ArithRelationGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
         D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
     > ConstraintSynthesizer<CF1<C1>>
     for GenericOffchainDeciderCircuit1<C1, C2, RU, IU, W, A, AVar, D>

--- a/folding-schemes/src/folding/circuits/decider/on_chain.rs
+++ b/folding-schemes/src/folding/circuits/decider/on_chain.rs
@@ -9,7 +9,7 @@ use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisE
 use ark_std::{marker::PhantomData, Zero};
 
 use crate::{
-    arith::{r1cs::R1CS, Arith, ArithGadget},
+    arith::{r1cs::R1CS, ArithRelation, ArithRelationGadget},
     commitment::pedersen::Params as PedersenParams,
     folding::{
         circuits::{
@@ -61,11 +61,11 @@ use super::DeciderEnabledNIFS;
 pub struct GenericOnchainDeciderCircuit<
     C1: Curve,
     C2: Curve,
-    RU: CommittedInstanceOps<C1>,       // Running instance
-    IU: CommittedInstanceOps<C1>,       // Incoming instance
-    W: WitnessOps<CF1<C1>>,             // Witness
-    A: Arith<W, RU>,                    // Constraint system
-    AVar: ArithGadget<W::Var, RU::Var>, // In-circuit representation of `A`
+    RU: CommittedInstanceOps<C1>,               // Running instance
+    IU: CommittedInstanceOps<C1>,               // Incoming instance
+    W: WitnessOps<CF1<C1>>,                     // Witness
+    A: ArithRelation<W, RU>,                    // Constraint system
+    AVar: ArithRelationGadget<W::Var, RU::Var>, // In-circuit representation of `A`
     D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
 > {
     pub _avar: PhantomData<AVar>,
@@ -110,8 +110,8 @@ impl<
         RU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         IU: CommittedInstanceOps<C1> + for<'a> Dummy<&'a A>,
         W: WitnessOps<CF1<C1>> + for<'a> Dummy<&'a A>,
-        A: Arith<W, RU>,
-        AVar: ArithGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
+        A: ArithRelation<W, RU>,
+        AVar: ArithRelationGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
         D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
     >
     Dummy<(
@@ -178,8 +178,8 @@ impl<
         RU: CommittedInstanceOps<C1>,
         IU: CommittedInstanceOps<C1>,
         W: WitnessOps<CF1<C1>>,
-        A: Arith<W, RU>,
-        AVar: ArithGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
+        A: ArithRelation<W, RU>,
+        AVar: ArithRelationGadget<W::Var, RU::Var> + AllocVar<A, CF1<C1>>,
         D: DeciderEnabledNIFS<C1, RU, IU, W, A>,
     > ConstraintSynthesizer<CF1<C1>> for GenericOnchainDeciderCircuit<C1, C2, RU, IU, W, A, AVar, D>
 where

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -6,7 +6,7 @@ use ark_std::{rand::Rng, sync::Arc, One, Zero};
 
 use super::circuits::CCCSVar;
 use super::Witness;
-use crate::arith::{ccs::CCS, Arith};
+use crate::arith::{ccs::CCS, ArithRelation};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Inputize;
@@ -98,7 +98,7 @@ impl<C: Curve> Dummy<&CCS<CF1<C>>> for CCCS<C> {
     }
 }
 
-impl<C: Curve> Arith<Witness<CF1<C>>, CCCS<C>> for CCS<CF1<C>> {
+impl<C: Curve> ArithRelation<Witness<CF1<C>>, CCCS<C>> for CCS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     fn eval_relation(&self, w: &Witness<CF1<C>>, u: &CCCS<C>) -> Result<Self::Evaluation, Error> {

--- a/folding-schemes/src/folding/hypernova/cccs.rs
+++ b/folding-schemes/src/folding/hypernova/cccs.rs
@@ -6,7 +6,7 @@ use ark_std::{rand::Rng, sync::Arc, One, Zero};
 
 use super::circuits::CCCSVar;
 use super::Witness;
-use crate::arith::{ccs::CCS, ArithRelation};
+use crate::arith::{ccs::CCS, Arith, ArithRelation};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Inputize;
@@ -36,7 +36,7 @@ impl<F: PrimeField> CCS<F> {
         // enforce that CCS's F is the C::ScalarField
         C: Curve<ScalarField = F>,
     {
-        let w: Vec<F> = z[(1 + self.l)..].to_vec();
+        let (w, x) = self.split_z(z);
 
         // if the commitment scheme is set to be hiding, set the random blinding parameter
         let r_w = if CS::is_hiding() {
@@ -46,25 +46,22 @@ impl<F: PrimeField> CCS<F> {
         };
         let C = CS::commit(cs_params, &w, &r_w)?;
 
-        Ok((
-            CCCS::<C> {
-                C,
-                x: z[1..(1 + self.l)].to_vec(),
-            },
-            Witness::<F> { w, r_w },
-        ))
+        Ok((CCCS::<C> { C, x }, Witness::<F> { w, r_w }))
     }
 
     /// Computes q(x) = \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
     /// polynomial over x
     pub fn compute_q(&self, z: &[F]) -> Result<VirtualPolynomial<F>, Error> {
         let mut q_x = VirtualPolynomial::<F>::new(self.s);
-        for i in 0..self.q {
+        for (S_i, &c_i) in self.S.iter().zip(&self.c) {
             let mut Q_k = vec![];
-            for &j in self.S[i].iter() {
-                Q_k.push(dense_vec_to_dense_mle(self.s, &mat_vec_mul(&self.M[j], z)?));
+            for &j in S_i {
+                Q_k.push(Arc::new(dense_vec_to_dense_mle(
+                    self.s,
+                    &mat_vec_mul(&self.M[j], z)?,
+                )));
             }
-            q_x.add_mle_list(Q_k.iter().map(|v| Arc::new(v.clone())), self.c[i])?;
+            q_x.add_mle_list(Q_k, c_i)?;
         }
         Ok(q_x)
     }
@@ -74,16 +71,19 @@ impl<F: PrimeField> CCS<F> {
     /// polynomial over x
     pub fn compute_Q(&self, z: &[F], beta: &[F]) -> Result<VirtualPolynomial<F>, Error> {
         let eq_beta = build_eq_x_r_vec(beta)?;
-        let eq_beta_mle = dense_vec_to_dense_mle(self.s, &eq_beta);
+        let eq_beta_mle = Arc::new(dense_vec_to_dense_mle(self.s, &eq_beta));
 
         let mut Q = VirtualPolynomial::<F>::new(self.s);
-        for i in 0..self.q {
+        for (S_i, &c_i) in self.S.iter().zip(&self.c) {
             let mut Q_k = vec![];
-            for &j in self.S[i].iter() {
-                Q_k.push(dense_vec_to_dense_mle(self.s, &mat_vec_mul(&self.M[j], z)?));
+            for &j in S_i {
+                Q_k.push(Arc::new(dense_vec_to_dense_mle(
+                    self.s,
+                    &mat_vec_mul(&self.M[j], z)?,
+                )));
             }
             Q_k.push(eq_beta_mle.clone());
-            Q.add_mle_list(Q_k.iter().map(|v| Arc::new(v.clone())), self.c[i])?;
+            Q.add_mle_list(Q_k, c_i)?;
         }
         Ok(Q)
     }
@@ -93,7 +93,7 @@ impl<C: Curve> Dummy<&CCS<CF1<C>>> for CCCS<C> {
     fn dummy(ccs: &CCS<CF1<C>>) -> Self {
         Self {
             C: C::zero(),
-            x: vec![CF1::<C>::zero(); ccs.l],
+            x: vec![CF1::<C>::zero(); ccs.n_public_inputs()],
         }
     }
 }

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -887,7 +887,7 @@ mod tests {
         arith::{
             ccs::tests::{get_test_ccs, get_test_z},
             r1cs::extract_w_x,
-            Arith,
+            ArithRelation,
         },
         commitment::{pedersen::Pedersen, CommitmentScheme},
         folding::{

--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -231,7 +231,7 @@ pub mod tests {
     use ark_std::{test_rng, UniformRand};
 
     use super::*;
-    use crate::arith::r1cs::R1CS;
+    use crate::arith::{r1cs::R1CS, Arith};
     use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::PreprocessorParam;
     use crate::frontend::utils::CubicFCircuit;
@@ -247,7 +247,7 @@ pub mod tests {
         let ccs = CCS::from(r1cs);
         let z: Vec<Fr> = (0..n_cols).map(|_| Fr::rand(&mut rng)).collect();
 
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         let (lcccs, w) = ccs.to_lcccs::<_, Projective, Pedersen<Projective>, false>(
             &mut rng,

--- a/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth_circuit.rs
@@ -28,7 +28,7 @@ use crate::Error;
 use crate::{
     arith::{
         ccs::{circuits::CCSMatricesVar, CCS},
-        ArithGadget,
+        ArithRelationGadget,
     },
     folding::circuits::decider::{EvalGadget, KZGChallengesGadget},
 };
@@ -38,7 +38,7 @@ use crate::{
     Curve,
 };
 
-impl<C: Curve> ArithGadget<WitnessVar<CF1<C>>, LCCCSVar<C>> for CCSMatricesVar<CF1<C>> {
+impl<C: Curve> ArithRelationGadget<WitnessVar<CF1<C>>, LCCCSVar<C>> for CCSMatricesVar<CF1<C>> {
     type Evaluation = Vec<FpVar<CF1<C>>>;
 
     fn eval_relation(

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -9,7 +9,7 @@ use ark_std::Zero;
 use super::circuits::LCCCSVar;
 use super::Witness;
 use crate::arith::ccs::CCS;
-use crate::arith::Arith;
+use crate::arith::ArithRelation;
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Inputize;
@@ -89,7 +89,7 @@ impl<C: Curve> Dummy<&CCS<CF1<C>>> for LCCCS<C> {
     }
 }
 
-impl<C: Curve> Arith<Witness<CF1<C>>, LCCCS<C>> for CCS<CF1<C>> {
+impl<C: Curve> ArithRelation<Witness<CF1<C>>, LCCCS<C>> for CCS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     /// Perform the check of the LCCCS instance described at section 4.2,
@@ -168,7 +168,7 @@ pub mod tests {
     use crate::arith::{
         ccs::tests::{get_test_ccs, get_test_z},
         r1cs::R1CS,
-        Arith,
+        ArithRelation,
     };
     use crate::commitment::pedersen::Pedersen;
     use crate::utils::hypercube::BooleanHypercube;

--- a/folding-schemes/src/folding/hypernova/lcccs.rs
+++ b/folding-schemes/src/folding/hypernova/lcccs.rs
@@ -1,6 +1,6 @@
 use ark_crypto_primitives::sponge::Absorb;
 use ark_ff::PrimeField;
-use ark_poly::{DenseMultilinearExtension, Polynomial};
+use ark_poly::Polynomial;
 use ark_serialize::CanonicalDeserialize;
 use ark_serialize::CanonicalSerialize;
 use ark_std::rand::Rng;
@@ -9,7 +9,7 @@ use ark_std::Zero;
 use super::circuits::LCCCSVar;
 use super::Witness;
 use crate::arith::ccs::CCS;
-use crate::arith::ArithRelation;
+use crate::arith::{Arith, ArithRelation};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Inputize;
@@ -44,7 +44,7 @@ impl<F: PrimeField> CCS<F> {
         // enforce that CCS's F is the C::ScalarField
         C: Curve<ScalarField = F>,
     {
-        let w: Vec<F> = z[(1 + self.l)..].to_vec();
+        let (w, x) = self.split_z(z);
         // if the commitment scheme is set to be hiding, set the random blinding parameter
         let r_w = if CS::is_hiding() {
             F::rand(rng)
@@ -55,20 +55,21 @@ impl<F: PrimeField> CCS<F> {
 
         let r_x: Vec<F> = (0..self.s).map(|_| F::rand(rng)).collect();
 
-        let Mzs: Vec<DenseMultilinearExtension<F>> = self
+        // compute v_j
+        let v = self
             .M
             .iter()
-            .map(|M_j| Ok(dense_vec_to_dense_mle(self.s, &mat_vec_mul(M_j, z)?)))
+            .map(|M_j| {
+                let Mz = dense_vec_to_dense_mle(self.s, &mat_vec_mul(M_j, z)?);
+                Ok(Mz.evaluate(&r_x))
+            })
             .collect::<Result<_, Error>>()?;
-
-        // compute v_j
-        let v: Vec<F> = Mzs.iter().map(|Mz| Mz.evaluate(&r_x)).collect();
 
         Ok((
             LCCCS::<C> {
                 C,
                 u: z[0],
-                x: z[1..(1 + self.l)].to_vec(),
+                x,
                 r_x,
                 v,
             },
@@ -82,7 +83,7 @@ impl<C: Curve> Dummy<&CCS<CF1<C>>> for LCCCS<C> {
         Self {
             C: C::zero(),
             u: CF1::<C>::zero(),
-            x: vec![CF1::<C>::zero(); ccs.l],
+            x: vec![CF1::<C>::zero(); ccs.n_public_inputs()],
             r_x: vec![CF1::<C>::zero(); ccs.s],
             v: vec![CF1::<C>::zero(); ccs.t],
         }
@@ -159,10 +160,7 @@ impl<C: Curve> Inputize<CF1<C>> for LCCCS<C> {
 #[cfg(test)]
 pub mod tests {
     use ark_pallas::{Fr, Projective};
-    use ark_std::test_rng;
-    use ark_std::One;
-    use ark_std::UniformRand;
-    use std::sync::Arc;
+    use ark_std::{sync::Arc, test_rng, One, UniformRand};
 
     use super::*;
     use crate::arith::{
@@ -181,19 +179,21 @@ pub mod tests {
         z: &[C::ScalarField],
     ) -> Result<Vec<VirtualPolynomial<C::ScalarField>>, Error> {
         let eq_rx = build_eq_x_r_vec(&lcccs.r_x)?;
-        let eq_rx_mle = dense_vec_to_dense_mle(ccs.s, &eq_rx);
+        let eq_rx_mle = Arc::new(dense_vec_to_dense_mle(ccs.s, &eq_rx));
 
-        let mut Ls = Vec::with_capacity(ccs.t);
-        for M_j in ccs.M.iter() {
-            let mut L = VirtualPolynomial::<C::ScalarField>::new(ccs.s);
-            let mut Mz = vec![dense_vec_to_dense_mle(ccs.s, &mat_vec_mul(M_j, z)?)];
-            Mz.push(eq_rx_mle.clone());
-            L.add_mle_list(
-                Mz.iter().map(|v| Arc::new(v.clone())),
-                C::ScalarField::one(),
-            )?;
-            Ls.push(L);
-        }
+        let Ls = ccs
+            .M
+            .iter()
+            .map(|M_j| {
+                let mut L = VirtualPolynomial::<C::ScalarField>::new(ccs.s);
+                let Mz = vec![
+                    Arc::new(dense_vec_to_dense_mle(ccs.s, &mat_vec_mul(M_j, z)?)),
+                    eq_rx_mle.clone(),
+                ];
+                L.add_mle_list(Mz, C::ScalarField::one())?;
+                Ok(L)
+            })
+            .collect::<Result<Vec<_>, Error>>()?;
         Ok(Ls)
     }
 
@@ -208,7 +208,7 @@ pub mod tests {
         let ccs = CCS::from(r1cs);
         let z: Vec<Fr> = (0..n_cols).map(|_| Fr::rand(&mut rng)).collect();
 
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         let (lcccs, _) = ccs.to_lcccs::<_, Projective, Pedersen<Projective, false>, false>(
             &mut rng,
@@ -248,7 +248,7 @@ pub mod tests {
         let (bad_w, bad_x) = ccs.split_z(&bad_z);
         assert!(ccs.check_relation(&bad_w, &bad_x).is_err());
 
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
         // Compute v_j with the right z
         let (lcccs, _) = ccs.to_lcccs::<_, Projective, Pedersen<Projective>, false>(
             &mut rng,

--- a/folding-schemes/src/folding/hypernova/mod.rs
+++ b/folding-schemes/src/folding/hypernova/mod.rs
@@ -41,7 +41,7 @@ use crate::{
     arith::{
         ccs::CCS,
         r1cs::{extract_w_x, R1CS},
-        Arith,
+        ArithRelation,
     },
     Curve, FoldingScheme, MultiFolding,
 };

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -1,7 +1,7 @@
 use ark_ff::{BigInteger, Field, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use ark_poly::{DenseUVPolynomial, Polynomial};
-use ark_std::{One, Zero};
+use ark_std::{fmt::Debug, marker::PhantomData, One, Zero};
 
 use super::{
     cccs::CCCS,
@@ -9,7 +9,7 @@ use super::{
     utils::{compute_c, compute_g, compute_sigmas_thetas},
     Witness,
 };
-use crate::arith::ccs::CCS;
+use crate::arith::{ccs::CCS, Arith};
 use crate::constants::NOVA_N_BITS_RO;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Dummy;
@@ -18,9 +18,6 @@ use crate::utils::sum_check::structs::{IOPProof as SumCheckProof, IOPProverMessa
 use crate::utils::sum_check::{IOPSumCheck, SumCheck};
 use crate::utils::virtual_polynomial::VPAuxInfo;
 use crate::{Curve, Error};
-
-use std::fmt::Debug;
-use std::marker::PhantomData;
 
 /// NIMFSProof defines a multifolding proof
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -316,7 +313,7 @@ impl<C: Curve, T: Transcript<C::ScalarField>> NIMFS<C, T> {
         let beta: Vec<C::ScalarField> = transcript.get_challenges(ccs.s);
 
         let vp_aux_info = VPAuxInfo::<C::ScalarField> {
-            max_degree: ccs.d + 1,
+            max_degree: ccs.degree() + 1,
             num_variables: ccs.s,
             phantom: PhantomData::<C::ScalarField>,
         };
@@ -424,7 +421,7 @@ pub mod tests {
 
         let sigmas_thetas = compute_sigmas_thetas(&ccs, &[z1.clone()], &[z2.clone()], &r_x_prime)?;
 
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         let (lcccs, w1) = ccs.to_lcccs::<_, Projective, Pedersen<Projective>, false>(
             &mut rng,
@@ -465,7 +462,7 @@ pub mod tests {
 
         // Create a basic CCS circuit
         let ccs = get_test_ccs::<Fr>();
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         // Generate a satisfying witness
         let z_1 = get_test_z(3);
@@ -521,7 +518,7 @@ pub mod tests {
 
         let ccs = get_test_ccs::<Fr>();
 
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         // LCCCS witness
         let z_1 = get_test_z(2);
@@ -581,7 +578,7 @@ pub mod tests {
 
         // Create a basic CCS circuit
         let ccs = get_test_ccs::<Fr>();
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         let mu = 10;
         let nu = 15;
@@ -660,7 +657,7 @@ pub mod tests {
 
         // Create a basic CCS circuit
         let ccs = get_test_ccs::<Fr>();
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
 
         let poseidon_config = poseidon_canonical_config::<Fr>();
         // Prover's transcript

--- a/folding-schemes/src/folding/hypernova/nimfs.rs
+++ b/folding-schemes/src/folding/hypernova/nimfs.rs
@@ -398,7 +398,7 @@ pub mod tests {
     use super::*;
     use crate::arith::{
         ccs::tests::{get_test_ccs, get_test_z},
-        Arith,
+        ArithRelation,
     };
     use crate::transcript::poseidon::poseidon_canonical_config;
     use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -1,5 +1,5 @@
 use ark_ff::PrimeField;
-use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
+use ark_poly::MultilinearExtension;
 use ark_std::One;
 use std::sync::Arc;
 
@@ -21,27 +21,27 @@ pub fn compute_sigmas_thetas<F: PrimeField>(
 ) -> Result<SigmasThetas<F>, Error> {
     let mut sigmas: Vec<Vec<F>> = Vec::new();
     for z_lcccs_i in z_lcccs {
-        let mut Mzs: Vec<DenseMultilinearExtension<F>> = vec![];
-        for M_j in ccs.M.iter() {
-            Mzs.push(dense_vec_to_dense_mle(ccs.s, &mat_vec_mul(M_j, z_lcccs_i)?));
-        }
-        let sigma_i = Mzs
+        let sigma_i = ccs
+            .M
             .iter()
-            .map(|Mz| Mz.fix_variables(r_x_prime)[0])
-            .collect();
+            .map(|M_j| {
+                let Mz = dense_vec_to_dense_mle(ccs.s, &mat_vec_mul(M_j, z_lcccs_i)?);
+                Ok(Mz.fix_variables(r_x_prime)[0])
+            })
+            .collect::<Result<Vec<F>, Error>>()?;
         sigmas.push(sigma_i);
     }
 
     let mut thetas: Vec<Vec<F>> = Vec::new();
     for z_cccs_i in z_cccs {
-        let mut Mzs: Vec<DenseMultilinearExtension<F>> = vec![];
-        for M_j in ccs.M.iter() {
-            Mzs.push(dense_vec_to_dense_mle(ccs.s, &mat_vec_mul(M_j, z_cccs_i)?));
-        }
-        let theta_i = Mzs
+        let theta_i = ccs
+            .M
             .iter()
-            .map(|Mz| Mz.fix_variables(r_x_prime)[0])
-            .collect();
+            .map(|M_j| {
+                let Mz = dense_vec_to_dense_mle(ccs.s, &mat_vec_mul(M_j, z_cccs_i)?);
+                Ok(Mz.fix_variables(r_x_prime)[0])
+            })
+            .collect::<Result<Vec<F>, Error>>()?;
         thetas.push(theta_i);
     }
     Ok(SigmasThetas(sigmas, thetas))
@@ -81,14 +81,14 @@ pub fn compute_c<F: PrimeField>(
     let e2 = eq_eval(beta, r_x_prime)?;
     for (k, thetas) in vec_thetas.iter().enumerate() {
         // + gamma^{t+1} * e2 * sum c_i * prod theta_j
-        let mut lhs = F::zero();
-        for i in 0..ccs.q {
+        let prods = ccs.S.iter().zip(&ccs.c).map(|(S_i, &c_i)| {
             let mut prod = F::one();
-            for j in ccs.S[i].clone() {
+            for &j in S_i {
                 prod *= thetas[j];
             }
-            lhs += ccs.c[i] * prod;
-        }
+            c_i * prod
+        });
+        let lhs = F::sum(prods);
         let gamma_t1 = gamma.pow([(mu * ccs.t + k) as u64]);
         c += gamma_t1 * e2 * lhs;
     }
@@ -128,24 +128,21 @@ pub fn compute_g<C: Curve>(
     }
 
     let eq_beta = build_eq_x_r_vec(beta)?;
-    let eq_beta_mle = dense_vec_to_dense_mle(ccs.s, &eq_beta);
+    let eq_beta_mle = Arc::new(dense_vec_to_dense_mle(ccs.s, &eq_beta));
 
     #[allow(clippy::needless_range_loop)]
     for k in 0..nu {
         // Q_k
-        for i in 0..ccs.q {
+        for (S_i, &c_i) in ccs.S.iter().zip(&ccs.c) {
             let mut Q_k = vec![];
-            for &j in ccs.S[i].iter() {
-                Q_k.push(dense_vec_to_dense_mle(
+            for &j in S_i {
+                Q_k.push(Arc::new(dense_vec_to_dense_mle(
                     ccs.s,
                     &mat_vec_mul(&ccs.M[j], &z_cccs[k])?,
-                ));
+                )));
             }
             Q_k.push(eq_beta_mle.clone());
-            g.add_mle_list(
-                Q_k.iter().map(|v| Arc::new(v.clone())),
-                ccs.c[i] * gamma_pow,
-            )?;
+            g.add_mle_list(Q_k, c_i * gamma_pow)?;
         }
         gamma_pow *= gamma;
     }
@@ -164,7 +161,7 @@ pub mod tests {
     use super::*;
     use crate::arith::{
         ccs::tests::{get_test_ccs, get_test_z},
-        ArithRelation,
+        Arith, ArithRelation,
     };
     use crate::commitment::{pedersen::Pedersen, CommitmentScheme};
     use crate::folding::hypernova::lcccs::tests::compute_Ls;
@@ -237,7 +234,7 @@ pub mod tests {
         let r_x_prime: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
         let (lcccs_instance, _) =
             ccs.to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z1)?;
 
@@ -285,7 +282,7 @@ pub mod tests {
         let beta: Vec<Fr> = (0..ccs.s).map(|_| Fr::rand(&mut rng)).collect();
 
         // Initialize a multifolding object
-        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n - ccs.l - 1)?;
+        let (pedersen_params, _) = Pedersen::<Projective>::setup(&mut rng, ccs.n_witnesses())?;
         let (lcccs_instance, _) =
             ccs.to_lcccs::<_, _, Pedersen<Projective>, false>(&mut rng, &pedersen_params, &z1)?;
 

--- a/folding-schemes/src/folding/hypernova/utils.rs
+++ b/folding-schemes/src/folding/hypernova/utils.rs
@@ -164,7 +164,7 @@ pub mod tests {
     use super::*;
     use crate::arith::{
         ccs::tests::{get_test_ccs, get_test_z},
-        Arith,
+        ArithRelation,
     };
     use crate::commitment::{pedersen::Pedersen, CommitmentScheme};
     use crate::folding::hypernova::lcccs::tests::compute_Ls;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     constants::NOVA_N_BITS_RO,
     utils::pp_hash,
 };
-use crate::{arith::Arith, commitment::CommitmentScheme};
+use crate::{arith::ArithRelation, commitment::CommitmentScheme};
 use crate::{Curve, Error};
 use decider_eth_circuit::WitnessVar;
 

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -12,15 +12,8 @@ use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
-use ark_std::fmt::Debug;
-use ark_std::rand::RngCore;
-use ark_std::{One, UniformRand, Zero};
-use core::marker::PhantomData;
+use ark_std::{cmp::max, fmt::Debug, marker::PhantomData, rand::RngCore, One, UniformRand, Zero};
 
-use crate::folding::circuits::cyclefold::{
-    fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldCommittedInstance, CycleFoldConfig,
-    CycleFoldWitness,
-};
 use crate::folding::{circuits::CF1, traits::Dummy};
 use crate::frontend::FCircuit;
 use crate::transcript::{poseidon::poseidon_canonical_config, Transcript};
@@ -30,6 +23,13 @@ use crate::{
     arith::r1cs::{extract_r1cs, extract_w_x, R1CS},
     constants::NOVA_N_BITS_RO,
     utils::pp_hash,
+};
+use crate::{
+    arith::Arith,
+    folding::circuits::cyclefold::{
+        fold_cyclefold_circuit, CycleFoldCircuit, CycleFoldCommittedInstance, CycleFoldConfig,
+        CycleFoldWitness,
+    },
 };
 use crate::{arith::ArithRelation, commitment::CommitmentScheme};
 use crate::{Curve, Error};
@@ -93,7 +93,7 @@ impl<C: Curve> Dummy<usize> for CommittedInstance<C> {
 
 impl<C: Curve> Dummy<&R1CS<CF1<C>>> for CommittedInstance<C> {
     fn dummy(r1cs: &R1CS<CF1<C>>) -> Self {
-        Self::dummy(r1cs.l)
+        Self::dummy(r1cs.n_public_inputs())
     }
 }
 
@@ -185,9 +185,9 @@ impl<C: Curve> Witness<C> {
 impl<C: Curve> Dummy<&R1CS<CF1<C>>> for Witness<C> {
     fn dummy(r1cs: &R1CS<CF1<C>>) -> Self {
         Self {
-            E: vec![C::ScalarField::zero(); r1cs.A.n_rows],
+            E: vec![C::ScalarField::zero(); r1cs.n_constraints()],
             rE: C::ScalarField::zero(),
-            W: vec![C::ScalarField::zero(); r1cs.A.n_cols - 1 - r1cs.l],
+            W: vec![C::ScalarField::zero(); r1cs.n_witnesses()],
             rW: C::ScalarField::zero(),
         }
     }
@@ -536,11 +536,25 @@ where
         // if cs params exist, use them, if not, generate new ones
         let (cs_pp, cs_vp) = match (&prep_param.cs_pp, &prep_param.cs_vp) {
             (Some(cs_pp), Some(cs_vp)) => (cs_pp.clone(), cs_vp.clone()),
-            _ => CS1::setup(&mut rng, r1cs.A.n_rows)?,
+            _ => CS1::setup(
+                &mut rng,
+                // `CS1` is for committing to Nova's witness vector `w` and
+                // error term `e`, where the length of `e` is the number of
+                // constraints, so we set `len` to the maximum of `e` and `w`'s
+                // lengths.
+                max(r1cs.n_constraints(), r1cs.n_witnesses()),
+            )?,
         };
         let (cf_cs_pp, cf_cs_vp) = match (&prep_param.cf_cs_pp, &prep_param.cf_cs_vp) {
             (Some(cf_cs_pp), Some(cf_cs_vp)) => (cf_cs_pp.clone(), cf_cs_vp.clone()),
-            _ => CS2::setup(&mut rng, cf_r1cs.A.n_rows)?,
+            _ => CS2::setup(
+                &mut rng,
+                // `CS2` is for committing to CycleFold's witness vector `w` and
+                // error term `e`, where the length of `e` is the number of
+                // constraints, so we set `len` to the maximum of `e` and `w`'s
+                // lengths.
+                max(cf_r1cs.n_constraints(), cf_r1cs.n_witnesses()),
+            )?,
         };
 
         let prover_params = ProverParams::<C1, C2, CS1, CS2, H> {
@@ -800,7 +814,7 @@ where
         // set values for next iteration
         self.i += C1::ScalarField::one();
         self.z_i = z_i1;
-        self.w_i = Witness::<C1>::new::<H>(w_i1, self.r1cs.A.n_rows, &mut rng);
+        self.w_i = Witness::<C1>::new::<H>(w_i1, self.r1cs.n_constraints(), &mut rng);
         self.u_i = self.w_i.commit::<CS1, H>(&self.cs_pp, x_i1)?;
         self.W_i = W_i1;
         self.U_i = U_i1;
@@ -1013,22 +1027,6 @@ where
     let r1cs = get_r1cs_from_cs::<C1::ScalarField>(augmented_F_circuit)?;
     let cf_r1cs = get_r1cs_from_cs::<C2::ScalarField>(cf_circuit)?;
     Ok((r1cs, cf_r1cs))
-}
-
-/// helper method to get the pedersen params length for both the AugmentedFCircuit and the
-/// CycleFold circuit
-pub fn get_cs_params_len<C1, C2, FC>(
-    poseidon_config: &PoseidonConfig<C1::ScalarField>,
-    F_circuit: FC,
-) -> Result<(usize, usize), Error>
-where
-    C1: Curve,
-    C2: Curve,
-    FC: FCircuit<C1::ScalarField>,
-    C1: Curve<BaseField = C2::ScalarField, ScalarField = C2::BaseField>,
-{
-    let (r1cs, cf_r1cs) = get_r1cs::<C1, C2, FC>(poseidon_config, F_circuit)?;
-    Ok((r1cs.A.n_rows, cf_r1cs.A.n_rows))
 }
 
 #[cfg(test)]

--- a/folding-schemes/src/folding/nova/nifs/mova.rs
+++ b/folding-schemes/src/folding/nova/nifs/mova.rs
@@ -4,17 +4,14 @@ use ark_crypto_primitives::sponge::Absorb;
 use ark_ff::PrimeField;
 use ark_poly::Polynomial;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::log2;
-use ark_std::rand::RngCore;
-use ark_std::{One, UniformRand, Zero};
-use std::marker::PhantomData;
+use ark_std::{log2, marker::PhantomData, rand::RngCore, One, UniformRand, Zero};
 
 use super::{
     nova::NIFS as NovaNIFS,
     pointvsline::{PointVsLine, PointVsLineProof, PointvsLineEvaluationClaim},
     NIFSTrait,
 };
-use crate::arith::{r1cs::R1CS, ArithRelation};
+use crate::arith::{r1cs::R1CS, Arith, ArithRelation};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Dummy;
@@ -73,8 +70,8 @@ pub struct Witness<C: Curve> {
 impl<C: Curve> Dummy<&R1CS<C::ScalarField>> for Witness<C> {
     fn dummy(r1cs: &R1CS<C::ScalarField>) -> Self {
         Self {
-            E: vec![C::ScalarField::zero(); r1cs.A.n_rows],
-            W: vec![C::ScalarField::zero(); r1cs.A.n_cols - 1 - r1cs.l],
+            E: vec![C::ScalarField::zero(); r1cs.n_constraints()],
+            W: vec![C::ScalarField::zero(); r1cs.n_witnesses()],
             rW: C::ScalarField::zero(),
         }
     }

--- a/folding-schemes/src/folding/nova/nifs/mova.rs
+++ b/folding-schemes/src/folding/nova/nifs/mova.rs
@@ -14,7 +14,7 @@ use super::{
     pointvsline::{PointVsLine, PointVsLineProof, PointvsLineEvaluationClaim},
     NIFSTrait,
 };
-use crate::arith::{r1cs::R1CS, Arith};
+use crate::arith::{r1cs::R1CS, ArithRelation};
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::folding::traits::Dummy;
@@ -354,7 +354,7 @@ impl<C: Curve, CS: CommitmentScheme<C, H>, T: Transcript<C::ScalarField>, const 
     }
 }
 
-impl<C: Curve> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+impl<C: Curve> ArithRelation<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     fn eval_relation(
@@ -380,7 +380,7 @@ pub mod tests {
     use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
     use ark_pallas::{Fr, Projective};
 
-    use crate::arith::{r1cs::tests::get_test_r1cs, Arith};
+    use crate::arith::{r1cs::tests::get_test_r1cs, ArithRelation};
     use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::nifs::tests::test_nifs_opt;
 

--- a/folding-schemes/src/folding/nova/nifs/nova.rs
+++ b/folding-schemes/src/folding/nova/nifs/nova.rs
@@ -282,7 +282,7 @@ pub mod tests {
     use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
     use ark_pallas::{Fr, Projective};
 
-    use crate::arith::{r1cs::tests::get_test_r1cs, Arith};
+    use crate::arith::{r1cs::tests::get_test_r1cs, ArithRelation};
     use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::nifs::tests::test_nifs_opt;
 

--- a/folding-schemes/src/folding/nova/nifs/ova.rs
+++ b/folding-schemes/src/folding/nova/nifs/ova.rs
@@ -254,14 +254,14 @@ pub mod tests {
     use super::*;
     use ark_pallas::{Fr, Projective};
 
-    use crate::arith::{r1cs::tests::get_test_r1cs, Arith};
+    use crate::arith::{r1cs::tests::get_test_r1cs, ArithRelation};
     use crate::commitment::pedersen::Pedersen;
     use crate::folding::nova::nifs::tests::test_nifs_opt;
     use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
 
     // Simple auxiliary structure mainly used to help pass a witness for which we can check
     // easily an R1CS relation.
-    // Notice that checking it requires us to have `E` as per [`Arith`] trait definition.
+    // Notice that checking it requires us to have `E` as per [`ArithRelation`] trait definition.
     // But since we don't hold `E` nor `e` within the NIFS, we create this structure to pass
     // `e` such that the check can be done.
     #[derive(Debug, Clone)]
@@ -269,7 +269,7 @@ pub mod tests {
         pub(crate) w: Vec<C::ScalarField>,
         pub(crate) e: Vec<C::ScalarField>,
     }
-    impl<C: Curve> Arith<TestingWitness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+    impl<C: Curve> ArithRelation<TestingWitness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
         type Evaluation = Vec<CF1<C>>;
 
         fn eval_relation(

--- a/folding-schemes/src/folding/nova/nifs/ova.rs
+++ b/folding-schemes/src/folding/nova/nifs/ova.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use super::nova::ChallengeGadget;
 use super::ova_circuits::CommittedInstanceVar;
 use super::NIFSTrait;
-use crate::arith::r1cs::R1CS;
+use crate::arith::{r1cs::R1CS, Arith};
 use crate::commitment::CommitmentScheme;
 use crate::folding::traits::{CommittedInstanceOps, Inputize};
 use crate::folding::{circuits::CF1, traits::Dummy};
@@ -107,7 +107,7 @@ impl<C: Curve> Witness<C> {
 impl<C: Curve> Dummy<&R1CS<CF1<C>>> for Witness<C> {
     fn dummy(r1cs: &R1CS<CF1<C>>) -> Self {
         Self {
-            w: vec![C::ScalarField::zero(); r1cs.A.n_cols - 1 - r1cs.l],
+            w: vec![C::ScalarField::zero(); r1cs.n_witnesses()],
             rW: C::ScalarField::zero(),
         }
     }

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -7,15 +7,15 @@ use super::nifs::nova_circuits::CommittedInstanceVar;
 use super::{CommittedInstance, Witness};
 use crate::arith::{
     r1cs::{circuits::R1CSMatricesVar, R1CS},
-    Arith, ArithGadget, ArithSampler,
+    ArithRelation, ArithRelationGadget, ArithSampler,
 };
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
 use crate::utils::gadgets::{EquivalenceGadget, VectorGadget};
 use crate::{Curve, Error};
 
-/// Implements `Arith` for R1CS, where the witness is of type [`Witness`], and
-/// the committed instance is of type [`CommittedInstance`].
+/// Implements [`ArithRelation`] for R1CS, where the witness is of type
+/// [`Witness`], and the committed instance is of type [`CommittedInstance`].
 ///
 /// Due to the error terms `Witness.E` and `CommittedInstance.u`, R1CS here is
 /// considered as a relaxed R1CS.
@@ -28,20 +28,20 @@ use crate::{Curve, Error};
 /// struct, but are part of the witness and committed instance.
 ///
 /// As a follow-up, one may further ask why not providing a trait for relaxed
-/// R1CS and implement it for the `R1CS` struct, where the relaxed R1CS trait
-/// has methods for relaxed satisfiability check, while the `Arith` trait that
-/// `R1CS` implements has methods for plain satisfiability check.
+/// R1CS and implement it for the [`R1CS`] struct, where the relaxed R1CS trait
+/// has methods for relaxed satisfiability check, while the [`ArithRelation`]
+/// trait that [`R1CS`] implements has methods for plain satisfiability check.
 /// However, it would be more ideal if we have a single method that can smartly
 /// choose the type of satisfiability check, which would make the code more
 /// generic and easier to maintain.
 ///
-/// This is achieved thanks to the new design of the [`Arith`] trait, where we
-/// can implement the trait for the same constraint system with different types
-/// of witnesses and committed instances.
+/// This is achieved thanks to the new design of the [`ArithRelation`] trait,
+/// where we can implement the trait for the same constraint system with
+/// different types of witnesses and committed instances.
 /// For R1CS, whether it is relaxed or not is now determined by the types of `W`
 /// and `U`: the satisfiability check is relaxed if `W` and `U` are defined by
 /// folding schemes, and plain if they are vectors of field elements.
-impl<C: Curve> Arith<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
+impl<C: Curve> ArithRelation<Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>> {
     type Evaluation = Vec<CF1<C>>;
 
     fn eval_relation(
@@ -102,7 +102,7 @@ impl<C: Curve> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>
     }
 }
 
-impl<C: Curve> ArithGadget<WitnessVar<C>, CommittedInstanceVar<C>>
+impl<C: Curve> ArithRelationGadget<WitnessVar<C>, CommittedInstanceVar<C>>
     for R1CSMatricesVar<C::ScalarField, FpVar<C::ScalarField>>
 {
     type Evaluation = (Vec<FpVar<C::ScalarField>>, Vec<FpVar<C::ScalarField>>);

--- a/folding-schemes/src/folding/nova/traits.rs
+++ b/folding-schemes/src/folding/nova/traits.rs
@@ -7,7 +7,7 @@ use super::nifs::nova_circuits::CommittedInstanceVar;
 use super::{CommittedInstance, Witness};
 use crate::arith::{
     r1cs::{circuits::R1CSMatricesVar, R1CS},
-    ArithRelation, ArithRelationGadget, ArithSampler,
+    Arith, ArithRelation, ArithRelationGadget, ArithSampler,
 };
 use crate::commitment::CommitmentScheme;
 use crate::folding::circuits::CF1;
@@ -73,10 +73,10 @@ impl<C: Curve> ArithSampler<C, Witness<C>, CommittedInstance<C>> for R1CS<CF1<C>
         let rE = C::ScalarField::rand(&mut rng);
         let rW = C::ScalarField::rand(&mut rng);
 
-        let W = (0..self.A.n_cols - self.l - 1)
+        let W = (0..self.n_witnesses())
             .map(|_| C::ScalarField::rand(&mut rng))
             .collect();
-        let x = (0..self.l)
+        let x = (0..self.n_public_inputs())
             .map(|_| C::ScalarField::rand(&mut rng))
             .collect::<Vec<C::ScalarField>>();
         let mut z = vec![u];

--- a/folding-schemes/src/folding/nova/zk.rs
+++ b/folding-schemes/src/folding/nova/zk.rs
@@ -41,7 +41,7 @@ use super::{
     CommittedInstance, Nova, Witness,
 };
 use crate::{
-    arith::{r1cs::R1CS, Arith, ArithSampler},
+    arith::{r1cs::R1CS, ArithRelation, ArithSampler},
     commitment::CommitmentScheme,
     folding::traits::CommittedInstanceOps,
     frontend::FCircuit,

--- a/folding-schemes/src/folding/protogalaxy/decider_eth.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth.rs
@@ -119,7 +119,7 @@ where
         // https://github.com/privacy-scaling-explorations/sonobe/issues/82
         let k = 1;
         let d = protogalaxy_vp.r1cs.degree();
-        let t = log2(protogalaxy_vp.r1cs.num_constraints()) as usize;
+        let t = log2(protogalaxy_vp.r1cs.n_constraints()) as usize;
 
         let circuit = DeciderEthCircuit::<C1, C2>::dummy((
             protogalaxy_vp.r1cs,

--- a/folding-schemes/src/folding/protogalaxy/decider_eth.rs
+++ b/folding-schemes/src/folding/protogalaxy/decider_eth.rs
@@ -14,6 +14,7 @@ use ark_std::{
 pub use super::decider_eth_circuit::DeciderEthCircuit;
 use super::decider_eth_circuit::DeciderProtoGalaxyGadget;
 use super::ProtoGalaxy;
+use crate::arith::Arith;
 use crate::folding::traits::{InputizeNonNative, WitnessOps};
 use crate::folding::{circuits::decider::DeciderEnabledNIFS, traits::Dummy};
 use crate::frontend::FCircuit;
@@ -117,9 +118,7 @@ where
         // HyperNova). Tracking issue:
         // https://github.com/privacy-scaling-explorations/sonobe/issues/82
         let k = 1;
-        // `d`, the degree of the constraint system, is set to 2, as we only
-        // support R1CS for now, whose highest degree is 2.
-        let d = 2;
+        let d = protogalaxy_vp.r1cs.degree();
         let t = log2(protogalaxy_vp.r1cs.num_constraints()) as usize;
 
         let circuit = DeciderEthCircuit::<C1, C2>::dummy((

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -77,8 +77,8 @@ impl<C: Curve> Folding<C> {
         let d = r1cs.degree();
         let k = vec_instances.len();
         let t = instance.betas.len();
-        let n = r1cs.A.n_cols;
-        let m = r1cs.A.n_rows;
+        let n = r1cs.n_variables();
+        let m = r1cs.n_constraints();
 
         let z = [vec![C::ScalarField::one()], instance.x.clone(), w.w.clone()].concat();
 
@@ -446,7 +446,7 @@ pub mod tests {
 
         let (pedersen_params, _) = Pedersen::<C>::setup(&mut rng, w.len())?;
 
-        let t = log2(get_test_r1cs::<C::ScalarField>().A.n_rows) as usize;
+        let t = log2(get_test_r1cs::<C::ScalarField>().n_constraints()) as usize;
 
         let beta = C::ScalarField::rand(&mut rng);
         let betas = exponential_powers(beta, t);

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -140,7 +140,7 @@ impl<C: Curve> Folding<C> {
         // 'refreshed' randomness) satisfies the relation.
         #[cfg(test)]
         {
-            use crate::arith::Arith;
+            use crate::arith::ArithRelation;
             r1cs.check_relation(
                 w,
                 &CommittedInstance::<_, true> {
@@ -408,7 +408,7 @@ pub mod tests {
     use ark_std::{rand::Rng, UniformRand};
 
     use crate::arith::r1cs::tests::{get_test_r1cs, get_test_z_split};
-    use crate::arith::Arith;
+    use crate::arith::ArithRelation;
     use crate::commitment::{pedersen::Pedersen, CommitmentScheme};
     use crate::transcript::poseidon::poseidon_canonical_config;
 

--- a/folding-schemes/src/folding/protogalaxy/folding.rs
+++ b/folding-schemes/src/folding/protogalaxy/folding.rs
@@ -12,11 +12,11 @@ use super::utils::{all_powers, betas_star, exponential_powers, pow_i};
 use super::ProtoGalaxyError;
 use super::{CommittedInstance, Witness};
 
-use crate::folding::traits::Dummy;
 use crate::transcript::Transcript;
 use crate::utils::vec::*;
 use crate::Error;
 use crate::{arith::r1cs::R1CS, Curve};
+use crate::{arith::Arith, folding::traits::Dummy};
 
 #[derive(Debug, Clone)]
 pub struct ProtoGalaxyProof<F: PrimeField> {
@@ -74,7 +74,7 @@ impl<C: Curve> Folding<C> {
                 vec_w.len(),
             ));
         }
-        let d = 2; // for the moment hardcoded to 2 since it only supports R1CS
+        let d = r1cs.degree();
         let k = vec_instances.len();
         let t = instance.betas.len();
         let n = r1cs.A.n_cols;

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -23,7 +23,7 @@ use num_bigint::BigUint;
 use crate::{
     arith::{
         r1cs::{extract_r1cs, extract_w_x, R1CS},
-        Arith,
+        ArithRelation,
     },
     commitment::CommitmentScheme,
     folding::circuits::{

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -100,11 +100,11 @@ impl<C: Curve, const TYPE: bool> Dummy<(usize, usize)> for CommittedInstance<C, 
 impl<C: Curve, const TYPE: bool> Dummy<&R1CS<CF1<C>>> for CommittedInstance<C, TYPE> {
     fn dummy(r1cs: &R1CS<CF1<C>>) -> Self {
         let t = if TYPE == RUNNING {
-            log2(r1cs.num_constraints()) as usize
+            log2(r1cs.n_constraints()) as usize
         } else {
             0
         };
-        Self::dummy((r1cs.num_public_inputs(), t))
+        Self::dummy((r1cs.n_public_inputs(), t))
     }
 }
 
@@ -254,7 +254,7 @@ impl<F: PrimeField> Witness<F> {
 impl<F: PrimeField> Dummy<&R1CS<F>> for Witness<F> {
     fn dummy(r1cs: &R1CS<F>) -> Self {
         Self {
-            w: vec![F::zero(); r1cs.num_witnesses()],
+            w: vec![F::zero(); r1cs.n_witnesses()],
             r_w: F::zero(),
         }
     }
@@ -722,8 +722,16 @@ where
         let cs2 = cs2.into_inner().ok_or(Error::NoInnerConstraintSystem)?;
         let cf_r1cs = extract_r1cs::<C1::BaseField>(&cs2)?;
 
-        let (cs_pp, cs_vp) = CS1::setup(&mut rng, r1cs.A.n_rows)?;
-        let (cf_cs_pp, cf_cs_vp) = CS2::setup(&mut rng, max(cf_r1cs.A.n_rows, cf_r1cs.A.n_cols))?;
+        // `CS1` is for committing to ProtoGalaxy's witness vector `w`, so we
+        // set `len` to the number of witnesses in `r1cs`.
+        let (cs_pp, cs_vp) = CS1::setup(&mut rng, r1cs.n_witnesses())?;
+        // `CS2` is for committing to CycleFold's witness vector `w` and error
+        // term `e`, where the length of `e` is the number of constraints, so we
+        // set `len` to the maximum of `e` and `w`'s lengths.
+        let (cf_cs_pp, cf_cs_vp) = CS2::setup(
+            &mut rng,
+            max(cf_r1cs.n_constraints(), cf_r1cs.n_witnesses()),
+        )?;
 
         Ok((
             Self::ProverParam {

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -23,7 +23,7 @@ use num_bigint::BigUint;
 use crate::{
     arith::{
         r1cs::{extract_r1cs, extract_w_x, R1CS},
-        ArithRelation,
+        Arith, ArithRelation,
     },
     commitment::CommitmentScheme,
     folding::circuits::{
@@ -659,7 +659,7 @@ where
 
         let f_circuit = FC::new(fc_params)?;
         let k = 1;
-        let d = 2;
+        let d = R1CS::<CF1<C1>>::empty().degree();
         let t = Self::compute_t(&poseidon_config, &f_circuit, d, k)?;
 
         // main circuit R1CS:
@@ -701,9 +701,7 @@ where
         // HyperNova). Tracking issue:
         // https://github.com/privacy-scaling-explorations/sonobe/issues/82
         let k = 1;
-        // `d`, the degree of the constraint system, is set to 2, as we only
-        // support R1CS for now, whose highest degree is 2.
-        let d = 2;
+        let d = R1CS::<CF1<C1>>::empty().degree();
         let t = Self::compute_t(poseidon_config, F, d, k)?;
 
         // prepare the circuit to obtain its R1CS
@@ -798,9 +796,7 @@ where
         // HyperNova). Tracking issue:
         // https://github.com/privacy-scaling-explorations/sonobe/issues/82
         let k = 1;
-        // `d`, the degree of the constraint system, is set to 2, as we only
-        // support R1CS for now, whose highest degree is 2.
-        let d = 2;
+        let d = self.r1cs.degree();
 
         // `sponge` is for digest computation.
         let sponge = PoseidonSponge::<C1::ScalarField>::new(&self.poseidon_config);
@@ -1168,7 +1164,7 @@ mod tests {
     #[ignore]
     #[test]
     fn test_t_bounds() -> Result<(), Error> {
-        let d = 2;
+        let d = R1CS::<Fr>::empty().degree();
         let k = 1;
 
         let poseidon_config = poseidon_canonical_config::<Fr>();

--- a/folding-schemes/src/folding/protogalaxy/traits.rs
+++ b/folding-schemes/src/folding/protogalaxy/traits.rs
@@ -17,7 +17,7 @@ use super::{
 use crate::{
     arith::{
         r1cs::{circuits::R1CSMatricesVar, R1CS},
-        Arith, ArithGadget,
+        ArithRelation, ArithRelationGadget,
     },
     folding::circuits::CF1,
     transcript::AbsorbNonNativeGadget,
@@ -56,14 +56,14 @@ impl<C: Curve, const TYPE: bool> AbsorbGadget<C::ScalarField> for CommittedInsta
     }
 }
 
-/// Implements `Arith` for R1CS, where the witness is of type [`Witness`], and
-/// the committed instance is of type [`CommittedInstance`].
+/// Implements [`ArithRelation`] for R1CS, where the witness is of type
+/// [`Witness`], and the committed instance is of type [`CommittedInstance`].
 ///
 /// Due to the error term `CommittedInstance.e`, R1CS here is considered as a
 /// relaxed R1CS.
 ///
 /// See `nova/traits.rs` for the rationale behind the design.
-impl<C: Curve, const TYPE: bool> Arith<Witness<CF1<C>>, CommittedInstance<C, TYPE>>
+impl<C: Curve, const TYPE: bool> ArithRelation<Witness<CF1<C>>, CommittedInstance<C, TYPE>>
     for R1CS<CF1<C>>
 {
     type Evaluation = Vec<CF1<C>>;
@@ -104,7 +104,7 @@ impl<C: Curve, const TYPE: bool> Arith<Witness<CF1<C>>, CommittedInstance<C, TYP
 
 /// Unlike its native counterpart, we only need to support running instances in
 /// circuit, as the decider circuit only checks running instance satisfiability.
-impl<C: Curve> ArithGadget<WitnessVar<CF1<C>>, CommittedInstanceVar<C, RUNNING>>
+impl<C: Curve> ArithRelationGadget<WitnessVar<CF1<C>>, CommittedInstanceVar<C, RUNNING>>
     for R1CSMatricesVar<CF1<C>, FpVar<CF1<C>>>
 {
     type Evaluation = (Vec<FpVar<CF1<C>>>, Vec<FpVar<CF1<C>>>);

--- a/folding-schemes/src/utils/vec.rs
+++ b/folding-schemes/src/utils/vec.rs
@@ -8,7 +8,7 @@ use ark_std::cfg_iter;
 use ark_std::rand::Rng;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
-use crate::Error;
+use crate::{folding::traits::Dummy, Error};
 
 #[derive(Clone, Debug, Eq, PartialEq, CanonicalSerialize, CanonicalDeserialize)]
 pub struct SparseMatrix<F: PrimeField> {
@@ -19,14 +19,22 @@ pub struct SparseMatrix<F: PrimeField> {
     pub coeffs: R1CSMatrix<F>,
 }
 
-impl<F: PrimeField> SparseMatrix<F> {
-    pub fn empty() -> Self {
+impl<F: PrimeField> Dummy<(usize, usize)> for SparseMatrix<F> {
+    fn dummy((n_rows, n_cols): (usize, usize)) -> Self {
         Self {
-            n_rows: 0,
-            n_cols: 0,
-            coeffs: vec![],
+            n_rows,
+            n_cols,
+            // unnecessary to allocate each row as the matrix is sparse
+            coeffs: vec![vec![]; n_rows],
         }
     }
+}
+
+impl<F: PrimeField> SparseMatrix<F> {
+    pub fn empty() -> Self {
+        Self::dummy((0, 0))
+    }
+
     pub fn rand<R: Rng>(rng: &mut R, n_rows: usize, n_cols: usize) -> Self {
         const ZERO_VAL_PROBABILITY: f64 = 0.8f64;
 


### PR DESCRIPTION
This PR introduces getter methods that return information about R1CS and CCS. With these getters, we can avoid declaring field members such as `ccs.m` as public.

Note that the `Arith` trait is now solely for these methods which are about the constraint system *itself*. The original `Arith` trait has been renamed to `ArithRelation`, stressing that it is about the *relation* between the constraint system's witness `W` and instance `U`.