### PR TITLE
Bump ark circom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,12 @@ rayon = { version = "1" }
 revm = { version = "19.5.0", default-features = false }
 rust-crypto = { version = "0.2" }
 thiserror = { version = "1.0" }
+tokio = "1.44.1"
+wasmer = "4.4.0"
 
 # Arkworks family
 ark-bn254 = { version = "^0.5.0", default-features = false }
-ark-circom = { git = "https://github.com/winderica/circom-compat", rev = "9f8d7c", default-features = false } # "arkworks-next" branch
+ark-circom = { version = "^0.5.0", default-features = false }
 ark-crypto-primitives = { version = "^0.5.0", default-features = false }
 ark-ec = { version = "^0.5.0", default-features = false }
 ark-ff = { version = "^0.5.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ revm = { version = "19.5.0", default-features = false }
 rust-crypto = { version = "0.2" }
 thiserror = { version = "1.0" }
 tokio = "1.44.1"
-wasmer = "4.4.0"
+wasmer = { version = "4.4.0", default-features = false }
 
 # Arkworks family
 ark-bn254 = { version = "^0.5.0", default-features = false }

--- a/experimental-frontends/Cargo.toml
+++ b/experimental-frontends/Cargo.toml
@@ -18,6 +18,8 @@ acvm = { workspace = true }
 folding-schemes = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tokio = { workspace = true }
+wasmer = { workspace = true }
 
 [dev-dependencies]
 ark-bn254 = { workspace = true, features = ["r1cs"] }

--- a/experimental-frontends/src/circom/mod.rs
+++ b/experimental-frontends/src/circom/mod.rs
@@ -95,14 +95,10 @@ impl<F: PrimeField, const SL: usize, const EIL: usize> FCircuit<F> for CircomFCi
         // record the allocated variable's index in `circom_index_to_cs_index`.
         // Cf. https://github.com/arnaucube/circom-compat/blob/22c8f5/src/circom/circuit.rs#L56-L86
         let mut z_i1 = vec![];
-        for i in 1..1 + SL {
-            let v = cs.new_witness_variable(|| Ok(witness[i]))?;
+        for &w in witness.iter().skip(1).take(SL) {
+            let v = cs.new_witness_variable(|| Ok(w))?;
             circom_index_to_cs_index.push(v);
-            z_i1.push(FpVar::Var(AllocatedFp::new(
-                Some(witness[i]),
-                v,
-                cs.clone(),
-            )));
+            z_i1.push(FpVar::Var(AllocatedFp::new(Some(w), v, cs.clone())));
         }
 
         // `z_i` and `external_inputs` have already been allocated as witness,

--- a/experimental-frontends/src/circom/mod.rs
+++ b/experimental-frontends/src/circom/mod.rs
@@ -77,14 +77,17 @@ impl<F: PrimeField, const SL: usize, const EIL: usize> FCircuit<F> for CircomFCi
 
         let num_existing_witnesses = cs.num_witness_variables();
 
-        let mut z_i1 = vec![];
-        for i in 1..1 + SL {
-            z_i1.push(FpVar::new_witness(cs.clone(), || Ok(witness[i]))?);
-        }
+        // Allocate the next state (1..1 + SL) as witness.
+        let z_i1 = witness
+            .iter()
+            .skip(1)
+            .take(SL)
+            .map(|w| FpVar::new_witness(cs.clone(), || Ok(w)))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        // Allocate the aux variables as witness.
-        for i in 1 + SL * 2 + EIL..witness.len() {
-            cs.new_witness_variable(|| Ok(witness[i]))?;
+        // Allocate the aux variables (1 + SL * 2 + EIL..) as witness.
+        for &w in witness.iter().skip(1 + SL * 2 + EIL) {
+            cs.new_witness_variable(|| Ok(w))?;
         }
 
         let var = |index| {

--- a/experimental-frontends/src/circom/utils.rs
+++ b/experimental-frontends/src/circom/utils.rs
@@ -1,24 +1,26 @@
+use std::{fs::File, io::Cursor, path::PathBuf};
+
 use ark_circom::{
     circom::{r1cs_reader, R1CS},
     WitnessCalculator,
 };
-use ark_ff::{BigInteger, PrimeField};
+use ark_ff::PrimeField;
 use ark_serialize::Read;
-use num_bigint::{BigInt, Sign};
-use std::{fs::File, io::Cursor, marker::PhantomData, path::PathBuf};
+use num_bigint::BigInt;
+use tokio::runtime::Runtime;
+use wasmer::{Module, Store};
 
 use folding_schemes::{utils::PathOrBin, Error};
 
 // A struct that wraps Circom functionalities, allowing for extraction of R1CS and witnesses
 // based on file paths to Circom's .r1cs and .wasm.
 #[derive(Clone, Debug)]
-pub struct CircomWrapper<F: PrimeField> {
+pub struct CircomWrapper {
     r1csfile_bytes: Vec<u8>,
     wasmfile_bytes: Vec<u8>,
-    _marker: PhantomData<F>,
 }
 
-impl<F: PrimeField> CircomWrapper<F> {
+impl CircomWrapper {
     // Creates a new instance of the CircomWrapper with the file paths.
     pub fn new(r1cs: PathOrBin, wasm: PathOrBin) -> Result<Self, Error> {
         match (r1cs, wasm) {
@@ -28,7 +30,6 @@ impl<F: PrimeField> CircomWrapper<F> {
             (PathOrBin::Bin(r1cs_bin), PathOrBin::Bin(wasm_bin)) => Ok(Self {
                 r1csfile_bytes: r1cs_bin,
                 wasmfile_bytes: wasm_bin,
-                _marker: PhantomData,
             }),
             _ => unreachable!("You should pass the same enum branch for both inputs"),
         }
@@ -49,18 +50,17 @@ impl<F: PrimeField> CircomWrapper<F> {
         Ok(CircomWrapper {
             r1csfile_bytes,
             wasmfile_bytes,
-            _marker: PhantomData,
         })
     }
 
     // Aggregated function to obtain R1CS and witness from Circom.
-    pub fn extract_r1cs_and_witness(
+    pub fn extract_r1cs_and_witness<F: PrimeField>(
         &self,
-        inputs: &[(String, Vec<BigInt>)],
+        inputs: Vec<(String, Vec<BigInt>)>,
     ) -> Result<(R1CS<F>, Option<Vec<F>>), Error> {
         // Extracts the R1CS
-        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(Cursor::new(&self.r1csfile_bytes))?;
-        let r1cs = r1cs_reader::R1CS::<F>::from(r1cs_file);
+        let r1cs_file = r1cs_reader::R1CSFile::new(Cursor::new(&self.r1csfile_bytes))?;
+        let r1cs = r1cs_reader::R1CS::from(r1cs_file);
 
         // Extracts the witness vector
         let witness_vec = self.extract_witness(inputs)?;
@@ -68,25 +68,27 @@ impl<F: PrimeField> CircomWrapper<F> {
         Ok((r1cs, Some(witness_vec)))
     }
 
-    pub fn extract_r1cs(&self) -> Result<R1CS<F>, Error> {
-        let r1cs_file = r1cs_reader::R1CSFile::<F>::new(Cursor::new(&self.r1csfile_bytes))?;
-        let mut r1cs = r1cs_reader::R1CS::<F>::from(r1cs_file);
+    pub fn extract_r1cs<F: PrimeField>(&self) -> Result<R1CS<F>, Error> {
+        let r1cs_file = r1cs_reader::R1CSFile::new(Cursor::new(&self.r1csfile_bytes))?;
+        let mut r1cs = r1cs_reader::R1CS::from(r1cs_file);
         r1cs.wire_mapping = None;
         Ok(r1cs)
     }
 
     // Extracts the witness vector as a vector of PrimeField elements.
-    pub fn extract_witness(&self, inputs: &[(String, Vec<BigInt>)]) -> Result<Vec<F>, Error> {
+    pub fn extract_witness<F: PrimeField>(&self, inputs: Vec<(String, Vec<BigInt>)>) -> Result<Vec<F>, Error> {
         let witness_bigint = self.calculate_witness(inputs)?;
 
         witness_bigint
-            .iter()
+            .into_iter()
             .map(|big_int| {
-                self.num_bigint_to_ark_bigint(big_int)
-                    .and_then(|ark_big_int| {
-                        F::from_bigint(ark_big_int)
-                            .ok_or_else(|| Error::Other("could not get F from bigint".to_string()))
-                    })
+                big_int.to_biguint().map(F::from).ok_or_else(|| {
+                    Error::ConversionError(
+                        "BigInt".into(),
+                        "BigUint".into(),
+                        "BigInt is negative".into(),
+                    )
+                })
             })
             .collect()
     }
@@ -94,41 +96,26 @@ impl<F: PrimeField> CircomWrapper<F> {
     // Calculates the witness given the Wasm filepath and inputs.
     pub fn calculate_witness(
         &self,
-        inputs: &[(String, Vec<BigInt>)],
+        inputs: Vec<(String, Vec<BigInt>)>,
     ) -> Result<Vec<BigInt>, Error> {
-        let mut calculator = WitnessCalculator::from_binary(&self.wasmfile_bytes).map_err(|e| {
-            Error::WitnessCalculationError(format!("Failed to create WitnessCalculator: {}", e))
-        })?;
-        calculator
-            .calculate_witness(inputs.iter().cloned(), true)
-            .map_err(|e| {
-                Error::WitnessCalculationError(format!("Failed to calculate witness: {}", e))
-            })
-    }
-
-    // Converts a num_bigint::BigInt to a PrimeField::BigInt.
-    pub fn num_bigint_to_ark_bigint(&self, value: &BigInt) -> Result<F::BigInt, Error> {
-        let big_uint = value.to_biguint().ok_or_else(|| {
-            Error::ConversionError(
-                "BigInt".into(),
-                "BigUint".into(),
-                "BigInt is negative".into(),
-            )
-        })?;
-        F::BigInt::try_from(big_uint).map_err(|_| {
-            Error::ConversionError(
-                "BigUint".into(),
-                "PrimeField::BigInt".into(),
-                "BigUint is too large to fit into PrimeField::BigInt".into(),
-            )
+        Runtime::new().unwrap().block_on(async {
+            let mut store = Store::default();
+            let module = Module::new(&store, &self.wasmfile_bytes).map_err(|e| {
+                Error::WitnessCalculationError(format!("Failed to create Wasm module: {}", e))
+            })?;
+            let mut calculator =
+                WitnessCalculator::from_module(&mut store, module).map_err(|e| {
+                    Error::WitnessCalculationError(format!(
+                        "Failed to create WitnessCalculator: {}",
+                        e
+                    ))
+                })?;
+            calculator
+                .calculate_witness(&mut store, inputs, true)
+                .map_err(|e| {
+                    Error::WitnessCalculationError(format!("Failed to calculate witness: {}", e))
+                })
         })
-    }
-
-    // Converts a PrimeField element to a num_bigint::BigInt representation.
-    pub fn ark_primefield_to_num_bigint(&self, value: F) -> BigInt {
-        let primefield_bigint: F::BigInt = value.into_bigint();
-        let bytes = primefield_bigint.to_bytes_be();
-        BigInt::from_bytes_be(Sign::Plus, &bytes)
     }
 }
 
@@ -144,8 +131,8 @@ mod tests {
     //bash ./frontends/src/circom/test_folder/compile.sh
 
     // Test the satisfication by using the CircomBuilder of circom-compat
-    #[test]
-    fn test_circombuilder_satisfied() -> Result<(), Error> {
+    #[tokio::test]
+    async fn test_circombuilder_satisfied() -> Result<(), Error> {
         let cfg = CircomConfig::<Fr>::new(
             "./src/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm",
             "./src/circom/test_folder/cubic_circuit.r1cs",
@@ -169,18 +156,13 @@ mod tests {
             PathBuf::from("./src/circom/test_folder/cubic_circuit_js/cubic_circuit.wasm");
 
         let inputs = vec![("ivc_input".to_string(), vec![BigInt::from(3)])];
-        let wrapper = CircomWrapper::<Fr>::new(r1cs_path.into(), wasm_path.into())?;
+        let wrapper = CircomWrapper::new(r1cs_path.into(), wasm_path.into())?;
 
-        let (r1cs, witness) = wrapper.extract_r1cs_and_witness(&inputs)?;
+        let (r1cs, witness) = wrapper.extract_r1cs_and_witness(inputs)?;
 
         let cs = ConstraintSystem::<Fr>::new_ref();
 
-        let circom_circuit = CircomCircuit {
-            r1cs,
-            witness,
-            public_inputs_indexes: vec![],
-            allocate_inputs_as_witnesses: false,
-        };
+        let circom_circuit = CircomCircuit { r1cs, witness };
 
         circom_circuit.generate_constraints(cs.clone())?;
         assert!(cs.is_satisfied()?);

--- a/experimental-frontends/src/circom/utils.rs
+++ b/experimental-frontends/src/circom/utils.rs
@@ -76,7 +76,10 @@ impl CircomWrapper {
     }
 
     // Extracts the witness vector as a vector of PrimeField elements.
-    pub fn extract_witness<F: PrimeField>(&self, inputs: Vec<(String, Vec<BigInt>)>) -> Result<Vec<F>, Error> {
+    pub fn extract_witness<F: PrimeField>(
+        &self,
+        inputs: Vec<(String, Vec<BigInt>)>,
+    ) -> Result<Vec<F>, Error> {
         let witness_bigint = self.calculate_witness(inputs)?;
 
         witness_bigint

--- a/experimental-frontends/src/noname/mod.rs
+++ b/experimental-frontends/src/noname/mod.rs
@@ -52,8 +52,8 @@ impl<F: PrimeField, BF: BackendField, const SL: usize, const EIL: usize> FCircui
         external_inputs: Self::ExternalInputsVar,
     ) -> Result<Vec<FpVar<F>>, SynthesisError> {
         let wtns_external_inputs =
-            NonameInputs::from_fpvars((&external_inputs.0, "external_inputs".to_string()))?;
-        let wtns_ivc_inputs = NonameInputs::from_fpvars((&z_i, "ivc_inputs".to_string()))?;
+            NonameInputs::from_fpvars((&external_inputs.0, "external_inputs".to_string()));
+        let wtns_ivc_inputs = NonameInputs::from_fpvars((&z_i, "ivc_inputs".to_string()));
         let noname_witness = self
             .circuit
             .generate_witness(wtns_ivc_inputs.0, wtns_external_inputs.0)

--- a/experimental-frontends/src/noname/utils.rs
+++ b/experimental-frontends/src/noname/utils.rs
@@ -38,17 +38,13 @@ impl<F: PrimeField> From<(&Vec<F>, String)> for NonameInputs {
 }
 
 impl NonameInputs {
-    pub fn from_fpvars<F: PrimeField>(
-        value: (&Vec<FpVar<F>>, String),
-    ) -> Self {
+    pub fn from_fpvars<F: PrimeField>(value: (&Vec<FpVar<F>>, String)) -> Self {
         let (values, key) = value;
         let mut inputs = HashMap::new();
         if !values.is_empty() {
             let field_elements: Vec<String> = values
                 .iter()
-                .map(|var| {
-                    var.value().unwrap_or_default().to_string()
-                })
+                .map(|var| var.value().unwrap_or_default().to_string())
                 .collect::<Vec<String>>();
             inputs.insert(key, json!(field_elements));
         }

--- a/experimental-frontends/src/noname/utils.rs
+++ b/experimental-frontends/src/noname/utils.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use ark_ff::PrimeField;
 use ark_r1cs_std::{fields::fp::FpVar, R1CSVar};
-use ark_relations::r1cs::SynthesisError;
 use noname::{
     backends::{r1cs::R1CS, BackendField},
     circuit_writer::CircuitWriter,
@@ -41,26 +40,19 @@ impl<F: PrimeField> From<(&Vec<F>, String)> for NonameInputs {
 impl NonameInputs {
     pub fn from_fpvars<F: PrimeField>(
         value: (&Vec<FpVar<F>>, String),
-    ) -> Result<Self, SynthesisError> {
+    ) -> Self {
         let (values, key) = value;
         let mut inputs = HashMap::new();
-        if values.is_empty() {
-            Ok(NonameInputs(JsonInputs(inputs)))
-        } else {
+        if !values.is_empty() {
             let field_elements: Vec<String> = values
                 .iter()
                 .map(|var| {
-                    let value = var.value()?;
-                    if value.is_zero() {
-                        Ok("0".to_string())
-                    } else {
-                        Ok(value.to_string())
-                    }
+                    var.value().unwrap_or_default().to_string()
                 })
-                .collect::<Result<Vec<String>, SynthesisError>>()?;
+                .collect::<Vec<String>>();
             inputs.insert(key, json!(field_elements));
-            Ok(NonameInputs(JsonInputs(inputs)))
         }
+        NonameInputs(JsonInputs(inputs))
     }
 }
 

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -440,7 +440,10 @@ impl<CFG: CycleFoldConfig> ConstraintSynthesizer<CF2<CFG::C>> for CycleFoldCircu
         //   computing them outside the circuit.
         // - `.enforce_equal()` prevents a malicious prover from claiming wrong
         //   public inputs that are not the honest `x` computed in-circuit.
-        Vec::new_input(cs.clone(), || x.value())?.enforce_equal(&x)?;
+        Vec::new_input(cs, || {
+            Ok(x.value().unwrap_or(vec![Zero::zero(); x.len()]))
+        })?
+        .enforce_equal(&x)?;
 
         Ok(())
     }

--- a/folding-schemes/src/folding/circuits/cyclefold.rs
+++ b/folding-schemes/src/folding/circuits/cyclefold.rs
@@ -440,10 +440,8 @@ impl<CFG: CycleFoldConfig> ConstraintSynthesizer<CF2<CFG::C>> for CycleFoldCircu
         //   computing them outside the circuit.
         // - `.enforce_equal()` prevents a malicious prover from claiming wrong
         //   public inputs that are not the honest `x` computed in-circuit.
-        Vec::new_input(cs, || {
-            Ok(x.value().unwrap_or(vec![Zero::zero(); x.len()]))
-        })?
-        .enforce_equal(&x)?;
+        Vec::new_input(cs, || Ok(x.value().unwrap_or(vec![Zero::zero(); x.len()])))?
+            .enforce_equal(&x)?;
 
         Ok(())
     }

--- a/folding-schemes/src/folding/hypernova/circuits.rs
+++ b/folding-schemes/src/folding/hypernova/circuits.rs
@@ -15,7 +15,8 @@ use ark_r1cs_std::{
     R1CSVar,
 };
 use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError, SynthesisMode,
+    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError,
+    SynthesisMode,
 };
 use ark_std::{fmt::Debug, iter::Sum, One, Zero};
 use core::{borrow::Borrow, marker::PhantomData};
@@ -628,9 +629,7 @@ where
     /// is not needed, directly generate the ConstraintSystem without calling the `finalize` method
     /// will save computing time.
     #[allow(clippy::type_complexity)]
-    pub fn compute_ccs(
-        &self,
-    ) -> Result<CCS<C1::ScalarField>, Error> {
+    pub fn compute_ccs(&self) -> Result<CCS<C1::ScalarField>, Error> {
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
         cs.set_mode(SynthesisMode::Setup);
         self.clone().generate_constraints(cs.clone())?;

--- a/folding-schemes/src/folding/nova/mod.rs
+++ b/folding-schemes/src/folding/nova/mod.rs
@@ -10,7 +10,7 @@ use ark_crypto_primitives::sponge::{
 };
 use ark_ff::{BigInteger, PrimeField};
 use ark_r1cs_std::R1CSVar;
-use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem};
+use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisMode};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_std::{cmp::max, fmt::Debug, marker::PhantomData, rand::RngCore, One, UniformRand, Zero};
 
@@ -499,6 +499,7 @@ where
         // main circuit R1CS:
         let f_circuit = FC::new(fc_params)?;
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, FC>::empty(&poseidon_config, f_circuit.clone());
         augmented_F_circuit.generate_constraints(cs.clone())?;
@@ -508,6 +509,7 @@ where
 
         // CycleFold circuit R1CS
         let cs2 = ConstraintSystem::<C1::BaseField>::new_ref();
+        cs2.set_mode(SynthesisMode::Setup);
         let cf_circuit = NovaCycleFoldCircuit::<C1>::empty();
         cf_circuit.generate_constraints(cs2.clone())?;
         cs2.finalize();
@@ -583,7 +585,9 @@ where
 
         // prepare the circuit to obtain its R1CS
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         let cs2 = ConstraintSystem::<C1::BaseField>::new_ref();
+        cs2.set_mode(SynthesisMode::Setup);
 
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, FC>::empty(&pp.poseidon_config, F.clone());
@@ -867,7 +871,9 @@ where
 
         let f_circuit = FC::new(fcircuit_params)?;
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         let cs2 = ConstraintSystem::<C1::BaseField>::new_ref();
+        cs2.set_mode(SynthesisMode::Setup);
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, FC>::empty(&pp.poseidon_config, f_circuit.clone());
         let cf_circuit = NovaCycleFoldCircuit::<C1>::empty();
@@ -1003,6 +1009,7 @@ pub fn get_r1cs_from_cs<F: PrimeField>(
     circuit: impl ConstraintSynthesizer<F>,
 ) -> Result<R1CS<F>, Error> {
     let cs = ConstraintSystem::<F>::new_ref();
+    cs.set_mode(SynthesisMode::Setup);
     circuit.generate_constraints(cs.clone())?;
     cs.finalize();
     let cs = cs.into_inner().ok_or(Error::NoInnerConstraintSystem)?;

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -11,7 +11,8 @@ use ark_r1cs_std::{
     R1CSVar,
 };
 use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError, SynthesisMode,
+    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError,
+    SynthesisMode,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_std::{

--- a/folding-schemes/src/folding/protogalaxy/mod.rs
+++ b/folding-schemes/src/folding/protogalaxy/mod.rs
@@ -11,7 +11,7 @@ use ark_r1cs_std::{
     R1CSVar,
 };
 use ark_relations::r1cs::{
-    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError,
+    ConstraintSynthesizer, ConstraintSystem, ConstraintSystemRef, Namespace, SynthesisError, SynthesisMode,
 };
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Valid};
 use ark_std::{
@@ -563,6 +563,7 @@ where
         // Later, we only need to re-run the rest of `F'` with updated `t` to
         // get the size of `F'`.
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         F.generate_step_constraints(
             cs.clone(),
             0,
@@ -577,6 +578,7 @@ where
 
         // Compute `augmentation_constraints`, the size of `F'` without `F`.
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         AugmentedFCircuit::<C1, C2, DummyCircuit>::empty(
             poseidon_config,
             dummy_circuit.clone(),
@@ -600,6 +602,7 @@ where
 
         for t in t_lower_bound..=t_upper_bound {
             let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+            cs.set_mode(SynthesisMode::Setup);
             AugmentedFCircuit::<C1, C2, DummyCircuit>::empty(
                 poseidon_config,
                 dummy_circuit.clone(),
@@ -664,6 +667,7 @@ where
 
         // main circuit R1CS:
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, FC>::empty(&poseidon_config, f_circuit.clone(), t, d, k);
         augmented_F_circuit.generate_constraints(cs.clone())?;
@@ -673,6 +677,7 @@ where
 
         // CycleFold circuit R1CS
         let cs2 = ConstraintSystem::<C1::BaseField>::new_ref();
+        cs2.set_mode(SynthesisMode::Setup);
         let cf_circuit = ProtoGalaxyCycleFoldCircuit::<C1>::empty();
         cf_circuit.generate_constraints(cs2.clone())?;
         cs2.finalize();
@@ -706,7 +711,9 @@ where
 
         // prepare the circuit to obtain its R1CS
         let cs = ConstraintSystem::<C1::ScalarField>::new_ref();
+        cs.set_mode(SynthesisMode::Setup);
         let cs2 = ConstraintSystem::<C1::BaseField>::new_ref();
+        cs2.set_mode(SynthesisMode::Setup);
 
         let augmented_F_circuit =
             AugmentedFCircuit::<C1, C2, FC>::empty(poseidon_config, F.clone(), t, d, k);


### PR DESCRIPTION
This PR updates `ark-circom` to version `0.5.0` without relying on a fork.

It also fixes #104 by ignoring the satisfiability check in setup mode, during which witnesses are still unknown.