### PR TITLE
fix: fix serialization mismatch on wasm32

### DIFF
--- a/folding-schemes/src/arith/ccs/mod.rs
+++ b/folding-schemes/src/arith/ccs/mod.rs
@@ -110,12 +110,12 @@ impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> ArithRelation<W, U> for CCS<F>
 impl<F: PrimeField> ArithSerializer for CCS<F> {
     fn params_to_le_bytes(&self) -> Vec<u8> {
         [
-            self.l.to_le_bytes(),
-            self.m.to_le_bytes(),
-            self.n.to_le_bytes(),
-            self.t.to_le_bytes(),
-            self.q.to_le_bytes(),
-            self.d.to_le_bytes(),
+            (self.l as u64).to_le_bytes(),
+            (self.m as u64).to_le_bytes(),
+            (self.n as u64).to_le_bytes(),
+            (self.t as u64).to_le_bytes(),
+            (self.q as u64).to_le_bytes(),
+            (self.d as u64).to_le_bytes(),
         ]
         .concat()
     }

--- a/folding-schemes/src/arith/r1cs/mod.rs
+++ b/folding-schemes/src/arith/r1cs/mod.rs
@@ -90,9 +90,9 @@ impl<F: PrimeField, W: AsRef<[F]>, U: AsRef<[F]>> ArithRelation<W, U> for R1CS<F
 impl<F: PrimeField> ArithSerializer for R1CS<F> {
     fn params_to_le_bytes(&self) -> Vec<u8> {
         [
-            self.l.to_le_bytes(),
-            self.A.n_rows.to_le_bytes(),
-            self.A.n_cols.to_le_bytes(),
+            (self.l as u64).to_le_bytes(),
+            (self.A.n_rows as u64).to_le_bytes(),
+            (self.A.n_cols as u64).to_le_bytes(),
         ]
         .concat()
     }


### PR DESCRIPTION
I noticed that the IVC proof generated for the wasm32 target fails to be verified by the Rust native IVC proof verifier.

The cause was that `ArithSerializer` produces different results depending on the architecture’s bit width when calling `to_le_bytes()` on usize dimensions.