### PR TITLE
refactor(fs): return named structs from fold APIs

### DIFF
--- a/crates/fs/src/definitions/algorithms.rs
+++ b/crates/fs/src/definitions/algorithms.rs
@@ -7,6 +7,18 @@ use sonobe_primitives::{relations::Relation, transcripts::Transcript};
 
 use super::{FoldingSchemeDef, errors::Error, keys::DeciderKey};
 
+/// The artifacts produced by a single folding step.
+pub struct FoldStep<FS: FoldingSchemeDef + ?Sized, const M: usize, const N: usize> {
+    /// The next running witness after folding.
+    pub next_running_witness: FS::RW,
+    /// The next running instance after folding.
+    pub next_running_instance: FS::RU,
+    /// The proof artifact emitted by the folding step.
+    pub proof: FS::Proof<M, N>,
+    /// The challenge derived during the folding step.
+    pub challenge: FS::Challenge,
+}
+
 /// [`FoldingSchemePreprocessor`] is the trait for folding scheme preprocessor.
 pub trait FoldingSchemePreprocessor: FoldingSchemeDef {
     /// [`FoldingSchemePreprocessor::preprocess`] defines the preprocessing
@@ -56,7 +68,7 @@ pub trait FoldingSchemeProver<const M: usize, const N: usize>: FoldingSchemeDef 
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
         rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<M, N>, Self::Challenge), Error>;
+    ) -> Result<FoldStep<Self, M, N>, Error>;
 }
 
 /// [`FoldingSchemeVerifier`] is the trait for folding scheme verifier.

--- a/crates/fs/src/definitions/circuits.rs
+++ b/crates/fs/src/definitions/circuits.rs
@@ -6,6 +6,14 @@ use sonobe_primitives::{commitments::CommitmentDefGadget, transcripts::Transcrip
 
 use super::{FoldingSchemeDefGadget, algorithms::FoldingSchemeOps};
 
+/// The artifacts produced by a partial in-circuit verification step.
+pub struct PartialVerifierStep<RU, Challenge> {
+    /// The next running instance after partial verification.
+    pub next_running_instance: RU,
+    /// The challenge derived during partial verification.
+    pub challenge: Challenge,
+}
+
 /// [`FoldingSchemePartialVerifierGadget`] is the partial in-circuit verifier.
 ///
 /// For schemes that have circuit-unfriendly parts in their verification, the
@@ -32,7 +40,7 @@ pub trait FoldingSchemePartialVerifierGadget<const M: usize, const N: usize>:
         Us: [&Self::RU; M],
         us: [&Self::IU; N],
         proof: &Self::Proof<M, N>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError>;
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError>;
 }
 
 /// [`FoldingSchemeFullVerifierGadget`] is the full in-circuit verifier.

--- a/crates/fs/src/hypernova/algorithms/prover.rs
+++ b/crates/fs/src/hypernova/algorithms/prover.rs
@@ -19,7 +19,7 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    Error, FoldingSchemeProver,
+    Error, FoldStep, FoldingSchemeProver,
     hypernova::{HyperNova, HyperNova2, HyperNovaKey, NIMFSProof},
 };
 
@@ -40,7 +40,7 @@ impl<
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
         _rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<M, N>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, M, N>, Error> {
         let Ws = &Ws.iter().map(|i| i.borrow()).collect::<Vec<_>>();
         let Us = &Us.iter().map(|i| i.borrow()).collect::<Vec<_>>();
         let ws = &ws.iter().map(|i| i.borrow()).collect::<Vec<_>>();
@@ -124,8 +124,8 @@ impl<
 
         let rho_powers = rho.powers(M + N);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 w: Ws
                     .iter()
                     .map(|w| &w.w[..])
@@ -137,7 +137,7 @@ impl<
                     .chain(ws.iter().map(|w| w.r))
                     .scalar_rlc(&rho_powers),
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 cm: Us
                     .iter()
                     .map(|u| u.cm)
@@ -159,13 +159,13 @@ impl<
                     .chain(thetas.chunks(t))
                     .slice_rlc(&rho_powers),
             },
