### PR TITLE
Allow the creation of custom Poseidon configs

### DIFF
--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -19,7 +19,7 @@ use crate::folding::traits::{
     CommittedInstanceOps, Dummy, Inputize, InputizeNonNative, WitnessOps,
 };
 use crate::frontend::FCircuit;
-use crate::transcript::poseidon::poseidon_canonical_config;
+use crate::transcript::poseidon::poseidon_custom_config;
 use crate::{Curve, Error};
 use crate::{Decider as DeciderTrait, FoldingScheme};
 
@@ -148,10 +148,19 @@ where
         >>::VerifierParam = vp.into();
         let pp_hash = nova_vp.pp_hash()?;
 
+        let poseidon_config1 = nova_vp.poseidon_config;
+        let poseidon_config2 = poseidon_custom_config(
+            poseidon_config1.full_rounds,
+            poseidon_config1.partial_rounds,
+            poseidon_config1.alpha,
+            poseidon_config1.rate,
+            poseidon_config1.capacity,
+        );
+
         let circuit1 = DeciderCircuit1::<C1, C2>::dummy((
             nova_vp.r1cs,
             &nova_vp.cf_r1cs,
-            nova_vp.poseidon_config,
+            poseidon_config1,
             (),
             (),
             state_len,
@@ -159,7 +168,7 @@ where
         ));
         let circuit2 = DeciderCircuit2::<C2>::dummy((
             nova_vp.cf_r1cs,
-            poseidon_canonical_config::<C2::ScalarField>(),
+            poseidon_config2,
             2, // Nova's running CommittedInstance contains 2 commitments
         ));
 

--- a/folding-schemes/src/folding/nova/decider.rs
+++ b/folding-schemes/src/folding/nova/decider.rs
@@ -149,6 +149,11 @@ where
         let pp_hash = nova_vp.pp_hash()?;
 
         let poseidon_config1 = nova_vp.poseidon_config;
+        // Create a poseidon config on `C2`'s scalar field for `circuit2`, with
+        // the same parameters (`full_rounds` etc.) as `circuit1` to ensure the
+        // security level is the same.
+        // Note: `ark` and `mds` will be different because they depend on the
+        // field, but they will not affect the security level.
         let poseidon_config2 = poseidon_custom_config(
             poseidon_config1.full_rounds,
             poseidon_config1.partial_rounds,

--- a/folding-schemes/src/folding/nova/decider_circuits.rs
+++ b/folding-schemes/src/folding/nova/decider_circuits.rs
@@ -117,8 +117,11 @@ impl<
     type Error = Error;
 
     fn try_from(nova: Nova<C1, C2, FC, CS1, CS2, H>) -> Result<Self, Error> {
-        // compute the Commitment Scheme challenges of the CycleFold instance commitments, used as
-        // inputs in the circuit
+        // Create a poseidon config on `C2`'s scalar field for `circuit2`, with
+        // the same parameters (`full_rounds` etc.) as `circuit1` to ensure the
+        // security level is the same.
+        // Note: `ark` and `mds` will be different because they depend on the
+        // field, but they will not affect the security level.
         let poseidon_config = poseidon_custom_config(
             nova.poseidon_config.full_rounds,
             nova.poseidon_config.partial_rounds,


### PR DESCRIPTION
This PR implements `poseidon_custom_config`, which allows users to create custom `PoseidonConfig`s by specifying parameters on their own.

The offchain `DeciderCircuit2`'s implementation is also updated. Instead of always using the canonical config for `DeciderCircuit2` on `C2::ScalarField`, we now create one that corresponds to (i.e., shares the same parameters with) the user-specified config on `C1::ScalarField`.