### PR TITLE
fix: use `&mut rng` to not take ownership of randomness generator

### DIFF
--- a/wip/fs/src/hypernova/algorithms/prover.rs
+++ b/wip/fs/src/hypernova/algorithms/prover.rs
@@ -37,7 +37,7 @@ impl<
         Us: &[impl Borrow<Self::RU>; M],
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<M, N>, Self::Challenge), Error> {
         let Ws = &Ws.iter().map(|i| i.borrow()).collect::<Vec<_>>();
         let Us = &Us.iter().map(|i| i.borrow()).collect::<Vec<_>>();
@@ -183,7 +183,7 @@ impl<
         Us: &[impl Borrow<Self::RU>; M],
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
-        mut rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<M, N>, Self::Challenge), Error> {
         let Ws = &Ws.iter().map(|i| i.borrow()).collect::<Vec<_>>();
         let Us = &Us.iter().map(|i| i.borrow()).collect::<Vec<_>>();
@@ -200,7 +200,7 @@ impl<
         let mut cms = [VC::Commitment::default(); N];
         let mut rs = [VC::Randomness::default(); N];
         for i in 0..N {
-            let (cm, r) = VC::commit(&pk.ck, ws[i], &mut rng)?;
+            let (cm, r) = VC::commit(&pk.ck, ws[i], rng)?;
             cms[i] = cm;
             rs[i] = r;
         }

--- a/wip/fs/src/hypernova/mod.rs
+++ b/wip/fs/src/hypernova/mod.rs
@@ -135,7 +135,7 @@ impl<A, VC: VectorCommitmentOps> WitnessInstanceSampler<IW<VC>, IU<VC>> for Hype
     type Source = AssignmentsOwned<VC::Scalar>;
     type Error = Error;
 
-    fn sample(&self, z: Self::Source, rng: impl RngCore) -> Result<(IW<VC>, IU<VC>), Error> {
+    fn sample(&self, z: Self::Source, rng: &mut impl RngCore) -> Result<(IW<VC>, IU<VC>), Error> {
         let (w, x) = (z.private, z.public);
         let (cm, r) = VC::commit(&self.ck, &w, rng)?;
         Ok((IW { w, r }, IU { cm, x }))
@@ -151,7 +151,7 @@ impl<A, VC: VectorCommitmentDef> WitnessInstanceSampler<PW<VC::Scalar>, PU<VC::S
     fn sample(
         &self,
         z: Self::Source,
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(PW<VC::Scalar>, PU<VC::Scalar>), Error> {
         Ok((z.private.into(), z.public.into()))
     }
@@ -166,7 +166,11 @@ where
     type Error = Error;
 
     #[allow(non_snake_case)]
-    fn sample(&self, _: Self::Source, mut rng: impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
+    fn sample(
+        &self,
+        _: Self::Source,
+        mut rng: &mut impl RngCore,
+    ) -> Result<(RW<VC>, RU<VC>), Error> {
         let u = VC::Scalar::rand(&mut rng);
         let x = (0..self.arith.n_public_inputs())
             .map(|_| VC::Scalar::rand(&mut rng))

--- a/wip/fs/src/lib.rs
+++ b/wip/fs/src/lib.rs
@@ -274,7 +274,7 @@ pub trait FoldingSchemeProver<const M: usize, const N: usize>: FoldingSchemeDef 
         Us: &[impl Borrow<Self::RU>; M],
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
-        rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<M, N>, Self::Challenge), Error>;
 }
 

--- a/wip/fs/src/mova/algorithms/prover.rs
+++ b/wip/fs/src/mova/algorithms/prover.rs
@@ -29,7 +29,7 @@ impl<VC: GroupBasedVectorCommitment, const CHALLENGE_BITS: usize> FoldingSchemeP
         Us: &[impl Borrow<Self::RU>; 1],
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
-        rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());

--- a/wip/fs/src/mova/mod.rs
+++ b/wip/fs/src/mova/mod.rs
@@ -1,7 +1,5 @@
 use ark_ff::{Field, Zero};
-use ark_poly::{
-    DenseMultilinearExtension as MLE, Polynomial,
-};
+use ark_poly::{DenseMultilinearExtension as MLE, Polynomial};
 use ark_r1cs_std::{
     alloc::{AllocVar, AllocationMode},
     fields::fp::FpVar,
@@ -9,16 +7,9 @@ use ark_r1cs_std::{
     GR1CSVar,
 };
 use ark_relations::gr1cs::{ConstraintSystemRef, Namespace, SynthesisError};
-use ark_std::{
-    borrow::Borrow, marker::PhantomData, rand::RngCore, sync::Arc,
-    UniformRand,
-};
+use ark_std::{borrow::Borrow, marker::PhantomData, rand::RngCore, sync::Arc, UniformRand};
 use sonobe_primitives::{
-    algebra::
-        ops::
-            poly::MLEHelper
-        
-    ,
+    algebra::ops::poly::MLEHelper,
     arithmetizations::{
         r1cs::{RelaxedInstance, RelaxedWitness, R1CS},
         Arith, ArithConfig, ArithRelation,
@@ -118,7 +109,7 @@ impl<A, VC: VectorCommitmentDef> WitnessInstanceSampler<IW<VC::Scalar>, IU<VC::S
     fn sample(
         &self,
         z: Self::Source,
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(IW<VC::Scalar>, IU<VC::Scalar>), Error> {
         Ok((z.private.into(), z.public.into()))
     }
@@ -136,23 +127,23 @@ where
     type Source = ();
     type Error = Error;
 
-    fn sample(&self, _: Self::Source, mut rng: impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
-        let u = VC::Scalar::rand(&mut rng);
+    fn sample(&self, _: Self::Source, rng: &mut impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
+        let u = VC::Scalar::rand(rng);
         let x = (0..self.arith.n_public_inputs())
-            .map(|_| VC::Scalar::rand(&mut rng))
+            .map(|_| VC::Scalar::rand(rng))
             .collect::<Vec<_>>();
         let w = (0..self.arith.n_witnesses())
-            .map(|_| VC::Scalar::rand(&mut rng))
+            .map(|_| VC::Scalar::rand(rng))
             .collect::<Vec<_>>();
         let e = self.arith.eval_relation(
             &RelaxedWitness { w: &w, e: &[] },
             &RelaxedInstance { x: &x, u: &u },
         )?;
 
-        let (cm_w, r_w) = VC::commit(&self.ck, &w, &mut rng)?;
+        let (cm_w, r_w) = VC::commit(&self.ck, &w, rng)?;
 
         let r_e = (0..self.arith.log_constraints())
-            .map(|_| VC::Scalar::rand(&mut rng))
+            .map(|_| VC::Scalar::rand(rng))
             .collect::<Vec<_>>();
         let v = MLE::from_evaluations(&e).evaluate(&r_e);
 

--- a/wip/fs/src/nova/algorithms/prover.rs
+++ b/wip/fs/src/nova/algorithms/prover.rs
@@ -3,11 +3,8 @@ use ark_std::{borrow::Borrow, cfg_into_iter, cfg_iter, ops::Mul, rand::RngCore};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use sonobe_primitives::{
-    algebra::ops::bits::FromBits,
-    circuits::AssignmentsOwned,
-    commitments::GroupBasedVectorCommitment,
-    traits::SonobeField,
-    transcripts::Transcript,
+    algebra::ops::bits::FromBits, circuits::AssignmentsOwned,
+    commitments::GroupBasedVectorCommitment, traits::SonobeField, transcripts::Transcript,
 };
 
 use crate::{
@@ -26,7 +23,7 @@ impl<VC: GroupBasedVectorCommitment, TF: SonobeField, const CHALLENGE_BITS: usiz
         Us: &[impl Borrow<Self::RU>; 1],
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
-        rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());
@@ -83,7 +80,7 @@ impl<VC: GroupBasedVectorCommitment, TF: SonobeField, const CHALLENGE_BITS: usiz
         [U1, U2]: &[impl Borrow<Self::RU>; 2],
         _: &[impl Borrow<Self::IW>; 0],
         _: &[impl Borrow<Self::IU>; 0],
-        rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<2, 0>, Self::Challenge), Error> {
         let (W1, U1) = (W1.borrow(), U1.borrow());
         let (W2, U2) = (W2.borrow(), U2.borrow());
@@ -152,7 +149,7 @@ impl<VC: GroupBasedVectorCommitment, TF: SonobeField, const CHALLENGE_BITS: usiz
         Us: &[impl Borrow<Self::RU>; 1],
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
-        mut rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());
@@ -169,9 +166,9 @@ impl<VC: GroupBasedVectorCommitment, TF: SonobeField, const CHALLENGE_BITS: usiz
             .map(|(a, b)| a - b)
             .collect::<Vec<_>>();
 
-        let (cm_w, r_w) = VC::commit(&pk.ck, w, &mut rng)?;
+        let (cm_w, r_w) = VC::commit(&pk.ck, w, rng)?;
 
-        let (cm_t, r_t) = VC::commit(&pk.ck, &t, &mut rng)?;
+        let (cm_t, r_t) = VC::commit(&pk.ck, &t, rng)?;
 
         let pi = (cm_w, cm_t);
 

--- a/wip/fs/src/nova/mod.rs
+++ b/wip/fs/src/nova/mod.rs
@@ -104,7 +104,7 @@ impl<A, VC: VectorCommitmentOps> WitnessInstanceSampler<IW<VC>, IU<VC>> for Nova
     type Source = AssignmentsOwned<VC::Scalar>;
     type Error = Error;
 
-    fn sample(&self, z: Self::Source, rng: impl RngCore) -> Result<(IW<VC>, IU<VC>), Error> {
+    fn sample(&self, z: Self::Source, rng: &mut impl RngCore) -> Result<(IW<VC>, IU<VC>), Error> {
         let (w, x) = (z.private, z.public);
         let (cm_w, r_w) = VC::commit(&self.ck, &w, rng)?;
         Ok((IW { w, r_w }, IU { cm_w, x }))
@@ -120,7 +120,7 @@ impl<A, VC: VectorCommitmentDef> WitnessInstanceSampler<PW<VC::Scalar>, PU<VC::S
     fn sample(
         &self,
         z: Self::Source,
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(PW<VC::Scalar>, PU<VC::Scalar>), Error> {
         Ok((z.private.into(), z.public.into()))
     }
@@ -138,7 +138,11 @@ where
     type Source = ();
     type Error = Error;
 
-    fn sample(&self, _: Self::Source, mut rng: impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
+    fn sample(
+        &self,
+        _: Self::Source,
+        mut rng: &mut impl RngCore,
+    ) -> Result<(RW<VC>, RU<VC>), Error> {
         let u = VC::Scalar::rand(&mut rng);
         let x = (0..self.arith.n_public_inputs())
             .map(|_| VC::Scalar::rand(&mut rng))

--- a/wip/fs/src/ova/algorithms/prover.rs
+++ b/wip/fs/src/ova/algorithms/prover.rs
@@ -3,15 +3,13 @@ use ark_std::{borrow::Borrow, cfg_iter, rand::RngCore};
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use sonobe_primitives::{
-    algebra::ops::bits::FromBits,
-    circuits::Assignments,
-    commitments::GroupBasedVectorCommitment,
-    traits::SonobeField,
-    transcripts::Transcript,
+    algebra::ops::bits::FromBits, circuits::Assignments, commitments::GroupBasedVectorCommitment,
+    traits::SonobeField, transcripts::Transcript,
 };
 
 use crate::{
-    Error, FoldingSchemeProver, ova::{AbstractOva, OvaKey}
+    ova::{AbstractOva, OvaKey},
+    Error, FoldingSchemeProver,
 };
 
 impl<VC: GroupBasedVectorCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
@@ -25,7 +23,7 @@ impl<VC: GroupBasedVectorCommitment, TF: SonobeField, const CHALLENGE_BITS: usiz
         Us: &[impl Borrow<Self::RU>; 1],
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
-        rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());

--- a/wip/fs/src/ova/mod.rs
+++ b/wip/fs/src/ova/mod.rs
@@ -95,7 +95,7 @@ impl<A, VC: VectorCommitmentDef> WitnessInstanceSampler<IW<VC::Scalar>, IU<VC::S
     fn sample(
         &self,
         z: Self::Source,
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(IW<VC::Scalar>, IU<VC::Scalar>), Error> {
         Ok((z.private.into(), z.public.into()))
     }
@@ -113,20 +113,20 @@ where
     type Source = ();
     type Error = Error;
 
-    fn sample(&self, _: Self::Source, mut rng: impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
-        let u = VC::Scalar::rand(&mut rng);
+    fn sample(&self, _: Self::Source, rng: &mut impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
+        let u = VC::Scalar::rand(rng);
         let x = (0..self.arith.n_public_inputs())
-            .map(|_| VC::Scalar::rand(&mut rng))
+            .map(|_| VC::Scalar::rand(rng))
             .collect::<Vec<_>>();
         let w = (0..self.arith.n_witnesses())
-            .map(|_| VC::Scalar::rand(&mut rng))
+            .map(|_| VC::Scalar::rand(rng))
             .collect::<Vec<_>>();
         let e = self.arith.eval_relation(
             &RelaxedWitness { w: &w, e: &[] },
             &RelaxedInstance { x: &x, u: &u },
         )?;
 
-        let (cm, r) = VC::commit(&self.ck, &[&w[..], &e].concat(), &mut rng)?;
+        let (cm, r) = VC::commit(&self.ck, &[&w[..], &e].concat(), rng)?;
         Ok((RW { w, r }, RU { x, cm, u }))
     }
 }

--- a/wip/fs/src/protogalaxy/algorithms/prover.rs
+++ b/wip/fs/src/protogalaxy/algorithms/prover.rs
@@ -29,7 +29,7 @@ impl<VC: GroupBasedVectorCommitment, const N: usize> FoldingSchemeProver<1, N> f
         Us: &[impl Borrow<Self::RU>; 1],
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<1, N>, Self::Challenge), Error> {
         if !(N + 1).is_power_of_two() {
             return Err(Error::Unsupported("N + 1 must be a power of two".into()));
@@ -200,7 +200,7 @@ impl<VC: GroupBasedVectorCommitment, const N: usize> FoldingSchemeProver<1, N>
         Us: &[impl Borrow<Self::RU>; 1],
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
-        mut rng: impl RngCore,
+        mut rng: &mut impl RngCore,
     ) -> Result<(Self::RW, Self::RU, Self::Proof<1, N>, Self::Challenge), Error> {
         if !(N + 1).is_power_of_two() {
             return Err(Error::Unsupported("N + 1 must be a power of two".into()));

--- a/wip/fs/src/protogalaxy/mod.rs
+++ b/wip/fs/src/protogalaxy/mod.rs
@@ -6,20 +6,15 @@ use ark_r1cs_std::{
 };
 use ark_relations::gr1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 use ark_std::{
-    borrow::Borrow, cfg_into_iter, log2, marker::PhantomData, rand::RngCore, sync::Arc,
-    UniformRand,
+    borrow::Borrow, cfg_into_iter, log2, marker::PhantomData, rand::RngCore, sync::Arc, UniformRand,
 };
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use sonobe_primitives::{
-    algebra::ops::
-        pow::Pow
-    ,
+    algebra::ops::pow::Pow,
     arithmetizations::{r1cs::R1CS, Arith, ArithConfig, ArithRelation, Error as ArithError},
     circuits::AssignmentsOwned,
-    commitments::{
-        GroupBasedVectorCommitment, VectorCommitmentDef, VectorCommitmentOps,
-    },
+    commitments::{GroupBasedVectorCommitment, VectorCommitmentDef, VectorCommitmentOps},
     relations::{Relation, WitnessInstanceSampler},
     traits::Dummy,
 };
@@ -32,9 +27,8 @@ use self::{
     witnesses::{IncomingWitness as IW, RunningWitness as RW},
 };
 use crate::{
-    DeciderKey, Error, FoldingSchemeDef, FoldingSchemeGadgetDef,
-    GroupBasedFoldingSchemePrimaryDef, PlainInstance as PU,
-    PlainWitness as PW, TaggedVec,
+    DeciderKey, Error, FoldingSchemeDef, FoldingSchemeGadgetDef, GroupBasedFoldingSchemePrimaryDef,
+    PlainInstance as PU, PlainWitness as PW, TaggedVec,
 };
 
 pub mod algorithms;
@@ -139,7 +133,7 @@ impl<A, VC: VectorCommitmentOps> WitnessInstanceSampler<IW<VC>, IU<VC>> for Prot
     type Source = AssignmentsOwned<VC::Scalar>;
     type Error = Error;
 
-    fn sample(&self, z: Self::Source, rng: impl RngCore) -> Result<(IW<VC>, IU<VC>), Error> {
+    fn sample(&self, z: Self::Source, rng: &mut impl RngCore) -> Result<(IW<VC>, IU<VC>), Error> {
         let (w, x) = (z.private, z.public);
         let (phi, r) = VC::commit(&self.ck, &w, rng)?;
         Ok((IW { w, r }, IU { phi, x }))
@@ -155,7 +149,7 @@ impl<A, VC: VectorCommitmentDef> WitnessInstanceSampler<PW<VC::Scalar>, PU<VC::S
     fn sample(
         &self,
         z: Self::Source,
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(PW<VC::Scalar>, PU<VC::Scalar>), Error> {
         Ok((z.private.into(), z.public.into()))
     }
@@ -169,7 +163,11 @@ where
     type Source = ();
     type Error = Error;
 
-    fn sample(&self, _: Self::Source, mut rng: impl RngCore) -> Result<(RW<VC>, RU<VC>), Error> {
+    fn sample(
+        &self,
+        _: Self::Source,
+        mut rng: &mut impl RngCore,
+    ) -> Result<(RW<VC>, RU<VC>), Error> {
         let x = (0..self.arith.n_public_inputs())
             .map(|_| VC::Scalar::rand(&mut rng))
             .collect::<Vec<_>>();

--- a/wip/primitives/src/commitments/mod.rs
+++ b/wip/primitives/src/commitments/mod.rs
@@ -70,7 +70,7 @@ pub trait VectorCommitmentOps: VectorCommitmentDef {
     fn commit(
         ck: &Self::Key,
         v: &[Self::Scalar],
-        rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(Self::Commitment, Self::Randomness), Error>;
 
     fn open(

--- a/wip/primitives/src/commitments/pedersen.rs
+++ b/wip/primitives/src/commitments/pedersen.rs
@@ -176,7 +176,7 @@ impl<C: SonobeCurve> VectorCommitmentOps for Pedersen<C, false> {
     fn commit(
         ck: &PedersenKey<C, false>,
         v: &[CF1<C>],
-        _rng: impl RngCore,
+        _rng: &mut impl RngCore,
     ) -> Result<(C, Null), Error> {
         Ok((ck.commit(v)?, Null))
     }
@@ -196,9 +196,9 @@ impl<C: SonobeCurve> VectorCommitmentOps for Pedersen<C, true> {
     fn commit(
         ck: &PedersenKey<C, true>,
         v: &[CF1<C>],
-        mut rng: impl RngCore,
+        rng: &mut impl RngCore,
     ) -> Result<(C, CF1<C>), Error> {
-        let r = C::ScalarField::rand(&mut rng);
+        let r = C::ScalarField::rand(rng);
         Ok((ck.commit(v, &r)?, r))
     }
 

--- a/wip/primitives/src/relations/mod.rs
+++ b/wip/primitives/src/relations/mod.rs
@@ -13,5 +13,5 @@ pub trait WitnessInstanceSampler<W, U> {
     type Source;
     type Error: Error + 'static;
 
-    fn sample(&self, source: Self::Source, rng: impl RngCore) -> Result<(W, U), Self::Error>;
+    fn sample(&self, source: Self::Source, rng: &mut impl RngCore) -> Result<(W, U), Self::Error>;
 }


### PR DESCRIPTION
While trying to use commitment routines from sonobe, noticed that the current function signature expects to take ownership of the randomness generator. This PR just changes that to `&mut rng`.