-            NIMFSProof {
+            proof: NIMFSProof {
                 sc_proof: sumcheck_proof,
                 sigmas,
                 thetas,
             },
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }
 
@@ -186,7 +186,7 @@ impl<
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
         mut rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<M, N>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, M, N>, Error> {
         let Ws = &Ws.iter().map(|i| i.borrow()).collect::<Vec<_>>();
         let Us = &Us.iter().map(|i| i.borrow()).collect::<Vec<_>>();
         let ws = &ws.iter().map(|i| i.borrow()).collect::<Vec<_>>();
@@ -279,8 +279,8 @@ impl<
 
         let rho_powers = rho.powers(M + N);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 w: Ws
                     .iter()
                     .map(|w| &w.w[..])
@@ -288,7 +288,7 @@ impl<
                     .slice_rlc(&rho_powers),
                 r: Ws.iter().map(|w| w.r).chain(rs).scalar_rlc(&rho_powers),
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 cm: Us
                     .iter()
                     .map(|u| u.cm)
@@ -310,7 +310,7 @@ impl<
                     .chain(thetas.chunks(t))
                     .slice_rlc(&rho_powers),
             },
-            (
+            proof: (
                 cms,
                 NIMFSProof {
                     sc_proof: sumcheck_proof,
@@ -318,7 +318,7 @@ impl<
                     thetas,
                 },
             ),
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }

--- a/crates/fs/src/hypernova/circuits/verifier.rs
+++ b/crates/fs/src/hypernova/circuits/verifier.rs
@@ -22,7 +22,7 @@ use sonobe_primitives::{
     transcripts::TranscriptGadget,
 };
 
-use crate::{FoldingSchemePartialVerifierGadget, hypernova::HyperNovaGadget};
+use crate::{FoldingSchemePartialVerifierGadget, PartialVerifierStep, hypernova::HyperNovaGadget};
 
 impl<
     CM: GroupBasedCommitment,
