### PR TITLE
Fix duplicate word in decider_eth.rs comment

### DIFF
--- a/folding-schemes/src/folding/hypernova/decider_eth.rs
+++ b/folding-schemes/src/folding/hypernova/decider_eth.rs
@@ -30,7 +30,7 @@ where
     // rho used at the last fold, U_{i+1}=NIMFS.V(rho, U_i, u_i), it is checked in-circuit
     rho: C1::ScalarField,
     // the KZG challenge is provided by the prover, but in-circuit it is checked to match
-    // the in-circuit computed computed one.
+    // the in-circuit computed one.
     kzg_challenge: C1::ScalarField,
 }
 


### PR DESCRIPTION
Fix duplicate word in decider_eth.rs comment
Remove duplicate "computed" word in KZG challenge comment to improve code readability.