### PR TITLE
perf: optimize pedersen and ipa commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ members = [
     "experimental-frontends"
 ]
 resolver = "2"
+
+[patch.crates-io]
+ark-r1cs-std = {git = "https://github.com/yelhousni/r1cs-std", branch="perf/sw"}

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -519,8 +519,22 @@ impl<C: Curve, const H: bool> IPAGadget<C, H> {
 
         // msm: G=<G, s>
         let mut G = C::Var::zero();
-        for (i, s_i) in s.iter().enumerate() {
-            G += g[i].scalar_mul_le(s_i.to_bits_le()?.iter())?;
+        let n = s.len();
+        if n % 2 == 1 {
+            G += g[n - 1].scalar_mul_le(s[n - 1].to_bits_le()?.iter())?;
+        } else {
+            G += g[n - 1].joint_scalar_mul_be(
+                &g[n - 2],
+                s[n - 1].to_bits_le()?.iter(),
+                s[n - 2].to_bits_le()?.iter(),
+            )?;
+        }
+        for i in (1..n - 2).step_by(2) {
+            G += g[i - 1].joint_scalar_mul_be(
+                &g[i],
+                s[i - 1].to_bits_le()?.iter(),
+                s[i].to_bits_le()?.iter(),
+            )?;
         }
 
         for (j, u_j) in u.iter().enumerate() {
@@ -537,11 +551,17 @@ impl<C: Curve, const H: bool> IPAGadget<C, H> {
 
         let q_1 = if H {
             G.scalar_mul_le(p.a.to_bits_le()?.iter())?
-                + h.scalar_mul_le(r.to_bits_le()?.iter())?
-                + U.scalar_mul_le((p.a.clone() * b).to_bits_le()?.iter())?
+                + h.joint_scalar_mul_be(
+                    &U,
+                    r.to_bits_le()?.iter(),
+                    (p.a.clone() * b).to_bits_le()?.iter(),
+                )?
         } else {
-            G.scalar_mul_le(p.a.to_bits_le()?.iter())?
-                + U.scalar_mul_le((p.a.clone() * b).to_bits_le()?.iter())?
+            G.joint_scalar_mul_be(
+                &U,
+                p.a.to_bits_le()?.iter(),
+                (p.a.clone() * b).to_bits_le()?.iter(),
+            )?
         };
         // q_0 == q_1
         q_0.is_eq(&q_1)

--- a/folding-schemes/src/commitment/ipa.rs
+++ b/folding-schemes/src/commitment/ipa.rs
@@ -552,13 +552,13 @@ impl<C: Curve, const H: bool> IPAGadget<C, H> {
         let q_1 = if H {
             G.scalar_mul_le(p.a.to_bits_le()?.iter())?
                 + h.joint_scalar_mul_be(
-                    &U,
+                    U,
                     r.to_bits_le()?.iter(),
                     (p.a.clone() * b).to_bits_le()?.iter(),
                 )?
         } else {
             G.joint_scalar_mul_be(
-                &U,
+                U,
                 p.a.to_bits_le()?.iter(),
                 (p.a.clone() * b).to_bits_le()?.iter(),
             )?

--- a/folding-schemes/src/commitment/pedersen.rs
+++ b/folding-schemes/src/commitment/pedersen.rs
@@ -189,8 +189,22 @@ impl<C: Curve, const H: bool> PedersenGadget<C, H> {
         if H {
             res += h.scalar_mul_le(r.iter())?;
         }
-        for (i, v_i) in v.iter().enumerate() {
-            res += g[i].scalar_mul_le(v_i.to_bits_le()?.iter())?;
+        let n = v.len();
+        if n % 2 == 1 {
+            res += g[n - 1].scalar_mul_le(v[n - 1].to_bits_le()?.iter())?;
+        } else {
+            res += g[n - 1].joint_scalar_mul_be(
+                &g[n - 2],
+                v[n - 1].to_bits_le()?.iter(),
+                v[n - 2].to_bits_le()?.iter(),
+            )?;
+        }
+        for i in (1..n - 2).step_by(2) {
+            res += g[i - 1].joint_scalar_mul_be(
+                &g[i],
+                v[i - 1].to_bits_le()?.iter(),
+                v[i].to_bits_le()?.iter(),
+            )?;
         }
         Ok(res)
     }


### PR DESCRIPTION
# Description
This PR optimizes Pedersen and IPA commitments gadgets, through the use of joint_scalar_mul_be and scalar_mul_le implemented here https://github.com/arkworks-rs/r1cs-std/pull/155.
solves https://github.com/privacy-scaling-explorations/sonobe/pull/201#issuecomment-2629296814.
# Benchmark
The Pedersen check circuit goes from 3,575,519 r1cs to 2,455,364 r1cs.
The IPA verify circuit also goes from 77,175 r1cs to 73,367 r1cs.