@@ -39,7 +39,7 @@ impl<
         Us: [&Self::RU; M],
         us: [&Self::IU; N],
         proof: &Self::Proof<M, N>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError> {
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError> {
         let d = V::degree();
         let s = proof.sc_proof.len();
         let t = V::n_matrices();
@@ -113,8 +113,8 @@ impl<
 
         let rho_powers = rho.powers(M + N);
 
-        Ok((
-            Self::RU {
+        Ok(PartialVerifierStep {
+            next_running_instance: Self::RU {
                 cm: {
                     let cms = Us
                         .iter()
@@ -147,7 +147,7 @@ impl<
                     .chain(proof.thetas.chunks(t))
                     .slice_rlc(&rho_powers),
             },
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }

--- a/crates/fs/src/lib.rs
+++ b/crates/fs/src/lib.rs
@@ -35,10 +35,12 @@ pub mod definitions;
 pub use self::definitions::{
     FoldingSchemeDef, FoldingSchemeDefGadget,
     algorithms::{
-        FoldingSchemeDecider, FoldingSchemeKeyGenerator, FoldingSchemeOps,
+        FoldStep, FoldingSchemeDecider, FoldingSchemeKeyGenerator, FoldingSchemeOps,
         FoldingSchemePreprocessor, FoldingSchemeProver, FoldingSchemeVerifier,
     },
-    circuits::{FoldingSchemeFullVerifierGadget, FoldingSchemePartialVerifierGadget},
+    circuits::{
+        FoldingSchemeFullVerifierGadget, FoldingSchemePartialVerifierGadget, PartialVerifierStep,
+    },
     errors::Error,
     instances::{FoldingInstance, FoldingInstanceVar, PlainInstance, PlainInstanceVar},
     keys::DeciderKey,
@@ -117,9 +119,12 @@ mod tests {
             let ws = ws.try_into().unwrap();
             let us = us.try_into().unwrap();
 
-            let (WW, UU, pi, _) = FS::prove(pk, &mut transcript_p, &Ws, &Us, &ws, &us, &mut rng)?;
-            FS::decide_running(&dk, &WW, &UU)?;
-            assert_eq!(FS::verify(vk, &mut transcript_v, &Us, &us, &pi)?, UU);
+            let step = FS::prove(pk, &mut transcript_p, &Ws, &Us, &ws, &us, &mut rng)?;
+            FS::decide_running(&dk, &step.next_running_witness, &step.next_running_instance)?;
+            assert_eq!(
+                FS::verify(vk, &mut transcript_v, &Us, &us, &step.proof)?,
+                step.next_running_instance
+            );
 
             for i in 0..M {
                 let (W, U) = WitnessInstanceSampler::<FS::RW, FS::RU>::sample(&dk, (), &mut rng)?;
@@ -129,8 +134,8 @@ mod tests {
             }
             if M != 0 {
                 let idx = rng.gen_range(0..M);
-                Ws[idx] = WW;
-                Us[idx] = UU;
+                Ws[idx] = step.next_running_witness;
+                Us[idx] = step.next_running_instance;
             }
         }
 

--- a/crates/fs/src/mova/algorithms/prover.rs
+++ b/crates/fs/src/mova/algorithms/prover.rs
@@ -16,7 +16,7 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    Error, FoldingSchemeProver,
+    Error, FoldStep, FoldingSchemeProver,
     mova::{Mova, MovaKey, MovaProof},
 };
 
@@ -32,7 +32,7 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemeProver<
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
         rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 1, 1>, Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());
 
@@ -111,8 +111,8 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemeProver<
         let rho = CM::Scalar::from_bits_le(&rho_bits);
 
         // Step 7.3: Compute new W and U
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 e: cfg_iter!(W.e).zip(&T).map(|(a, b)| rho * b + a).collect(),
                 w: cfg_iter!(W.w)
                     .zip(&w[..])
@@ -120,7 +120,7 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemeProver<
                     .collect(),
                 r_w: W.r_w + r_w * rho,
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 r_e: r_e_prime,
                 v: h1.evaluate(&beta) + rho * t,
                 u: U.u + rho,
@@ -130,8 +130,8 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemeProver<
                     .map(|(a, b)| rho * b + a)
                     .collect(),
             },
-            MovaProof { h1_coeffs, t, cm_w },
-            rho_bits.try_into().unwrap(),
-        ))
+            proof: MovaProof { h1_coeffs, t, cm_w },
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }

--- a/crates/fs/src/mova/circuits/verifier.rs
+++ b/crates/fs/src/mova/circuits/verifier.rs
@@ -10,7 +10,7 @@ use sonobe_primitives::{
     transcripts::TranscriptGadget,
 };
 
-use crate::{FoldingSchemePartialVerifierGadget, mova::MovaGadget};
+use crate::{FoldingSchemePartialVerifierGadget, PartialVerifierStep, mova::MovaGadget};
 
 impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemePartialVerifierGadget<1, 1>
     for MovaGadget<CM, CHALLENGE_BITS>
@@ -22,7 +22,7 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemePartial
         [U]: [&Self::RU; 1],
         [u]: [&Self::IU; 1],
         proof: &Self::Proof<1, 1>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError> {
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError> {
         let h1 = DensePolynomialVar::from_coefficients_vec(
             [&[U.v.clone()][..], &proof.h1_coeffs].concat(),
         );
@@ -42,8 +42,8 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemePartial
         let rho_bits = transcript.challenge_bits(CHALLENGE_BITS)?;
         let rho = FpVar::from_bits_le(&rho_bits)?;
 
-        Ok((
-            Self::RU {
+        Ok(PartialVerifierStep {
+            next_running_instance: Self::RU {
                 r_e: U
                     .r_e
                     .iter()
@@ -58,7 +58,7 @@ impl<CM: GroupBasedCommitment, const CHALLENGE_BITS: usize> FoldingSchemePartial
                 })?,
                 x: U.x.iter().zip(&u[..]).map(|(a, b)| &rho * b + a).collect(),
             },
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }

--- a/crates/fs/src/nova/algorithms/prover.rs
+++ b/crates/fs/src/nova/algorithms/prover.rs
@@ -10,7 +10,7 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    Error, FoldingSchemeProver,
+    Error, FoldStep, FoldingSchemeProver,
     nova::{AbstractNova, AbstractNova2, NovaKey},
 };
 
@@ -26,7 +26,7 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
         rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 1, 1>, Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());
 
@@ -52,22 +52,22 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         };
         let rho = CM::Scalar::from_bits_le(&rho_bits);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 e: cfg_iter!(W.e).zip(&t).map(|(a, b)| rho * b + a).collect(),
                 r_e: W.r_e + r_t * rho,
                 w: cfg_iter!(W.w).zip(&w.w).map(|(a, b)| rho * b + a).collect(),
                 r_w: W.r_w + w.r_w * rho,
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 cm_e: U.cm_e + cm_t.mul(rho),
                 u: U.u + rho,
                 cm_w: U.cm_w + u.cm_w.mul(rho),
                 x: cfg_iter!(U.x).zip(&u.x).map(|(a, b)| rho * b + a).collect(),
             },
-            cm_t,
-            rho_bits.try_into().unwrap(),
-        ))
+            proof: cm_t,
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }
 
