### PR TITLE
docs: add documentation for split_z method format

### DIFF
--- a/folding-schemes/src/arith/ccs/mod.rs
+++ b/folding-schemes/src/arith/ccs/mod.rs
@@ -90,6 +90,16 @@ impl<F: PrimeField> Arith for CCS<F> {
         self.n_variables() - self.n_public_inputs() - 1
     }
 
+    /// Splits the assignment vector `z` into witness and public inputs.
+    ///
+    /// The input vector `z` must have the format `[1, x, w]` where:
+    /// - `z[0] = 1` (constant)
+    /// - `z[1..l+1] = x` (public inputs, length `l = n_public_inputs()`)
+    /// - `z[l+1..] = w` (witness)
+    ///
+    /// Returns a tuple `(w, x)` containing:
+    /// - `w`: witness vector (secret inputs)
+    /// - `x`: public inputs vector
     fn split_z<P: PrimeField>(&self, z: &[P]) -> (Vec<P>, Vec<P>) {
         (z[self.l + 1..].to_vec(), z[1..self.l + 1].to_vec())
     }

--- a/folding-schemes/src/arith/mod.rs
+++ b/folding-schemes/src/arith/mod.rs
@@ -26,7 +26,16 @@ pub trait Arith: Clone {
     /// Returns the number of witnesses / secret inputs in the constraint system
     fn n_witnesses(&self) -> usize;
 
-    /// Returns a tuple containing (w, x) (witness and public inputs respectively)
+    /// Splits the assignment vector `z` into witness and public inputs.
+    ///
+    /// The input vector `z` must have the format `[1, x, w]` where:
+    /// - `z[0] = 1` (constant)
+    /// - `z[1..l+1] = x` (public inputs, length `l = n_public_inputs()`)
+    /// - `z[l+1..] = w` (witness)
+    ///
+    /// Returns a tuple `(w, x)` containing:
+    /// - `w`: witness vector (secret inputs)
+    /// - `x`: public inputs vector
     fn split_z<F: PrimeField>(&self, z: &[F]) -> (Vec<F>, Vec<F>);
 }
 

--- a/folding-schemes/src/arith/r1cs/mod.rs
+++ b/folding-schemes/src/arith/r1cs/mod.rs
@@ -70,6 +70,16 @@ impl<F: PrimeField> Arith for R1CS<F> {
         self.n_variables() - self.n_public_inputs() - 1
     }
 
+    /// Splits the assignment vector `z` into witness and public inputs.
+    ///
+    /// The input vector `z` must have the format `[1, x, w]` where:
+    /// - `z[0] = 1` (constant)
+    /// - `z[1..l+1] = x` (public inputs, length `l = n_public_inputs()`)
+    /// - `z[l+1..] = w` (witness)
+    ///
+    /// Returns a tuple `(w, x)` containing:
+    /// - `w`: witness vector (secret inputs)
+    /// - `x`: public inputs vector
     fn split_z<P: PrimeField>(&self, z: &[P]) -> (Vec<P>, Vec<P>) {
         (z[self.l + 1..].to_vec(), z[1..self.l + 1].to_vec())
     }


### PR DESCRIPTION
Document the expected format of the input vector `z` for `split_z` method
in Arith trait and its implementations. The vector must follow `[1, x, w]`
structure where the first element is constant 1, followed by public inputs
and witness. This clarifies the method's contract and prevents misuse.