### PR TITLE
Move dependencies and common properties to the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,55 @@ members = [
     "experimental-frontends"
 ]
 resolver = "2"
+
+[workspace.package]
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/privacy-scaling-explorations/sonobe/"
+
+[workspace.dependencies]
+acvm = { git = "https://github.com/winderica/noir", branch = "arkworks-next", default-features = false }
+askama = { version = "0.12.0", default-features = false }
+clap = { version = "4.4" }
+clap-verbosity-flag = { version = "2.1" }
+criterion = { version = "0.5" }
+env_logger = { version = "0.10" }
+getrandom = { version = "0.2" }
+log = { version = "0.4" }
+noname = { git = "https://github.com/dmpierre/noname" }
+num-bigint = { version = "0.4.3" }
+num-integer = { version = "0.1" }
+pprof = { version = "0.13" }
+serde = { version = "^1.0.0" }
+serde_json = { version = "^1.0.0" }
+sha3 = { version = "0.10" }
+rand = { version = "0.8.5" }
+rayon = { version = "1" }
+revm = { version = "3.5.0", default-features = false }
+rust-crypto = { version = "0.2" }
+thiserror = { version = "1.0" }
+
+# Arkworks family
+ark-bn254 = { version = "^0.5.0", default-features = false }
+ark-circom = { git = "https://github.com/winderica/circom-compat", branch = "arkworks-next", default-features = false }
+ark-crypto-primitives = { version = "^0.5.0", default-features = false }
+ark-ec = { version = "^0.5.0", default-features = false }
+ark-ff = { version = "^0.5.0", default-features = false }
+ark-groth16 = { version = "^0.5.0" }
+ark-grumpkin = { version = "^0.5.0", default-features = false }
+ark-mnt4-298 = { version = "^0.5.0" }
+ark-mnt6-298 = { version = "^0.5.0" }
+ark-pallas = { version = "^0.5.0" }
+ark-poly = { version = "^0.5.0", default-features = false }
+ark-poly-commit = { version = "^0.5.0" }
+ark-r1cs-std = { version = "^0.5.0", default-features = false }
+ark-relations = { version = "^0.5.0", default-features = false }
+ark-serialize = { version = "^0.5.0" }
+ark-snark = { version = "^0.5.0", default-features = false }
+ark-std = { version = "^0.5.0", default-features = false }
+ark-vesta = { version = "^0.5.0" }
+
+# Local crates
+experimental-frontends = { path = "experimental-frontends" }
+folding-schemes = { path = "folding-schemes" }
+solidity-verifiers = { path = "solidity-verifiers" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "solidity-verifiers-cli"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-ark-serialize = "^0.5.0"
-solidity-verifiers = { path = "../solidity-verifiers" }
-clap = { version = "4.4", features = ["derive", "string"] }
-clap-verbosity-flag = "2.1"
-env_logger = "0.10"
+ark-serialize = { workspace = true }
+solidity-verifiers = { workspace = true }
+clap = { workspace = true, features = ["derive", "string"] }
+clap-verbosity-flag = { workspace = true }
+env_logger = { workspace = true }
 
 [features]
 default = ["parallel"]

--- a/experimental-frontends/Cargo.toml
+++ b/experimental-frontends/Cargo.toml
@@ -1,29 +1,31 @@
 [package]
 name = "experimental-frontends"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-ark-ff = { version = "^0.5.0", default-features = false, features = ["parallel", "asm"] }
-ark-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-relations = { version = "^0.5.0", default-features = false }
-ark-r1cs-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-serialize = { version = "^0.5.0", default-features = false }
-ark-circom = { git = "https://github.com/winderica/circom-compat", branch = "arkworks-next", default-features = false }
-num-bigint = "0.4"
-noname = { git = "https://github.com/dmpierre/noname" }
-acvm = { git = "https://github.com/winderica/noir", branch = "arkworks-next", default-features = false }
-folding-schemes = { path = "../folding-schemes/"}
-serde = { version = "^1.0.0", features = ["derive"] }
-serde_json = "^1.0.0"
+ark-ff = { workspace = true, features = ["parallel", "asm"] }
+ark-std = { workspace = true, features = ["parallel"] }
+ark-relations = { workspace = true }
+ark-r1cs-std = { workspace = true, features = ["parallel"] }
+ark-serialize = { workspace = true }
+ark-circom = { workspace = true }
+num-bigint = { workspace = true }
+noname = { workspace = true }
+acvm = { workspace = true }
+folding-schemes = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-ark-bn254 = { version="^0.5.0", features=["r1cs"]}
+ark-bn254 = { workspace = true, features = ["r1cs"] }
 
 # This allows the crate to be built when targeting WASM.
 # See more at: https://docs.rs/getrandom/#webassembly-support 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 
 [features]
 default = ["ark-circom/default", "parallel"]

--- a/folding-schemes/Cargo.toml
+++ b/folding-schemes/Cargo.toml
@@ -1,51 +1,51 @@
 [package]
 name = "folding-schemes"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-ark-ec = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-ff = { version = "^0.5.0", default-features = false, features = ["parallel", "asm"] }
-ark-poly = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-crypto-primitives = { version = "^0.5.0", default-features = false, features = ["r1cs", "sponge", "crh", "parallel"] }
-ark-poly-commit = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-relations = { version = "^0.5.0", default-features = false }
-ark-r1cs-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-snark = { version = "^0.5.0", default-features = false }
-ark-serialize = { version = "^0.5.0", default-features = false }
-ark-groth16 = { version = "^0.5.0", default-features = false, features = ["parallel"]}
-ark-bn254 = { version = "^0.5.0", default-features = false }
-ark-grumpkin = { version = "^0.5.0", default-features = false }
-thiserror = "1.0"
-rayon = "1"
-num-bigint = "0.4"
-num-integer = "0.1"
-sha3 = "0.10"
-log = "0.4"
+ark-ec = { workspace = true, features = ["parallel"] }
+ark-ff = { workspace = true, features = ["parallel", "asm"] }
+ark-poly = { workspace = true, features = ["parallel"] }
+ark-std = { workspace = true, features = ["parallel"] }
+ark-crypto-primitives = { workspace = true, features = ["r1cs", "sponge", "crh", "parallel"] }
+ark-poly-commit = { workspace = true, features = ["parallel"] }
+ark-relations = { workspace = true }
+ark-r1cs-std = { workspace = true, features = ["parallel"] }
+ark-snark = { workspace = true }
+ark-serialize = { workspace = true }
+ark-groth16 = { workspace = true, features = ["parallel"] }
+ark-bn254 = { workspace = true }
+ark-grumpkin = { workspace = true }
+thiserror = { workspace = true }
+rayon = { workspace = true }
+num-bigint = { workspace = true }
+num-integer = { workspace = true }
+sha3 = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
-ark-pallas = {version="^0.5.0", features=["r1cs"]}
-ark-vesta = {version="^0.5.0", features=["r1cs"]}
-ark-bn254 = {version="^0.5.0", features=["r1cs"]}
-ark-grumpkin = {version="^0.5.0", features=["r1cs"]}
+ark-pallas = { workspace = true, features = ["r1cs"] }
+ark-vesta = { workspace = true, features = ["r1cs"] }
+ark-bn254 = { workspace = true, features = ["r1cs"] }
+ark-grumpkin = { workspace = true, features = ["r1cs"] }
 # Note: do not use the MNTx_298 curves in practice due security reasons, here
 # we only use them in the tests.
-ark-mnt4-298 = {version="^0.5.0", features=["r1cs"]}
-ark-mnt6-298 = {version="^0.5.0", features=["r1cs"]}
-rand = "0.8.5"
-num-bigint = {version = "0.4", features = ["rand"]}
-tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }
-tracing-subscriber = { version = "0.2" }
+ark-mnt4-298 = { workspace = true, features = ["r1cs"] }
+ark-mnt6-298 = { workspace = true, features = ["r1cs"] }
+rand = { workspace = true }
+num-bigint = { workspace = true, features = ["rand"] }
 
 # for benchmarks