@@ -83,7 +83,7 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         _: &[impl Borrow<Self::IW>; 0],
         _: &[impl Borrow<Self::IU>; 0],
         rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<2, 0>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 2, 0>, Error> {
         let (W1, U1) = (W1.borrow(), U1.borrow());
         let (W2, U2) = (W2.borrow(), U2.borrow());
 
@@ -111,8 +111,8 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         let rho = CM::Scalar::from_bits_le(&rho_bits);
         let rho_squared = rho * rho;
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 e: cfg_iter!(W1.e)
                     .zip(&t)
                     .zip(&W2.e)
@@ -125,7 +125,7 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
                     .collect(),
                 r_w: W1.r_w + W2.r_w * rho,
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 cm_e: U1.cm_e + cm_t.mul(rho) + U2.cm_e.mul(rho_squared),
                 u: U1.u + rho * U2.u,
                 cm_w: U1.cm_w + U2.cm_w.mul(rho),
@@ -134,9 +134,9 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
                     .map(|(a, b)| rho * b + a)
                     .collect(),
             },
-            cm_t,
-            rho_bits.try_into().unwrap(),
-        ))
+            proof: cm_t,
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }
 
@@ -152,7 +152,7 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
         mut rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 1, 1>, Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());
 
@@ -182,8 +182,8 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         };
         let rho = CM::Scalar::from_bits_le(&rho_bits);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 e: cfg_iter!(W.e).zip(&t).map(|(a, b)| rho * b + a).collect(),
                 r_e: W.r_e + r_t * rho,
                 w: cfg_iter!(W.w)
@@ -192,7 +192,7 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
                     .collect(),
                 r_w: W.r_w + r_w * rho,
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 cm_e: U.cm_e + cm_t.mul(rho),
                 u: U.u + rho,
                 cm_w: U.cm_w + cm_w.mul(rho),
@@ -201,8 +201,8 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
                     .map(|(a, b)| rho * b + a)
                     .collect(),
             },
-            pi,
-            rho_bits.try_into().unwrap(),
-        ))
+            proof: pi,
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }

