### PR TITLE
Improve Clarity in Comments and Documentation

### DIFF
--- a/experimental-frontends/src/noname/mod.rs
+++ b/experimental-frontends/src/noname/mod.rs
@@ -64,7 +64,7 @@ impl<F: PrimeField, BF: BackendField, const L: usize> FCircuit<F> for NonameFCir
             .map(|idx| -> Result<FpVar<F>, SynthesisError> {
                 // the assigned zi1 is of the same size than the initial zi and is located in the
                 // output of the witness vector
-                // we prefer to assign z_i1 here since (1) we have to return it, (2) we cant return
+                // we prefer to assign z_i1 here since (1) we have to return it, (2) we can't return
                 // anything with the `generate_constraints` method used below
                 let value: BigUint = Into::into(noname_witness.witness[idx]);
                 let field_element = F::from(value);

--- a/folding-schemes/src/folding/nova/nifs/pointvsline.rs
+++ b/folding-schemes/src/folding/nova/nifs/pointvsline.rs
@@ -45,7 +45,7 @@ impl<C: Curve, T: Transcript<C::ScalarField>> PointVsLine<C, T> {
         let mleE1 = dense_vec_to_dense_mle(n_vars, &w1.E);
         let mleE2 = dense_vec_to_dense_mle(n_vars, &w2.E);
 
-        // We have l(0) = r1, l(1) = r2 so we know that l(x) = r1 + x(r2-r1) thats why we need r2-r1
+        // We have l(0) = r1, l(1) = r2 so we know that l(x) = r1 + x(r2-r1) that's why we need r2-r1
         let r2_sub_r1: Vec<<C>::ScalarField> = ci1
             .rE
             .iter()

--- a/folding-schemes/src/utils/espresso/virtual_polynomial.rs
+++ b/folding-schemes/src/utils/espresso/virtual_polynomial.rs
@@ -19,7 +19,7 @@ use std::{cmp::max, collections::HashMap, marker::PhantomData, ops::Add, sync::A
 use thiserror::Error;
 
 //-- aritherrors
-/// A `enum` specifying the possible failure modes of the arithmetics.
+/// A `enum` specifying the possible failure modes of the arithmetic.
 #[derive(Error, Debug)]
 pub enum ArithErrors {
     #[error("Invalid parameters: {0}")]


### PR DESCRIPTION
- `we cant return` → `we can't return`
- `thats why we need r2-r1` → `that's why we need r2-r1`
- `failure modes of the arithmetics` → `failure modes of the arithmetic`
