### PR TITLE
Fix broken examples link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The folding scheme and decider used can be swapped with a few lines of code (eg.
 
 The [Sonobe docs](https://privacy-scaling-explorations.github.io/sonobe-docs/) contain more details about the usage and design of the library.
 
-Complete examples can be found at [folding-schemes/examples](https://github.com/privacy-scaling-explorations/sonobeAcknowledgments/tree/main/examples)
+Complete examples can be found at [folding-schemes/examples](https://github.com/privacy-scaling-explorations/sonobe/tree/main/examples)
 
 ## License
 


### PR DESCRIPTION
Fixes a broken README link to the examples directory.

The previous URL accidentally included `Acknowledgments` in the repository path, which made the link point to a non-existent location. This updates it to the correct `sonobe/tree/main/examples` path.