--- a/crates/fs/src/nova/circuits/verifier.rs
+++ b/crates/fs/src/nova/circuits/verifier.rs
@@ -9,7 +9,8 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    FoldingSchemeFullVerifierGadget, FoldingSchemePartialVerifierGadget, nova::AbstractNovaGadget,
+    FoldingSchemeFullVerifierGadget, FoldingSchemePartialVerifierGadget, PartialVerifierStep,
+    nova::AbstractNovaGadget,
 };
 
 impl<CM, const CHALLENGE_BITS: usize> FoldingSchemePartialVerifierGadget<1, 1>
@@ -24,7 +25,7 @@ where
         [U]: [&Self::RU; 1],
         [u]: [&Self::IU; 1],
         proof: &Self::Proof<1, 1>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError> {
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError> {
         let rho_bits = {
             transcript.add(&U)?;
             transcript.add(&u)?;
@@ -33,8 +34,8 @@ where
         };
         let rho = CM::ScalarVar::from_bits_le(&rho_bits)?;
 
-        Ok((
-            Self::RU {
+        Ok(PartialVerifierStep {
+            next_running_instance: Self::RU {
                 u: (U.u.clone() + &rho)
                     .try_into()
                     .map_err(|_| SynthesisError::Unsatisfiable)?,
@@ -59,8 +60,8 @@ where
                     .collect::<Result<_, _>>()
                     .map_err(|_| SynthesisError::Unsatisfiable)?,
             },
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }
 
@@ -76,7 +77,7 @@ where
         [U1, U2]: [&Self::RU; 2],
         _: [&Self::IU; 0],
         proof: &Self::Proof<2, 0>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError> {
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError> {
         let rho_bits = {
             transcript.add(&U1)?;
             transcript.add(&U2)?;
@@ -85,8 +86,8 @@ where
         };
         let rho = CM::ScalarVar::from_bits_le(&rho_bits)?;
 
-        Ok((
-            Self::RU {
+        Ok(PartialVerifierStep {
+            next_running_instance: Self::RU {
                 u: (U2.u.clone() * &rho + &U1.u)
                     .try_into()
                     .map_err(|_| SynthesisError::Unsatisfiable)?,
@@ -114,8 +115,8 @@ where
                     .collect::<Result<_, _>>()
                     .map_err(|_| SynthesisError::Unsatisfiable)?,
             },
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }
 

--- a/crates/fs/src/ova/algorithms/prover.rs
+++ b/crates/fs/src/ova/algorithms/prover.rs
@@ -10,7 +10,7 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    Error, FoldingSchemeProver,
+    Error, FoldStep, FoldingSchemeProver,
     ova::{AbstractOva, OvaKey},
 };
 
@@ -26,7 +26,7 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         ws: &[impl Borrow<Self::IW>; 1],
         us: &[impl Borrow<Self::IU>; 1],
         rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<1, 1>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 1, 1>, Error> {
         let (W, U) = (Ws[0].borrow(), Us[0].borrow());
         let (w, u) = (ws[0].borrow(), us[0].borrow());
 
@@ -53,15 +53,15 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
         };
         let rho = CM::Scalar::from_bits_le(&rho_bits);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 w: cfg_iter!(W.w)
                     .zip(&w[..])
                     .map(|(a, b)| rho * b + a)
                     .collect(),
                 r: W.r + r * rho,
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 u: U.u + rho,
                 cm: U.cm + cm * rho,
                 x: cfg_iter!(U.x)
@@ -69,8 +69,8 @@ impl<CM: GroupBasedCommitment, TF: SonobeField, const CHALLENGE_BITS: usize>
                     .map(|(a, b)| rho * b + a)
                     .collect(),
             },
-            cm,
-            rho_bits.try_into().unwrap(),
-        ))
+            proof: cm,
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }

--- a/crates/fs/src/ova/circuits/verifier.rs
+++ b/crates/fs/src/ova/circuits/verifier.rs
@@ -9,7 +9,8 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    FoldingSchemeFullVerifierGadget, FoldingSchemePartialVerifierGadget, ova::AbstractOvaGadget,
+    FoldingSchemeFullVerifierGadget, FoldingSchemePartialVerifierGadget, PartialVerifierStep,
+    ova::AbstractOvaGadget,
 };
 
 impl<CM, const CHALLENGE_BITS: usize> FoldingSchemePartialVerifierGadget<1, 1>
@@ -24,7 +25,7 @@ where
         [U]: [&Self::RU; 1],
         [u]: [&Self::IU; 1],
         proof: &Self::Proof<1, 1>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError> {
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError> {
         let rho_bits = {
             transcript.add(&U)?;
             transcript.add(&u)?;
@@ -33,8 +34,8 @@ where
         };
         let rho = CM::ScalarVar::from_bits_le(&rho_bits)?;
 
-        Ok((
-            Self::RU {
+        Ok(PartialVerifierStep {
+            next_running_instance: Self::RU {
                 u: (U.u.clone() + &rho)
                     .try_into()
                     .map_err(|_| SynthesisError::Unsatisfiable)?,
@@ -49,8 +50,8 @@ where
                     .collect::<Result<_, _>>()
                     .map_err(|_| SynthesisError::Unsatisfiable)?,
             },
-            rho_bits.try_into().unwrap(),
-        ))
+            challenge: rho_bits.try_into().unwrap(),
+        })
     }
 }
 

--- a/crates/fs/src/protogalaxy/algorithms/prover.rs
+++ b/crates/fs/src/protogalaxy/algorithms/prover.rs
@@ -18,7 +18,7 @@ use sonobe_primitives::{
 };
 
 use crate::{
-    Error, FoldingSchemeProver,
+    Error, FoldStep, FoldingSchemeProver,
     protogalaxy::{ProtoGalaxy, ProtoGalaxy2, ProtoGalaxyKey, ProtoGalaxyProof},
 };
 
@@ -32,7 +32,7 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
         _rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<1, N>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 1, N>, Error> {
         if !(N + 1).is_power_of_two() {
             return Err(Error::Unsupported("N + 1 must be a power of two".into()));
         }
@@ -163,8 +163,8 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
 
         let lagrange_evals = H.evaluate_all_lagrange_coefficients(gamma);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 w: once(&W.w[..])
                     .chain(ws.iter().map(|w| &w.w[..]))
                     .slice_rlc(&lagrange_evals),
@@ -172,7 +172,7 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
                     .chain(ws.iter().map(|w| w.r))
                     .scalar_rlc(&lagrange_evals),
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 e: f_alpha * lagrange_evals[0]
                     + H.evaluate_vanishing_polynomial(gamma) * k_poly.evaluate(&gamma),
                 x: once(&U.x[..])
@@ -183,12 +183,12 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
                     .chain(us.iter().map(|u| u.phi))
                     .scalar_rlc(&lagrange_evals),
             },
-            ProtoGalaxyProof {
+            proof: ProtoGalaxyProof {
                 f_coeffs,
                 k_coeffs: k_poly.coeffs,
             },
-            lagrange_evals.into(),
-        ))
+            challenge: lagrange_evals.into(),
+        })
     }
 }
 
@@ -202,7 +202,7 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
         ws: &[impl Borrow<Self::IW>; N],
         us: &[impl Borrow<Self::IU>; N],
         mut rng: impl RngCore,
-    ) -> Result<(Self::RW, Self::RU, Self::Proof<1, N>, Self::Challenge), Error> {
+    ) -> Result<FoldStep<Self, 1, N>, Error> {
         if !(N + 1).is_power_of_two() {
             return Err(Error::Unsupported("N + 1 must be a power of two".into()));
         }
@@ -342,14 +342,14 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
 
         let lagrange_evals = H.evaluate_all_lagrange_coefficients(gamma);
 
-        Ok((
-            Self::RW {
+        Ok(FoldStep {
+            next_running_witness: Self::RW {
                 w: once(&W.w[..])
                     .chain(ws.iter().map(|w| &w[..]))
                     .slice_rlc(&lagrange_evals),
                 r: once(W.r).chain(rs).scalar_rlc(&lagrange_evals),
             },
-            Self::RU {
+            next_running_instance: Self::RU {
                 e: f_alpha * lagrange_evals[0]
                     + H.evaluate_vanishing_polynomial(gamma) * k_poly.evaluate(&gamma),
                 x: once(&U.x[..])
@@ -358,15 +358,15 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemeProver<1, N> for Pro
                 betas: betas_star,
                 phi: once(U.phi).chain(phis).scalar_rlc(&lagrange_evals),
             },
-            (
+            proof: (
                 phis,
                 ProtoGalaxyProof {
                     f_coeffs,
                     k_coeffs: k_poly.coeffs,
                 },
             ),
-            lagrange_evals,
-        ))
+            challenge: lagrange_evals,
+        })
     }
 }
 

--- a/crates/fs/src/protogalaxy/circuits/verifier.rs
+++ b/crates/fs/src/protogalaxy/circuits/verifier.rs
@@ -19,7 +19,9 @@ use sonobe_primitives::{
     transcripts::TranscriptGadget,
 };
 
-use crate::{FoldingSchemePartialVerifierGadget, protogalaxy::ProtoGalaxyGadget};
+use crate::{
+    FoldingSchemePartialVerifierGadget, PartialVerifierStep, protogalaxy::ProtoGalaxyGadget,
+};
 
 impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemePartialVerifierGadget<1, N>
     for ProtoGalaxyGadget<CM>
@@ -31,7 +33,7 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemePartialVerifierGadge
         [U]: [&Self::RU; 1],
         us: [&Self::IU; N],
         proof: &Self::Proof<1, N>,
-    ) -> Result<(Self::RU, Self::Challenge), SynthesisError> {
+    ) -> Result<PartialVerifierStep<Self::RU, Self::Challenge>, SynthesisError> {
         transcript.add(&FpVar::constant((proof.f_coeffs.len() as u64).into()))?;
         transcript.add(&FpVar::constant((proof.k_coeffs.len() as u64).into()))?;
 
@@ -62,8 +64,8 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemePartialVerifierGadge
 
         let lagrange_evals = H.evaluate_all_lagrange_coefficients_var(&gamma)?;
 
-        Ok((
-            Self::RU {
+        Ok(PartialVerifierStep {
+            next_running_instance: Self::RU {
                 e: f_alpha * &lagrange_evals[0]
                     + H.evaluate_vanishing_polynomial_var(&gamma)? * k_poly.evaluate(&gamma)?,
                 x: once(&U.x[..])
@@ -87,7 +89,7 @@ impl<CM: GroupBasedCommitment, const N: usize> FoldingSchemePartialVerifierGadge
                     })?
                 },
             },
-            lagrange_evals.into(),
-        ))
+            challenge: lagrange_evals.into(),
+        })
     }
 }

