### PR TITLE
Upgrade to actions/checkout@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - feature_set: basic
             features: --features default,light-test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       - uses: noir-lang/noirup@v0.1.3
         with:
@@ -88,7 +88,7 @@ jobs:
           # - wasm32-unknown-emscripten
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           override: false
@@ -116,7 +116,7 @@ jobs:
     name: Run examples & examples tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       - uses: noir-lang/noirup@v0.1.3
         with:
@@ -148,7 +148,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
@@ -162,7 +162,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - run: rustup component add rustfmt
@@ -185,7 +185,7 @@ jobs:
           - feature_set: wasm
             features: -p experimental-frontends --features wasm,parallel --target wasm32-unknown-unknown
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: actions-rs/toolchain@v1
         with:
           components: clippy
@@ -203,7 +203,7 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use typos with config file
         uses: crate-ci/typos@master
         with:


### PR DESCRIPTION
Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0