-criterion = "0.5"
-pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
+criterion = { workspace = true }
+pprof = { workspace = true, features = ["criterion", "flamegraph"] }
 
 # This allows the crate to be built when targeting WASM.
 # See more at: https://docs.rs/getrandom/#webassembly-support 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 
 [features]
 default = ["parallel"]

--- a/solidity-verifiers/Cargo.toml
+++ b/solidity-verifiers/Cargo.toml
@@ -1,38 +1,40 @@
 [package]
 name = "solidity-verifiers"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
-ark-groth16 = "^0.5.0"
-ark-bn254 = { version = "^0.5.0", default-features = false, features = ["r1cs"] }
-ark-poly-commit = "^0.5.0"
-ark-serialize = "^0.5.0"
-askama = { version = "0.12.0", features = ["config"], default-features = false }
-revm = {version="3.5.0", default-features=false, features=["std"]}
-rust-crypto = "0.2"
-num-bigint = "0.4.3"
-folding-schemes = { path = "../folding-schemes/"} # without 'light-test' enabled
+ark-groth16 = { workspace = true }
+ark-bn254 = { workspace = true, features = ["r1cs"] }
+ark-poly-commit = { workspace = true }
+ark-serialize = { workspace = true }
+askama = { workspace = true, features = ["config"] }
+revm = { workspace = true, features = ["std"] }
+rust-crypto = { workspace = true }
+num-bigint = { workspace = true }
+folding-schemes = { workspace = true } # without 'light-test' enabled
 
 [dev-dependencies]