--- a/crates/ivc/src/compilers/cyclefold/circuits.rs
+++ b/crates/ivc/src/compilers/cyclefold/circuits.rs
@@ -119,7 +119,9 @@ where
         // 1.c. Fold the primary running instance `U` and incoming instance `u`
         //      using the provided proof to obtain the next running instance
         //      `UU`.
-        let (UU, rho) = FS1::Gadget::verify_hinted(&(), &mut transcript, [&U], [&u], &proof)?;
+        let step = FS1::Gadget::verify_hinted(&(), &mut transcript, [&U], [&u], &proof)?;
+        let UU = step.next_running_instance;
+        let rho = step.challenge;
         // 1.d. If this is the base case (`i = 0`), then we should instead use
         //      the dummy running instance as the next running instance.
         let actual_UU = is_basecase.select(&U_dummy, &UU)?;

--- a/crates/ivc/src/compilers/cyclefold/mod.rs
+++ b/crates/ivc/src/compilers/cyclefold/mod.rs
@@ -254,8 +254,7 @@ where
         let mut cf_WW = Dummy::dummy(arith2_config);
 
         if i != 0 {
-            let challenge;
-            (WW, UU, proof, challenge) = FS1::prove(
+            let step = FS1::prove(
                 dk1.to_pk(),
                 &mut transcript,
                 &[W],
@@ -265,14 +264,17 @@ where
                 &mut rng,
             )?;
 
-            let cf_circuits = FS1::to_cyclefold_circuits(&[U], &[u], &proof, challenge);
+            let cf_circuits = FS1::to_cyclefold_circuits(&[U], &[u], &step.proof, step.challenge);
+            WW = step.next_running_witness;
+            UU = step.next_running_instance;
+            proof = step.proof;
             for (i, cf_circuit) in cf_circuits.into_iter().enumerate() {
                 let cs = AssignmentsExtractor::new();
                 cs.execute_fn(|cs| cf_circuit.verify_point_rlc(cs))?;
 
                 let (cf_w, cf_u) = dk2.sample(cs.assignments()?, &mut rng)?;
 
-                (cf_WW, cf_UU, cf_proofs[i], _) = FS2::prove(
+                let cf_step = FS2::prove(
                     dk2.to_pk(),
                     &mut transcript,
                     &[if i == 0 { cf_W } else { &cf_WW }],
@@ -281,6 +283,9 @@ where
                     &[&cf_u],
                     &mut rng,
                 )?;
+                cf_WW = cf_step.next_running_witness;
+                cf_UU = cf_step.next_running_instance;
+                cf_proofs[i] = cf_step.proof;
                 cf_us[i] = cf_u;
             }
         }


### PR DESCRIPTION
This PR replaces tuple-returning fold outputs with named structs and updates the relevant CycleFold call sites to use the new named results.

This is a breaking API cleanup that makes fold artifacts explicit by name across the folding-scheme interfaces.

Note to reviewers: Because this replaces the signatures of the canonical folding traits, the migration necessarily updates the current fs implementations (Nova, HyperNova, Mova, Ova, and ProtoGalaxy) and the downstream CycleFold consumers. Most of the resulting churn is mechanical.

Why:

- The CycleFold path still passes large positional tuples like `(RW, RU, Proof, Challenge)` and `(RU, Challenge)` through some of its most complex code paths.
- Naming those artifacts makes these call sites easier to read and review.

What changes:

- change `FoldingSchemeProver::prove(...)` to return `FoldStep`
- change `FoldingSchemePartialVerifierGadget::verify_hinted(...)` to return `PartialVerifierStep`
- migrate the existing Nova, HyperNova, Mova, Ova, and ProtoGalaxy implementations to the new return types
- update the relevant CycleFold call sites to consume the new named structs

Testing:

- `cargo test -p sonobe-fs`
- `cargo test -p sonobe-ivc`

References:

- `prove` returns the challenge explicitly for CycleFold:
  [crates/fs/src/definitions/algorithms.rs#L33-L59](https://github.com/privacy-ethereum/sonobe/blob/dev/crates/fs/src/definitions/algorithms.rs#L33-L59)
- `verify_hinted` is intentionally a partial verifier:
  [crates/fs/src/definitions/circuits.rs#L9-L35](https://github.com/privacy-ethereum/sonobe/blob/dev/crates/fs/src/definitions/circuits.rs#L9-L35)
- Current tuple plumbing in the CycleFold prover path:
  [crates/ivc/src/compilers/cyclefold/mod.rs#L248-L312](https://github.com/privacy-ethereum/sonobe/blob/dev/crates/ivc/src/compilers/cyclefold/mod.rs#L248-L312)
- Current tuple plumbing in the augmented-circuit path:
  [crates/ivc/src/compilers/cyclefold/circuits.rs#L118-L145](https://github.com/privacy-ethereum/sonobe/blob/dev/crates/ivc/src/compilers/cyclefold/circuits.rs#L118-L145)