-ark-ec = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-ff = { version = "^0.5.0", default-features = false, features = ["parallel", "asm"] }
-ark-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-crypto-primitives = { version = "^0.5.0", default-features = false, features = ["sponge", "parallel"] }
-ark-snark = { version = "^0.5.0", default-features = false }
-ark-relations = { version = "^0.5.0", default-features = false }
-ark-r1cs-std = { version = "^0.5.0", default-features = false, features = ["parallel"] }
-ark-grumpkin = { version = "^0.5.0", default-features = false, features = ["r1cs"] }
-folding-schemes = { path = "../folding-schemes/", features=["light-test"]}
-experimental-frontends = { path = "../experimental-frontends/"}
-noname = { git = "https://github.com/dmpierre/noname" }
+ark-ec = { workspace = true, features = ["parallel"] }
+ark-ff = { workspace = true, features = ["parallel", "asm"] }
+ark-std = { workspace = true, features = ["parallel"] }
+ark-crypto-primitives = { workspace = true, features = ["sponge", "parallel"] }
+ark-snark = { workspace = true }
+ark-relations = { workspace = true }
+ark-r1cs-std = { workspace = true, features = ["parallel"] }
+ark-grumpkin = { workspace = true, features = ["r1cs"] }
+folding-schemes = { workspace = true, features = ["light-test"] }
+experimental-frontends = { workspace = true }
+noname = { workspace = true }
 
 [features]
 default = ["parallel"]
 
-parallel = [ 
-    "ark-groth16/parallel", 
-    "ark-poly-commit/parallel",  
+parallel = [
+    "ark-groth16/parallel",
+    "ark-poly-commit/parallel",
     "folding-schemes/parallel",
 ]
 


### PR DESCRIPTION
1. Package properties:
    - `edition` was moved to the workspace level and inherited in all 4 crates
    - `repository` and `license` were introduced at the workspace level and inherited in all 4 crates
2. Dependencies:
    - all moved to the workspace level and inherited in all 4 crates
    - grouped into 3 categories for easier navigation - general, arkworks and local
    - removed unused `tracing` and `tracing-subscriber` dependencies
3. Whitespace refactor